### PR TITLE
chore(kotlin): use the JDK 11 kotlin libs

### DIFF
--- a/gradle/kotlin-test.gradle
+++ b/gradle/kotlin-test.gradle
@@ -17,7 +17,7 @@
 apply plugin: "kotlin"
 
 dependencies {
-  testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+  testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.platform:junit-platform-runner"


### PR DESCRIPTION
I missed this in commit #4919, which switched us to targeting Java 11.