### PR TITLE
fix(aws): use the Spinnaker region provider with the sts client builder, so that it defaults to the default region, when no region is defined

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,6 @@ subprojects {
     }
 
     test {
-      environment "AWS_REGION",  "us-west-2"
       useJUnitPlatform()
       testLogging {
         exceptionFormat = 'full'

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixSTSAssumeRoleSessionCredentialsProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixSTSAssumeRoleSessionCredentialsProvider.java
@@ -21,6 +21,7 @@ import com.amazonaws.auth.AWSSessionCredentials;
 import com.amazonaws.auth.AWSSessionCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
+import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.SpinnakerAwsRegionProvider;
 import java.io.Closeable;
 
 public class NetflixSTSAssumeRoleSessionCredentialsProvider
@@ -37,12 +38,16 @@ public class NetflixSTSAssumeRoleSessionCredentialsProvider
       String externalId) {
     this.accountId = accountId;
 
+    var chain = new SpinnakerAwsRegionProvider();
+    var region = chain.getRegion();
+
     delegate =
         new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
             .withExternalId(externalId)
             .withStsClient(
                 AWSSecurityTokenServiceClient.builder()
                     .withCredentials(longLivedCredentialsProvider)
+                    .withRegion(region)
                     .build())
             .build();
 


### PR DESCRIPTION
fix(aws): use the Spinnaker region provider with the sts client builder, so that it defaults to the default region, when no region is defined