### PR TITLE
fix(beans): fix eureka config binding with multiple ConfigurationService

### DIFF
--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/config/EurekaProviderConfiguration.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/config/EurekaProviderConfiguration.groovy
@@ -35,14 +35,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.context.properties.bind.Bindable
 import org.springframework.boot.context.properties.bind.Binder
-import org.springframework.boot.context.properties.bind.PropertySourcesPlaceholdersResolver
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName
-import org.springframework.boot.context.properties.source.ConfigurationPropertySources
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.convert.ConversionService
-import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.Environment
 import retrofit.converter.Converter
 import retrofit.converter.JacksonConverter
 
@@ -58,10 +55,7 @@ class EurekaProviderConfiguration {
   Registry registry
 
   @Autowired
-  ConversionService conversionService
-
-  @Autowired
-  ConfigurableEnvironment environment
+  Environment environment
 
   @Bean
   @ConfigurationProperties("eureka.provider")
@@ -70,18 +64,13 @@ class EurekaProviderConfiguration {
   }
 
   private OkHttpClientConfigurationProperties eurekaClientConfig() {
-    Binder binder = new Binder(
-      ConfigurationPropertySources.from(environment.propertySources),
-      new PropertySourcesPlaceholdersResolver(environment),
-      conversionService)
-
     OkHttpClientConfigurationProperties properties =
       new OkHttpClientConfigurationProperties(
         propagateSpinnakerHeaders: false,
         connectTimoutMs: 10000,
         keyStore: null,
         trustStore: null)
-    binder.bind(
+    Binder.get(environment).bind(
       ConfigurationPropertyName.of("eureka.readonly.ok-http-client"),
       Bindable.ofInstance(properties))
     return properties


### PR DESCRIPTION
The EurekaProviderConfiguration does some manual ConfigurationProperties binding to allow eureka configuration
to behave differently than standard rest clients without polluting the application context with extra
OkHttpClientProperties beans.

This was failing if multiple ConfigurationService beans were present. We don't actually need any ConfigurationService beans to
successfully bind this configuration anyway, so this change just removes the autowiring.