### PR TITLE
feat(aws): Add ability to specificy externalId to AWS account for assuming roles via STS

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AssumeRoleAmazonCredentials.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AssumeRoleAmazonCredentials.java
@@ -36,7 +36,8 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
       AWSCredentialsProvider credentialsProvider,
       String accountId,
       String assumeRole,
-      String sessionName) {
+      String sessionName,
+      String externalId) {
     String assumeRoleValue = Objects.requireNonNull(assumeRole, "assumeRole");
     if (!assumeRoleValue.startsWith("arn:")) {
 
@@ -57,13 +58,16 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
             credentialsProvider,
             assumeRoleValue,
             Objects.requireNonNull(sessionName, "sessionName"),
-            accountId);
+            accountId,
+            externalId);
   }
 
   /** The role to assume on the target account. */
   private final String assumeRole;
 
   private final String sessionName;
+
+  private final String externalId;
 
   public AssumeRoleAmazonCredentials(
       @JsonProperty("name") String name,
@@ -79,7 +83,8 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
       @JsonProperty("lifecycleHooks") List<LifecycleHook> lifecycleHooks,
       @JsonProperty("allowPrivateThirdPartyImages") boolean allowPrivateThirdPartyImages,
       @JsonProperty("assumeRole") String assumeRole,
-      @JsonProperty("sessionName") String sessionName) {
+      @JsonProperty("sessionName") String sessionName,
+      @JsonProperty("externalId") String externalId) {
     this(
         name,
         environment,
@@ -95,7 +100,8 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
         allowPrivateThirdPartyImages,
         null,
         assumeRole,
-        sessionName);
+        sessionName,
+        externalId);
   }
 
   public AssumeRoleAmazonCredentials(
@@ -115,7 +121,8 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
         copy.getAllowPrivateThirdPartyImages(),
         credentialsProvider,
         copy.getAssumeRole(),
-        copy.getSessionName());
+        copy.getSessionName(),
+        copy.getExternalId());
   }
 
   AssumeRoleAmazonCredentials(
@@ -133,7 +140,8 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
       boolean allowPrivateThirdPartyImages,
       AWSCredentialsProvider credentialsProvider,
       String assumeRole,
-      String sessionName) {
+      String sessionName,
+      String externalId) {
     super(
         name,
         environment,
@@ -151,9 +159,11 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
             credentialsProvider,
             accountId,
             assumeRole,
-            sessionName == null ? DEFAULT_SESSION_NAME : sessionName));
+            sessionName == null ? DEFAULT_SESSION_NAME : sessionName,
+            externalId));
     this.assumeRole = assumeRole;
     this.sessionName = sessionName == null ? DEFAULT_SESSION_NAME : sessionName;
+    this.externalId = externalId;
   }
 
   public String getAssumeRole() {
@@ -162,5 +172,9 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
 
   public String getSessionName() {
     return sessionName;
+  }
+
+  public String getExternalId() {
+    return externalId;
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixAssumeRoleAmazonCredentials.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixAssumeRoleAmazonCredentials.java
@@ -29,6 +29,8 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
 
   private final String sessionName;
 
+  private final String externalId;
+
   public NetflixAssumeRoleAmazonCredentials(
       @JsonProperty("name") String name,
       @JsonProperty("environment") String environment,
@@ -53,7 +55,8 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
       @JsonProperty("shieldEnabled") Boolean shieldEnabled,
       @JsonProperty("assumeRole") String assumeRole,
       @JsonProperty("sessionName") String sessionName,
-      @JsonProperty("lambdaEnabled") Boolean lambdaEnabled) {
+      @JsonProperty("lambdaEnabled") Boolean lambdaEnabled,
+      @JsonProperty("externalId") String externalId) {
 
     this(
         name,
@@ -80,7 +83,8 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
         shieldEnabled,
         assumeRole,
         sessionName,
-        lambdaEnabled);
+        lambdaEnabled,
+        externalId);
   }
 
   public NetflixAssumeRoleAmazonCredentials(
@@ -110,7 +114,8 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
         copy.getShieldEnabled(),
         copy.getAssumeRole(),
         copy.getSessionName(),
-        copy.getLambdaEnabled());
+        copy.getLambdaEnabled(),
+        copy.getExternalId());
   }
 
   NetflixAssumeRoleAmazonCredentials(
@@ -138,7 +143,8 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
       Boolean shieldEnabled,
       String assumeRole,
       String sessionName,
-      Boolean lambdaEnabled) {
+      Boolean lambdaEnabled,
+      String externalId) {
     super(
         name,
         environment,
@@ -156,7 +162,8 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
             credentialsProvider,
             accountId,
             assumeRole,
-            sessionName == null ? AssumeRoleAmazonCredentials.DEFAULT_SESSION_NAME : sessionName),
+            sessionName == null ? AssumeRoleAmazonCredentials.DEFAULT_SESSION_NAME : sessionName,
+            externalId),
         edda,
         eddaEnabled,
         discovery,
@@ -170,6 +177,7 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
     this.assumeRole = assumeRole;
     this.sessionName =
         sessionName == null ? AssumeRoleAmazonCredentials.DEFAULT_SESSION_NAME : sessionName;
+    this.externalId = externalId;
   }
 
   public String getAssumeRole() {
@@ -178,5 +186,9 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
 
   public String getSessionName() {
     return sessionName;
+  }
+
+  public String getExternalId() {
+    return externalId;
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsConfig.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsConfig.java
@@ -152,6 +152,7 @@ public class CredentialsConfig {
     private Boolean bastionEnabled;
     private String assumeRole;
     private String sessionName;
+    private String externalId;
     private List<LifecycleHook> lifecycleHooks;
     private boolean allowPrivateThirdPartyImages;
 
@@ -313,6 +314,14 @@ public class CredentialsConfig {
 
     public void setSessionName(String sessionName) {
       this.sessionName = sessionName;
+    }
+
+    public String getExternalId() {
+      return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+      this.externalId = externalId;
     }
 
     public List<LifecycleHook> getLifecycleHooks() {


### PR DESCRIPTION
My goal is to enable the use of the externalId parameter when assuming a role as outlined here:
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html

I am opening the PR now as a draft, while I figure out how to test this.
Digging through the code, this looks like what needs to be changed though.