### PR TITLE
feat(aws): update awscli and s3cmd

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -20,7 +20,7 @@ RUN wget https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/lin
   ln -sf /usr/local/bin/aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws
 
 RUN apk -v --update add py-pip && \
-  pip install --upgrade awscli==1.16.258 s3cmd==2.0.1 python-magic && \
+  pip install --upgrade awscli==1.18.152 s3cmd==2.0.2 python-magic && \
   apk -v --purge del py-pip && \
   rm /var/cache/apk/*
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y curl gnupg && \
   google-cloud-sdk-app-engine-go \
   kubectl \
   python-pip && \
-  pip install awscli==1.16.258 --upgrade && \
+  pip install awscli==1.18.152 --upgrade && \
   rm -rf ~/.config/gcloud
 
 RUN curl -o  /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/linux/amd64/aws-iam-authenticator && \


### PR DESCRIPTION
update awscli version from 1.16.258 to 1.18.152 and s3cmd from 2.0.1 to 2.0.2

The main benefit is to be able to use this command: https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login-password.html

> This command is supported using the latest version of AWS CLI version 2 or in v1.17.10 or later of AWS CLI version 1.

This is my first attempt at opening a pull request for this project, please let me know if I need to improve anything/follow a different process!
