### PR TITLE
fix(provider/cf): fix regression caused by clusterSummaries

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepository.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepository.java
@@ -105,7 +105,7 @@ public class CacheRepository {
     CloudFoundryCluster cluster =
         objectMapper.convertValue(
             clusterData.getAttributes().get("resource"), CloudFoundryCluster.class);
-    if (detail.equals(Detail.NONE) || detail.equals(Detail.NAMES_ONLY)) {
+    if (detail.equals(Detail.NONE)) {
       return cluster.withServerGroups(emptySet());
     }
     return cluster.withServerGroups(

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/view/CloudFoundryClusterProvider.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/view/CloudFoundryClusterProvider.java
@@ -65,7 +65,7 @@ public class CloudFoundryClusterProvider implements ClusterProvider {
         repository.findClustersByKeys(
             cacheView.filterIdentifiers(
                 CLUSTERS.getNs(), Keys.getClusterKey("*", applicationName, "*")),
-            CacheRepository.Detail.NAMES_ONLY));
+            CacheRepository.Detail.NONE));
   }
 
   @Override

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepositoryTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepositoryTest.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.cache;
 
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.cache.CacheRepository.Detail.FULL;
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.cache.CacheRepository.Detail.NAMES_ONLY;
+import static com.netflix.spinnaker.clouddriver.cloudfoundry.cache.CacheRepository.Detail.NONE;
 import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -157,6 +158,16 @@ class CacheRepositoryTest {
             });
 
     assertThat(repo.findClusterByKey(clusterKey, NAMES_ONLY))
+        .hasValueSatisfying(
+            cluster ->
+                assertThat(cluster.getServerGroups())
+                    .hasOnlyOneElementSatisfying(
+                        serverGroup -> {
+                          assertThat(serverGroup.getLoadBalancers()).isEmpty();
+                          assertThat(serverGroup.getInstances()).isNotEmpty();
+                        }));
+
+    assertThat(repo.findClusterByKey(clusterKey, NONE))
         .hasValueSatisfying(cluster -> assertThat(cluster.getServerGroups()).isEmpty());
   }
 


### PR DESCRIPTION
Fix a regression caused by clusterSummaries. ClusterSummaries should not fully hydrate the servergroups, hence needs to be changed to NONE for details. The underlying method that is ran got reverted to its original state until we can revisit this set of features at a later date. A test was added to ensure the functionality works as expected. 