### PR TITLE
fix(aws): Dont override imdsv2 flag when cloning LT backed asg

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -168,7 +168,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
           iamInstanceProfile = launchTemplateData.iamInstanceProfile?.name
           instanceMonitoring = launchTemplateData.monitoring?.enabled
           spotPrice = launchTemplateData.instanceMarketOptions?.spotOptions?.maxPrice
-          newDescription.requireIMDSv2 = launchTemplateData.metadataOptions?.httpTokens == "required"
+          newDescription.requireIMDSv2 = description.requireIMDSv2 != null ? description.requireIMDSv2 : launchTemplateData.metadataOptions?.httpTokens == "required"
           if (!launchTemplateData.networkInterfaces?.empty && launchTemplateData.networkInterfaces*.associatePublicIpAddress?.any()) {
             associatePublicIpAddress = true
           }


### PR DESCRIPTION
- updated to get the flag from the request
