### PR TITLE
feat(test): Add ECS changes for CreateServerGroup for task definitions

### DIFF
--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/EcsSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/EcsSpec.java
@@ -37,6 +37,7 @@ import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -50,6 +51,7 @@ import org.springframework.test.context.TestPropertySource;
 public class EcsSpec {
   protected static final String TEST_OPERATIONS_LOCATION =
       "src/integration/resources/testoperations";
+  protected static final String TEST_ARTIFACTS_LOCATION = "src/integration/resources/testartifacts";
   protected final String ECS_ACCOUNT_NAME = "ecs-account";
   protected final String TEST_REGION = "us-west-2";
 
@@ -60,6 +62,8 @@ public class EcsSpec {
   Boolean awsEnabled;
 
   @LocalServerPort private int port;
+
+  @Autowired AccountCredentialsRepository accountCredentialsRepository;
 
   @MockBean protected AmazonClientProvider mockAwsProvider;
 
@@ -88,6 +92,10 @@ public class EcsSpec {
     return new String(Files.readAllBytes(Paths.get(TEST_OPERATIONS_LOCATION, path)));
   }
 
+  protected String generateStringFromTestArtifactFile(String path) throws IOException {
+    return new String(Files.readAllBytes(Paths.get(TEST_ARTIFACTS_LOCATION, path)));
+  }
+
   protected String getTestUrl(String path) {
     return "http://localhost:" + port + path;
   }
@@ -113,5 +121,39 @@ public class EcsSpec {
       }
     }
     fail(failMsg);
+  }
+
+  protected void setEcsAccountCreds() {
+    AmazonCredentials.AWSRegion testRegion = new AmazonCredentials.AWSRegion(TEST_REGION, null);
+
+    NetflixAssumeRoleAmazonCredentials ecsCreds =
+        new NetflixAssumeRoleAmazonCredentials(
+            ECS_ACCOUNT_NAME,
+            "test",
+            "test",
+            "123456789012",
+            null,
+            true,
+            Collections.singletonList(testRegion),
+            null,
+            null,
+            null,
+            null,
+            false,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            "SpinnakerManaged",
+            "SpinnakerSession",
+            false,
+            "");
+
+    accountCredentialsRepository.save(ECS_ACCOUNT_NAME, ecsCreds);
   }
 }

--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/EcsSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/EcsSpec.java
@@ -15,7 +15,8 @@
 
 package com.netflix.spinnaker.clouddriver.ecs;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -32,18 +33,16 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
-import org.junit.Test;
+import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(
     classes = {Main.class},
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -62,7 +61,7 @@ public class EcsSpec {
 
   @LocalServerPort private int port;
 
-  @MockBean AmazonClientProvider mockAwsProvider;
+  @MockBean protected AmazonClientProvider mockAwsProvider;
 
   @MockBean AmazonAccountsSynchronizer mockAccountsSyncer;
 
@@ -102,5 +101,17 @@ public class EcsSpec {
     dataMap.put(namespace, dataPoints);
 
     return new DefaultCacheResult(dataMap);
+  }
+
+  protected void retryUntilTrue(BooleanSupplier func, String failMsg, int retrySeconds)
+      throws InterruptedException {
+    for (int i = 0; i < retrySeconds; i++) {
+      if (!func.getAsBoolean()) {
+        Thread.sleep(1000);
+      } else {
+        return;
+      }
+    }
+    fail(failMsg);
   }
 }

--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/CreateServerGroupSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/CreateServerGroupSpec.java
@@ -15,31 +15,95 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.test;
 
+import static io.restassured.RestAssured.get;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import com.amazonaws.services.ecs.AmazonECS;
+import com.amazonaws.services.ecs.model.*;
+import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing;
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest;
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsResult;
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAssumeRoleAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.EcsSpec;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 import io.restassured.http.ContentType;
 import java.io.IOException;
 import java.util.Collections;
-import org.junit.Test;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-/**
- * TODO (allisaurus): Ideally these tests would go further and actually assert that the resulting
- * ecs:create-service call is formed as expected, but for now, it asserts that the given operation
- * is correctly validated and submitted as a task.
- */
 public class CreateServerGroupSpec extends EcsSpec {
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
 
   @Autowired AccountCredentialsRepository accountCredentialsRepository;
 
+  private final int TASK_RETRY_SECONDS = 3;
+  private AmazonECS mockECS = mock(AmazonECS.class);
+  private AmazonElasticLoadBalancing mockELB = mock(AmazonElasticLoadBalancing.class);
+
   private static final String CREATE_SG_TEST_PATH = "/ecs/ops/createServerGroup";
+
+  @BeforeEach
+  public void setup() {
+    // mock ECS responses
+    when(mockECS.listServices(any(ListServicesRequest.class))).thenReturn(new ListServicesResult());
+    when(mockECS.describeServices(any(DescribeServicesRequest.class)))
+        .thenReturn(new DescribeServicesResult());
+    when(mockECS.registerTaskDefinition(any(RegisterTaskDefinitionRequest.class)))
+        .thenAnswer(
+            (Answer<RegisterTaskDefinitionResult>)
+                invocation -> {
+                  RegisterTaskDefinitionRequest request =
+                      (RegisterTaskDefinitionRequest) invocation.getArguments()[0];
+                  String testArn = "arn:aws:ecs:::task-definition/" + request.getFamily() + ":1";
+                  TaskDefinition taskDef = new TaskDefinition().withTaskDefinitionArn(testArn);
+                  return new RegisterTaskDefinitionResult().withTaskDefinition(taskDef);
+                });
+    when(mockECS.createService(any(CreateServiceRequest.class)))
+        .thenReturn(
+            new CreateServiceResult().withService(new Service().withServiceName("createdService")));
+
+    when(mockAwsProvider.getAmazonEcs(
+            any(NetflixAmazonCredentials.class), anyString(), anyBoolean()))
+        .thenReturn(mockECS);
+
+    // mock ELB responses
+    when(mockELB.describeTargetGroups(any(DescribeTargetGroupsRequest.class)))
+        .thenAnswer(
+            (Answer<DescribeTargetGroupsResult>)
+                invocation -> {
+                  DescribeTargetGroupsRequest request =
+                      (DescribeTargetGroupsRequest) invocation.getArguments()[0];
+                  String testArn =
+                      "arn:aws:elasticloadbalancing:::targetgroup/"
+                          + request.getNames().get(0)
+                          + "/76tgredfc";
+                  TargetGroup testTg = new TargetGroup().withTargetGroupArn(testArn);
+
+                  return new DescribeTargetGroupsResult().withTargetGroups(testTg);
+                });
+
+    when(mockAwsProvider.getAmazonElasticLoadBalancingV2(
+            any(NetflixAmazonCredentials.class), anyString(), anyBoolean()))
+        .thenReturn(mockELB);
+  }
 
   @DisplayName(
       ".\n===\n"
@@ -47,25 +111,71 @@ public class CreateServerGroupSpec extends EcsSpec {
           + "successfully submit createServerGroup operation"
           + "\n===")
   @Test
-  public void createServerGroupOperationTest() throws IOException {
+  public void createServerGroup_InputsEc2LegacyTargetGroupTest()
+      throws IOException, InterruptedException {
 
     // given
     String url = getTestUrl(CREATE_SG_TEST_PATH);
     String requestBody = generateStringFromTestFile("/createServerGroup-inputs-ec2.json");
+    String expectedServerGroupName = "ecs-integInputsEc2LegacyTargetGroup";
     setEcsAccountCreds();
 
     // when
-    given()
-        .contentType(ContentType.JSON)
-        .body(requestBody)
-        .when()
-        .post(url)
-        // then
-        .then()
-        .statusCode(200)
-        .contentType(ContentType.JSON)
-        .body("id", notNullValue())
-        .body("resourceUri", containsString("/task/"));
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(url)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    retryUntilTrue(
+        () -> {
+          List<Object> taskHistory =
+              get(getTestUrl("/task/" + taskId))
+                  .then()
+                  .contentType(ContentType.JSON)
+                  .extract()
+                  .path("history");
+          if (taskHistory
+              .toString()
+              .contains(String.format("Done creating 1 of %s-v000", expectedServerGroupName))) {
+            return true;
+          }
+          return false;
+        },
+        String.format("Failed to detect service creation in %s seconds", TASK_RETRY_SECONDS),
+        TASK_RETRY_SECONDS);
+
+    // then
+    ArgumentCaptor<RegisterTaskDefinitionRequest> registerTaskDefArgs =
+        ArgumentCaptor.forClass(RegisterTaskDefinitionRequest.class);
+    verify(mockECS).registerTaskDefinition(registerTaskDefArgs.capture());
+    RegisterTaskDefinitionRequest seenTaskDefRequest = registerTaskDefArgs.getValue();
+    assertEquals(expectedServerGroupName, seenTaskDefRequest.getFamily());
+    assertEquals(1, seenTaskDefRequest.getContainerDefinitions().size());
+
+    ArgumentCaptor<DescribeTargetGroupsRequest> elbArgCaptor =
+        ArgumentCaptor.forClass(DescribeTargetGroupsRequest.class);
+    verify(mockELB).describeTargetGroups(elbArgCaptor.capture());
+
+    ArgumentCaptor<CreateServiceRequest> createServiceArgs =
+        ArgumentCaptor.forClass(CreateServiceRequest.class);
+    verify(mockECS).createService(createServiceArgs.capture());
+    CreateServiceRequest seenCreateServRequest = createServiceArgs.getValue();
+    assertEquals("EC2", seenCreateServRequest.getLaunchType());
+    assertEquals(expectedServerGroupName + "-v000", seenCreateServRequest.getServiceName());
+    assertEquals(1, seenCreateServRequest.getLoadBalancers().size());
+    LoadBalancer serviceLB = seenCreateServRequest.getLoadBalancers().get(0);
+    assertEquals("v000", serviceLB.getContainerName());
+    assertEquals(80, serviceLB.getContainerPort().intValue());
+    assertEquals("integInputsEc2LegacyTargetGroup-cluster", seenCreateServRequest.getCluster());
   }
 
   @DisplayName(
@@ -74,28 +184,74 @@ public class CreateServerGroupSpec extends EcsSpec {
           + "successfully submit createServerGroup operation"
           + "\n===")
   @Test
-  public void createSGOWithInputsFargateLegacyTargetGroupTest() throws IOException {
+  public void createServerGroup_InputsFargateLegacyTargetGroupTest()
+      throws IOException, InterruptedException {
 
     // given
     String url = getTestUrl(CREATE_SG_TEST_PATH);
     String requestBody =
         generateStringFromTestFile(
             "/createServerGroupOperation-inputs-fargate-legacyTargetGroup.json");
+    String expectedServerGroupName = "ecs-integInputsFargateLegacyTargetGroup";
     setEcsAccountCreds();
 
     // when
-    given()
-        .contentType(ContentType.JSON)
-        .body(requestBody)
-        .when()
-        .post(url)
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(url)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
 
-        // then
-        .then()
-        .statusCode(200)
-        .contentType(ContentType.JSON)
-        .body("id", notNullValue())
-        .body("resourceUri", containsString("/task/"));
+    retryUntilTrue(
+        () -> {
+          List<Object> taskHistory =
+              get(getTestUrl("/task/" + taskId))
+                  .then()
+                  .contentType(ContentType.JSON)
+                  .extract()
+                  .path("history");
+          if (taskHistory
+              .toString()
+              .contains(String.format("Done creating 1 of %s-v000", expectedServerGroupName))) {
+            return true;
+          }
+          return false;
+        },
+        String.format("Failed to detect service creation in %s seconds", TASK_RETRY_SECONDS),
+        TASK_RETRY_SECONDS);
+
+    // then
+    ArgumentCaptor<RegisterTaskDefinitionRequest> registerTaskDefArgs =
+        ArgumentCaptor.forClass(RegisterTaskDefinitionRequest.class);
+    verify(mockECS).registerTaskDefinition(registerTaskDefArgs.capture());
+    RegisterTaskDefinitionRequest seenTaskDefRequest = registerTaskDefArgs.getValue();
+    assertEquals(expectedServerGroupName, seenTaskDefRequest.getFamily());
+    assertEquals(1, seenTaskDefRequest.getContainerDefinitions().size());
+    assertEquals("aws-vpc", seenTaskDefRequest.getNetworkMode());
+
+    ArgumentCaptor<DescribeTargetGroupsRequest> elbArgCaptor =
+        ArgumentCaptor.forClass(DescribeTargetGroupsRequest.class);
+    verify(mockELB).describeTargetGroups(elbArgCaptor.capture());
+
+    ArgumentCaptor<CreateServiceRequest> createServiceArgs =
+        ArgumentCaptor.forClass(CreateServiceRequest.class);
+    verify(mockECS).createService(createServiceArgs.capture());
+    CreateServiceRequest seenCreateServRequest = createServiceArgs.getValue();
+    assertEquals("FARGATE", seenCreateServRequest.getLaunchType());
+    assertEquals(expectedServerGroupName + "-v000", seenCreateServRequest.getServiceName());
+    assertEquals(1, seenCreateServRequest.getLoadBalancers().size());
+    LoadBalancer serviceLB = seenCreateServRequest.getLoadBalancers().get(0);
+    assertEquals("v000", serviceLB.getContainerName());
+    assertEquals(80, serviceLB.getContainerPort().intValue());
+    assertEquals("integInputsFargateLegacyTargetGroup-cluster", seenCreateServRequest.getCluster());
   }
 
   @DisplayName(
@@ -104,35 +260,131 @@ public class CreateServerGroupSpec extends EcsSpec {
           + "successfully submit createServerGroup operation"
           + "\n===")
   @Test
-  public void createSGOWithInputsFargateNewTargetGroupMappingsTest() throws IOException {
+  public void createServerGroup_InputsFargateTgMappingsTest()
+      throws IOException, InterruptedException {
 
     // given
     String url = getTestUrl(CREATE_SG_TEST_PATH);
     String requestBody =
         generateStringFromTestFile(
             "/createServerGroupOperation-inputs-fargate-targetGroupMappings.json");
+    String expectedServerGroupName = "ecs-integInputsFargateTgMappings";
     setEcsAccountCreds();
 
     // when
-    given()
-        .contentType(ContentType.JSON)
-        .body(requestBody)
-        .when()
-        .post(url)
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(url)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
 
-        // then
-        .then()
-        .statusCode(200)
-        .contentType(ContentType.JSON)
-        .body("id", notNullValue())
-        .body("resourceUri", containsString("/task/"));
+    retryUntilTrue(
+        () -> {
+          List<Object> taskHistory =
+              get(getTestUrl("/task/" + taskId))
+                  .then()
+                  .contentType(ContentType.JSON)
+                  .extract()
+                  .path("history");
+          if (taskHistory
+              .toString()
+              .contains(String.format("Done creating 1 of %s-v000", expectedServerGroupName))) {
+            return true;
+          }
+          return false;
+        },
+        String.format("Failed to detect service creation in %s seconds", TASK_RETRY_SECONDS),
+        TASK_RETRY_SECONDS);
+
+    // then
+    ArgumentCaptor<RegisterTaskDefinitionRequest> registerTaskDefArgs =
+        ArgumentCaptor.forClass(RegisterTaskDefinitionRequest.class);
+    verify(mockECS).registerTaskDefinition(registerTaskDefArgs.capture());
+    RegisterTaskDefinitionRequest seenTaskDefRequest = registerTaskDefArgs.getValue();
+    assertEquals(expectedServerGroupName, seenTaskDefRequest.getFamily());
+    assertEquals(1, seenTaskDefRequest.getContainerDefinitions().size());
+    assertEquals("aws-vpc", seenTaskDefRequest.getNetworkMode());
+
+    ArgumentCaptor<DescribeTargetGroupsRequest> elbArgCaptor =
+        ArgumentCaptor.forClass(DescribeTargetGroupsRequest.class);
+    verify(mockELB).describeTargetGroups(elbArgCaptor.capture());
+
+    ArgumentCaptor<CreateServiceRequest> createServiceArgs =
+        ArgumentCaptor.forClass(CreateServiceRequest.class);
+    verify(mockECS).createService(createServiceArgs.capture());
+    CreateServiceRequest seenCreateServRequest = createServiceArgs.getValue();
+    assertEquals(expectedServerGroupName + "-v000", seenCreateServRequest.getServiceName());
+    assertEquals(1, seenCreateServRequest.getLoadBalancers().size());
+    assertEquals("FARGATE", seenCreateServRequest.getLaunchType());
+    // assert network stuff is set
+    LoadBalancer serviceLB = seenCreateServRequest.getLoadBalancers().get(0);
+    assertEquals("main", serviceLB.getContainerName());
+    assertEquals(80, serviceLB.getContainerPort().intValue());
+    assertEquals("integInputsFargateTgMappings-cluster", seenCreateServRequest.getCluster());
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given description w/ task def inputs,"
+          + "task should fail if ECS service creation fails"
+          + "\n===")
+  @Test
+  public void createServerGroup_errorIfCreateServiceFails()
+      throws IOException, InterruptedException {
+    // given
+    String url = getTestUrl(CREATE_SG_TEST_PATH);
+    String requestBody =
+        generateStringFromTestFile("/createServerGroup-inputs-ecsCreateFails.json");
+    setEcsAccountCreds();
+
+    // when
+    Mockito.doThrow(new InvalidParameterException("Something is wrong."))
+        .when(mockECS)
+        .createService(any(CreateServiceRequest.class));
+
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(url)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    retryUntilTrue(
+        () -> {
+          HashMap<String, Boolean> status =
+              get(getTestUrl("/task/" + taskId))
+                  .then()
+                  .contentType(ContentType.JSON)
+                  .extract()
+                  .path("status");
+
+          return status.get("failed").equals(true);
+        },
+        String.format("Failed to observe task failure after %s seconds", TASK_RETRY_SECONDS),
+        TASK_RETRY_SECONDS);
   }
 
   private void setEcsAccountCreds() {
     AmazonCredentials.AWSRegion testRegion = new AmazonCredentials.AWSRegion(TEST_REGION, null);
 
-    NetflixAmazonCredentials ecsCreds =
-        new NetflixAmazonCredentials(
+    NetflixAssumeRoleAmazonCredentials ecsCreds =
+        new NetflixAssumeRoleAmazonCredentials(
             ECS_ACCOUNT_NAME,
             "test",
             "test",
@@ -154,7 +406,10 @@ public class CreateServerGroupSpec extends EcsSpec {
             null,
             false,
             false,
-            false);
+            "SpinnakerManaged",
+            "SpinnakerSession",
+            false,
+            "");
 
     accountCredentialsRepository.save(ECS_ACCOUNT_NAME, ecsCreds);
   }

--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/CreateServerGroupSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/CreateServerGroupSpec.java
@@ -28,14 +28,11 @@ import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing;
 import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest;
 import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsResult;
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup;
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
-import com.netflix.spinnaker.clouddriver.aws.security.NetflixAssumeRoleAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.EcsSpec;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 import io.restassured.http.ContentType;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -378,39 +375,5 @@ public class CreateServerGroupSpec extends EcsSpec {
         },
         String.format("Failed to observe task failure after %s seconds", TASK_RETRY_SECONDS),
         TASK_RETRY_SECONDS);
-  }
-
-  private void setEcsAccountCreds() {
-    AmazonCredentials.AWSRegion testRegion = new AmazonCredentials.AWSRegion(TEST_REGION, null);
-
-    NetflixAssumeRoleAmazonCredentials ecsCreds =
-        new NetflixAssumeRoleAmazonCredentials(
-            ECS_ACCOUNT_NAME,
-            "test",
-            "test",
-            "123456789012",
-            null,
-            true,
-            Collections.singletonList(testRegion),
-            null,
-            null,
-            null,
-            null,
-            false,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            false,
-            "SpinnakerManaged",
-            "SpinnakerSession",
-            false,
-            "");
-
-    accountCredentialsRepository.save(ECS_ACCOUNT_NAME, ecsCreds);
   }
 }

--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/EcsControllersSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/EcsControllersSpec.java
@@ -30,8 +30,8 @@ import io.restassured.response.Response;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Test;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class EcsControllersSpec extends EcsSpec {

--- a/clouddriver-ecs/src/integration/resources/testoperations/createServerGroup-inputs-ec2.json
+++ b/clouddriver-ecs/src/integration/resources/testoperations/createServerGroup-inputs-ec2.json
@@ -17,11 +17,11 @@
   "containerPort": 80,
   "credentials": "ecs-account",
   "dockerImageAddress": "nginx",
-  "ecsClusterName": "spinnaker-deployment-cluster",
+  "ecsClusterName": "integInputsEc2LegacyTargetGroup-cluster",
   "launchType": "EC2",
   "networkMode": "bridge",
   "placementStrategySequence": [],
   "reservedMemory": 512,
-  "stack": "integ-test-stack",
-  "targetGroup": "spin-ec2-instanceTG"
+  "stack": "integInputsEc2LegacyTargetGroup",
+  "targetGroup": "integInputsEc2LegacyTargetGroup-targetGroup"
 }

--- a/clouddriver-ecs/src/integration/resources/testoperations/createServerGroup-inputs-ecsCreateFails.json
+++ b/clouddriver-ecs/src/integration/resources/testoperations/createServerGroup-inputs-ecsCreateFails.json
@@ -2,9 +2,9 @@
   "account": "ecs-account",
   "application": "ecs",
   "availabilityZones": {
-    "us-west-2": [
-      "us-west-2a",
-      "us-west-2c"
+    "us-west-1": [
+      "us-west-1a",
+      "us-west-1c"
     ]
   },
   "capacity": {
@@ -17,11 +17,11 @@
   "containerPort": 80,
   "credentials": "ecs-account",
   "dockerImageAddress": "nginx",
-  "ecsClusterName": "integInputsFargateLegacyTargetGroup-cluster",
-  "launchType": "FARGATE",
-  "networkMode": "aws-vpc",
+  "ecsClusterName": "integInputsErrorFromEcs-cluster",
+  "launchType": "EC2",
+  "networkMode": "bridge",
   "placementStrategySequence": [],
   "reservedMemory": 512,
-  "stack": "integInputsFargateLegacyTargetGroup",
-  "targetGroup": "integInputsFargateLegacyTargetGroup-targetGroup"
+  "stack": "integInputsErrorFromEcs",
+  "targetGroup": "integInputsErrorFromEcs-targetGroup"
 }

--- a/clouddriver-ecs/src/integration/resources/testoperations/createServerGroupOperation-inputs-fargate-targetGroupMappings.json
+++ b/clouddriver-ecs/src/integration/resources/testoperations/createServerGroupOperation-inputs-fargate-targetGroupMappings.json
@@ -16,18 +16,17 @@
   "computeUnits": 256,
   "credentials": "ecs-account",
   "dockerImageAddress": "nginx",
-  "ecsClusterName": "spinnaker-deployment-cluster",
+  "ecsClusterName": "integInputsFargateTgMappings-cluster",
   "launchType": "FARGATE",
   "networkMode": "aws-vpc",
   "placementStrategySequence": [],
   "reservedMemory": 512,
-  "stack": "integTestStack",
-  "freeFormDetails" : "detailTest",
+  "stack": "integInputsFargateTgMappings",
   "targetGroupMappings": [
     {
       "containerName" : "main",
       "containerPort" : 80,
-      "targetGroup" : "spin-fargate-instanceTG"
+      "targetGroup" : "integInputsFargateTgMappings-targetGroup"
     }
   ]
 }


### PR DESCRIPTION
This PR contain changes that are required for CreateServerGroup for task definition artifacts to work and moving common code from CreateServerGroupSpec.java to EcsSpec.java in order to remove redundancy of a code.

1. Add generateStringFromTestArtifactFile method to locate the artifact files
2. Add retryUntilTrue method to retry getting response for the newly created services in ECS
3. Add setEcsAccountCreds method to set NetflixAmazonCredentials.

This PR is related to [Clouddriver integration test](https://github.com/spinnaker/clouddriver/pull/4827) and builds on top of https://github.com/spinnaker/clouddriver/pull/4972