### PR TITLE
Revert "fix(titus): Store application ref for server groups and instances"

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
@@ -737,7 +737,6 @@ public class TitusStreamingUpdateAgent implements CustomScheduledAgent, CachingA
       attributes.put("region", region.getName());
       attributes.put("account", account.getName());
       attributes.put("targetGroups", data.targetGroupNames);
-      attributes.put("application", data.name.getApp());
 
       Map<String, Collection<String>> relationships = serverGroupCache.getRelationships();
       relationships.computeIfAbsent(APPLICATIONS.ns, key -> new HashSet<>()).add(data.appNameKey);
@@ -767,7 +766,6 @@ public class TitusStreamingUpdateAgent implements CustomScheduledAgent, CachingA
       instanceCache.getAttributes().put(HEALTH.ns, singletonList(getTitusHealth(data.task)));
       instanceCache.getAttributes().put("task", data.task);
       instanceCache.getAttributes().put("jobId", data.jobId);
-      instanceCache.getAttributes().put("application", Names.parseName(data.serverGroup).getApp());
 
       if (!data.serverGroup.isEmpty()) {
         instanceCache


### PR DESCRIPTION
Reverts spinnaker/clouddriver#4992

This introduces a regression into the AWS provider when used side-by-side with Titus. I find it hard to believe that the AWS cloud provider plays nicely with any of the other cloud providers if they're populating the `application` attribute as well - which makes me suspect none of them do.

The problem is that with the SQL provider, we introduced a new `CacheView` method `getAllByApplication`, but there's no way of filtering what cloud provider to get all cached items by. This means that the `AmazonClusterProvider` is expecting only AWS resources, but with this change will also get Titus resources. This is all fine until it calls [Keys.parse()](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy#L86) from [L332](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy#L332). This call will return `null` and then immediately NPE at [L337](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy#L337) when we try to read key data.

The fix, as far as I can tell, would be to introduce a `CloudProviderCacheFilter` that cloud providers could supply to only get the data they need. Implementing this would take quite a lot, as `CacheFilter` is currently only available for relationships, not the resources themselves. Furthermore, if we were going to implement a `CloudProviderCacheFilter`, it would only make sense that we'd do so after creating a dedicated column in the SQL schema so we could filter on the SQL server, rather that in the application itself. That's a lot of work, and not really something I want to bite off while trying to bring the V2 cache schema across the line.