### PR TITLE
fix(provider/aws): encode security group names

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
@@ -88,8 +88,9 @@ class Keys implements KeyParser {
 
     switch (result.type) {
       case Namespace.SECURITY_GROUPS.ns:
-        def names = Names.parseName(parts[2])
-        result << [application: names.app, name: parts[2], id: parts[3], region: parts[4], account: parts[5], vpcId: parts[6] == "null" ? null : parts[6]]
+        def name = decode(parts[2])
+        def frigga = Names.parseName(name)
+        result << [application: frigga.app, name: name, id: parts[3], region: parts[4], account: parts[5], vpcId: parts[6] == "null" ? null : parts[6]]
         break
       case Namespace.VPCS.ns:
         result << [id: parts[2], account: parts[3], region: parts[4]]
@@ -120,12 +121,21 @@ class Keys implements KeyParser {
     result
   }
 
+  static String encode(String value) {
+    return value.replace([':' : '%3A', '%' : '%25'])
+  }
+
+  static String decode(String value) {
+    return value.replace(['%3A' : ':', '%25' : '%'])
+  }
+
   static String getSecurityGroupKey(String securityGroupName,
                                     String securityGroupId,
                                     String region,
                                     String account,
                                     String vpcId) {
-    "$ID:${Namespace.SECURITY_GROUPS}:${securityGroupName}:${securityGroupId}:${region}:${account}:${vpcId}"
+    // Security group name can contain `:` so we encode it here
+    "$ID:${Namespace.SECURITY_GROUPS}:${encode(securityGroupName)}:${securityGroupId}:${region}:${account}:${vpcId}"
   }
 
   static String getSubnetKey(String subnetId,

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/cache/KeysSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/cache/KeysSpec.groovy
@@ -32,4 +32,30 @@ class KeysSpec extends Specification {
     key                                                                                                         | namespace
     "aws:securityGroups:appname:appname-stack-detail:test:us-west-1:appname-stack-detail-v000:stack:detail:000" | Keys.Namespace.SECURITY_GROUPS
   }
+
+  @Unroll
+  def 'decode escaped security group name'() {
+
+    expect:
+    Keys.parse(key)
+
+    where:
+
+    key                                                                              || name
+    "aws:securityGroups:app-stack-detail:sg-12345:us-west-2:0123456789:vpc-1234"     || 'appname-stack-detail'
+    "aws:securityGroups:app%3Astack%25detail:sg-12345:us-west-2:0123456789:vpc-1234" || 'appname:stack%detail'
+  }
+
+  @Unroll
+  def 'encode security group name'() {
+
+    expect:
+    key == Keys.getSecurityGroupKey(securityGroupName, securityGroupId, region, account, vpcId)
+
+    where:
+
+    securityGroupName  | securityGroupId | region      | account      | vpcId      || key
+    "app-stack-detail" | "sg-12345"      | "us-west-2" | "0123456789" | "vpc-1234" || "aws:securityGroups:app-stack-detail:sg-12345:us-west-2:0123456789:vpc-1234"
+    "app:stack%detail" | "sg-12345"      | "us-west-2" | "0123456789" | "vpc-1234" || "aws:securityGroups:app%3Astack%25detail:sg-12345:us-west-2:0123456789:vpc-1234"
+  }
 }


### PR DESCRIPTION
Security group names in AWS can contain `:` which breaks the cache key parsing. This patch adds a simple encode/decode step
to the security group name using percent encoding when it encounters either `:` or `%`.
