### PR TITLE
feat(test): Add ECS changes for CreateServerGroup for task definition artifacts

### DIFF
--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/CreateServerGroupSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/CreateServerGroupSpec.java
@@ -30,9 +30,16 @@ import org.junit.Test;
 import org.junit.jupiter.api.DisplayName;
 import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * TODO (allisaurus): Ideally these tests would go further and actually assert that the resulting
+ * ecs:create-service call is formed as expected, but for now, it asserts that the given operation
+ * is correctly validated and submitted as a task.
+ */
 public class CreateServerGroupSpec extends EcsSpec {
 
   @Autowired AccountCredentialsRepository accountCredentialsRepository;
+
+  private static final String CREATE_SG_TEST_PATH = "/ecs/ops/createServerGroup";
 
   @DisplayName(
       ".\n===\n"
@@ -41,14 +48,9 @@ public class CreateServerGroupSpec extends EcsSpec {
           + "\n===")
   @Test
   public void createServerGroupOperationTest() throws IOException {
-    /**
-     * TODO (allisaurus): Ideally this test would go further and actually assert that the resulting
-     * ecs:create-service call is formed as expected, but for now, it asserts that the given
-     * operation is correctly validated and submitted as a task.
-     */
 
     // given
-    String url = getTestUrl("/ecs/ops/createServerGroup");
+    String url = getTestUrl(CREATE_SG_TEST_PATH);
     String requestBody = generateStringFromTestFile("/createServerGroup-inputs-ec2.json");
     setEcsAccountCreds();
 
@@ -58,6 +60,66 @@ public class CreateServerGroupSpec extends EcsSpec {
         .body(requestBody)
         .when()
         .post(url)
+        // then
+        .then()
+        .statusCode(200)
+        .contentType(ContentType.JSON)
+        .body("id", notNullValue())
+        .body("resourceUri", containsString("/task/"));
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given description w/ task def inputs, FARGATE launch type, and legacy target group fields, "
+          + "successfully submit createServerGroup operation"
+          + "\n===")
+  @Test
+  public void createSGOWithInputsFargateLegacyTargetGroupTest() throws IOException {
+
+    // given
+    String url = getTestUrl(CREATE_SG_TEST_PATH);
+    String requestBody =
+        generateStringFromTestFile(
+            "/createServerGroupOperation-inputs-fargate-legacyTargetGroup.json");
+    setEcsAccountCreds();
+
+    // when
+    given()
+        .contentType(ContentType.JSON)
+        .body(requestBody)
+        .when()
+        .post(url)
+
+        // then
+        .then()
+        .statusCode(200)
+        .contentType(ContentType.JSON)
+        .body("id", notNullValue())
+        .body("resourceUri", containsString("/task/"));
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given description w/ task def inputs, FARGATE launch type, and new target group fields, "
+          + "successfully submit createServerGroup operation"
+          + "\n===")
+  @Test
+  public void createSGOWithInputsFargateNewTargetGroupMappingsTest() throws IOException {
+
+    // given
+    String url = getTestUrl(CREATE_SG_TEST_PATH);
+    String requestBody =
+        generateStringFromTestFile(
+            "/createServerGroupOperation-inputs-fargate-targetGroupMappings.json");
+    setEcsAccountCreds();
+
+    // when
+    given()
+        .contentType(ContentType.JSON)
+        .body(requestBody)
+        .when()
+        .post(url)
+
         // then
         .then()
         .statusCode(200)

--- a/clouddriver-ecs/src/integration/resources/testoperations/createServerGroupOperation-inputs-fargate-legacyTargetGroup.json
+++ b/clouddriver-ecs/src/integration/resources/testoperations/createServerGroupOperation-inputs-fargate-legacyTargetGroup.json
@@ -1,0 +1,28 @@
+{
+  "account": "ecs-account",
+  "application": "ecs",
+  "availabilityZones": {
+    "us-west-2": [
+      "us-west-2a",
+      "us-west-2c"
+    ]
+  },
+  "capacity": {
+    "desired": 1,
+    "max": 1,
+    "min": 1
+  },
+  "cloudProvider": "ecs",
+  "computeUnits": 256,
+  "containerPort": 80,
+  "credentials": "ecs-account",
+  "dockerImageAddress": "nginx",
+  "ecsClusterName": "spinnaker-deployment-cluster",
+  "launchType": "FARGATE",
+  "networkMode": "aws-vpc",
+  "placementStrategySequence": [],
+  "reservedMemory": 512,
+  "stack": "integTestStack",
+  "freeFormDetails" : "detailTest",
+  "targetGroup": "spin-fargate-instanceTG"
+}

--- a/clouddriver-ecs/src/integration/resources/testoperations/createServerGroupOperation-inputs-fargate-targetGroupMappings.json
+++ b/clouddriver-ecs/src/integration/resources/testoperations/createServerGroupOperation-inputs-fargate-targetGroupMappings.json
@@ -1,0 +1,33 @@
+{
+  "account": "ecs-account",
+  "application": "ecs",
+  "availabilityZones": {
+    "us-west-2": [
+      "us-west-2a",
+      "us-west-2c"
+    ]
+  },
+  "capacity": {
+    "desired": 1,
+    "max": 1,
+    "min": 1
+  },
+  "cloudProvider": "ecs",
+  "computeUnits": 256,
+  "credentials": "ecs-account",
+  "dockerImageAddress": "nginx",
+  "ecsClusterName": "spinnaker-deployment-cluster",
+  "launchType": "FARGATE",
+  "networkMode": "aws-vpc",
+  "placementStrategySequence": [],
+  "reservedMemory": 512,
+  "stack": "integTestStack",
+  "freeFormDetails" : "detailTest",
+  "targetGroupMappings": [
+    {
+      "containerName" : "main",
+      "containerPort" : 80,
+      "targetGroup" : "spin-fargate-instanceTG"
+    }
+  ]
+}


### PR DESCRIPTION
This PR contain changes that are required for CreateServerGroup for task definition artifacts to work.

1. Add generateStringFromTestArtifactFile method to locate the artifact files
2. Add retryUntilTrue method to retry getting response for the newly created services in ECS
3. Add setEcsAccountCreds method to set NetflixAmazonCredentials.

This PR is related to [Clouddriver integration test](https://github.com/spinnaker/clouddriver/pull/4827)
