### PR TITLE
fix(titus): Improve handling for a non-existent Titus Job

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/DestroyTitusJobCompletionHandler.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/DestroyTitusJobCompletionHandler.java
@@ -22,25 +22,31 @@ import com.netflix.spinnaker.clouddriver.saga.models.Saga;
 import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider;
 import com.netflix.spinnaker.clouddriver.titus.deploy.actions.DestroyTitusJob;
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.DestroyTitusJobDescription;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
 public class DestroyTitusJobCompletionHandler
-    implements SagaCompletionHandler<DeleteServerGroupEvent> {
+    implements SagaCompletionHandler<Optional<DeleteServerGroupEvent>> {
 
   @Nullable
   @Override
-  public DeleteServerGroupEvent handle(@Nonnull Saga completedSaga) {
+  public Optional<DeleteServerGroupEvent> handle(@Nonnull Saga completedSaga) {
     final DestroyTitusJobDescription description =
         completedSaga.getEvent(DestroyTitusJob.DestroyTitusJobCommand.class).getDescription();
 
-    return new DeleteServerGroupEvent(
-        TitusCloudProvider.ID,
-        // titus entity tags are created using the account name (and not the accountId)
-        description.getAccount(),
-        description.getRegion(),
-        description.getServerGroupName());
+    if (description.getServerGroupName() == null) {
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        new DeleteServerGroupEvent(
+            TitusCloudProvider.ID,
+            // titus entity tags are created using the account name (and not the accountId)
+            description.getAccount(),
+            description.getRegion(),
+            description.getServerGroupName()));
   }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/DestroyTitusJobAtomicOperation.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/DestroyTitusJobAtomicOperation.groovy
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.NotNull
 
 import javax.annotation.Nonnull
 
-class DestroyTitusJobAtomicOperation extends AbstractSagaAtomicOperation<DestroyTitusJobDescription, DeleteServerGroupEvent, Void> {
+class DestroyTitusJobAtomicOperation extends AbstractSagaAtomicOperation<DestroyTitusJobDescription, Optional<DeleteServerGroupEvent>, Void> {
   private final Collection<DeleteServerGroupEvent> events = []
 
   DestroyTitusJobAtomicOperation(DestroyTitusJobDescription description) {
@@ -53,8 +53,8 @@ class DestroyTitusJobAtomicOperation extends AbstractSagaAtomicOperation<Destroy
   }
 
   @Override
-  protected Void parseSagaResult(@NotNull @Nonnull DeleteServerGroupEvent result) {
-    events << result
+  protected Void parseSagaResult(@NotNull @Nonnull Optional<DeleteServerGroupEvent> result) {
+    result.map { events << it }
     return null
   }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/DestroyTitusServerGroupAtomicOperation.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/DestroyTitusServerGroupAtomicOperation.groovy
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.NotNull
 import javax.annotation.Nonnull
 
 @Slf4j
-class DestroyTitusServerGroupAtomicOperation extends AbstractSagaAtomicOperation<DestroyTitusServerGroupDescription, DeleteServerGroupEvent, Void> {
+class DestroyTitusServerGroupAtomicOperation extends AbstractSagaAtomicOperation<DestroyTitusServerGroupDescription, Optional<DeleteServerGroupEvent>, Void> {
   private final Collection<DeleteServerGroupEvent> events = []
 
   DestroyTitusServerGroupAtomicOperation(DestroyTitusServerGroupDescription description) {
@@ -63,8 +63,8 @@ class DestroyTitusServerGroupAtomicOperation extends AbstractSagaAtomicOperation
   }
 
   @Override
-  protected Void parseSagaResult(@NotNull @Nonnull DeleteServerGroupEvent result) {
-    events << result
+  protected Void parseSagaResult(@NotNull @Nonnull Optional<DeleteServerGroupEvent> result) {
+    result.map { events << it }
     return null
   }
 


### PR DESCRIPTION
Rather than fail the action, no-op the delete and return an empty `DeleteServerGroupEvent`.
