### PR TITLE
fix(provider/cf): only perform ondemand caching when account equals the credentials account

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryLoadBalancerCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryLoadBalancerCachingAgent.java
@@ -165,6 +165,11 @@ public class CloudFoundryLoadBalancerCachingAgent extends AbstractCloudFoundryCa
     if (account == null || region == null || loadBalancerName == null) {
       return null;
     }
+
+    if (!this.getAccountName().equals(account)) {
+      return null;
+    }
+
     CloudFoundrySpace space = getClient().getOrganizations().findSpaceByRegion(region).orElse(null);
     if (space == null) {
       return null;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
@@ -144,6 +144,11 @@ public class CloudFoundryServerGroupCachingAgent extends AbstractCloudFoundryCac
     if (account == null || region == null) {
       return null;
     }
+
+    if (!this.getAccountName().equals(account)) {
+      return null;
+    }
+
     CloudFoundrySpace space =
         this.getClient().getOrganizations().findSpaceByRegion(region).orElse(null);
     if (space == null) {

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryLoadBalancerCachingAgentTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryLoadBalancerCachingAgentTest.java
@@ -452,4 +452,19 @@ class CloudFoundryLoadBalancerCachingAgentTest {
 
     assertThat(result).isEqualToComparingFieldByFieldRecursively(expectedCacheResult);
   }
+
+  @Test
+  void shouldReturnNullWhenAccountNameDiffers() {
+    Map<String, String> data =
+        HashMap.of(
+                "account", "NotAccount",
+                "region", "org1 > space1",
+                "loadBalancerName", "doesntMatter")
+            .toJavaMap();
+
+    OnDemandAgent.OnDemandResult result =
+        cloudFoundryLoadBalancerCachingAgent.handle(mockProviderCache, data);
+
+    assertThat(result).isEqualTo(null);
+  }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgentTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgentTest.java
@@ -672,4 +672,19 @@ class CloudFoundryServerGroupCachingAgentTest {
 
     assertThat(result).isEqualToComparingFieldByFieldRecursively(expectedCacheResult);
   }
+
+  @Test
+  void shouldReturnNullWhenAccountNameDiffers() {
+    Map<String, String> data =
+        HashMap.of(
+                "account", "NotAccount",
+                "region", "org1 > space1",
+                "serverGroupName", "doesntMatter")
+            .toJavaMap();
+
+    OnDemandAgent.OnDemandResult result =
+        cloudFoundryServerGroupCachingAgent.handle(mockProviderCache, data);
+
+    assertThat(result).isEqualTo(null);
+  }
 }


### PR DESCRIPTION
Small but very important fix. Without checking to see if the `agent.getAccountName() equals data.account`, every caching agent that matches the handle for provider `cloudfoundry` and type `OnDemandType.ServerGroup or OnDemandType.LoadBalancer`, will proceed and create false evictions and potentially other harmful data inconsistencies. This fix will remove those data inconsistencies from happening and in theory, greatly speed up the Force Cache Refresh in the deploy stages for serverGroups and loadBalancers. Instead of N-CloudFoundry agents all processing onDemandCache and making subsequent API calls, only a single agent will now run to process the cache.
