### PR TITLE
feat(aws): Use Kork's BaseProvider

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsCleanupProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsCleanupProvider.groovy
@@ -16,26 +16,14 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider
 
-import com.netflix.spinnaker.cats.agent.Agent
-import com.netflix.spinnaker.cats.agent.AgentSchedulerAware
-import com.netflix.spinnaker.cats.provider.Provider
 
-class AwsCleanupProvider extends AgentSchedulerAware implements Provider {
+import com.netflix.spinnaker.clouddriver.security.BaseProvider
+
+class AwsCleanupProvider extends BaseProvider {
   public static final String PROVIDER_NAME = AwsCleanupProvider.name
-
-  private final Collection<Agent> agents
-
-  AwsCleanupProvider(Collection<Agent> agents) {
-    this.agents = agents
-  }
 
   @Override
   String getProviderName() {
     return PROVIDER_NAME
-  }
-
-  @Override
-  Collection<Agent> getAgents() {
-    return agents
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsInfrastructureProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsInfrastructureProvider.groovy
@@ -17,37 +17,23 @@
 package com.netflix.spinnaker.clouddriver.aws.provider
 
 import com.fasterxml.jackson.core.type.TypeReference
-import com.netflix.spinnaker.cats.agent.Agent
-import com.netflix.spinnaker.cats.agent.AgentSchedulerAware
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
+import com.netflix.spinnaker.clouddriver.aws.cache.Keys
 import com.netflix.spinnaker.clouddriver.cache.KeyParser
 import com.netflix.spinnaker.clouddriver.cache.SearchableProvider
-import com.netflix.spinnaker.clouddriver.aws.cache.Keys
+import com.netflix.spinnaker.clouddriver.security.BaseProvider
 
 import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.SECURITY_GROUPS
-import static com.netflix.spinnaker.clouddriver.cache.SearchableProvider.SearchableResource
 
-class AwsInfrastructureProvider extends AgentSchedulerAware implements SearchableProvider {
+class AwsInfrastructureProvider extends BaseProvider implements SearchableProvider {
   public static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}
 
   public static final String PROVIDER_NAME = AwsInfrastructureProvider.name
 
-  private final Collection<Agent> agents
-
   private final KeyParser keyParser = new Keys()
-
-  AwsInfrastructureProvider(Collection<Agent> agents) {
-    this.agents = agents
-  }
 
   @Override
   String getProviderName() {
     return PROVIDER_NAME
-  }
-
-  @Override
-  Collection<Agent> getAgents() {
-    agents
   }
 
   final Set<String> defaultCaches = [SECURITY_GROUPS.ns].asImmutable()
@@ -56,7 +42,7 @@ class AwsInfrastructureProvider extends AgentSchedulerAware implements Searchabl
     (SECURITY_GROUPS.ns): '/securityGroups/$account/$provider/$name?region=$region'
   ]
 
-  final Map<SearchableResource, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
+  final Map<SearchableResource, SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
 
   @Override
   Map<String, String> parseKey(String key) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AbstractAmazonLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AbstractAmazonLoadBalancerCachingAgent.groovy
@@ -129,7 +129,7 @@ abstract class AbstractAmazonLoadBalancerCachingAgent implements CachingAgent, O
   abstract CacheResult loadDataInternal(ProviderCache providerCache)
 
   @Override
-  Collection<Map<String, ?>> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map<String, Object>> pendingOnDemandRequests(ProviderCache providerCache) {
     return []
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
@@ -382,7 +382,7 @@ class AmazonApplicationLoadBalancerCachingAgent extends AbstractAmazonLoadBalanc
   }
 
   @Override
-  Collection<Map<String, ?>> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map<String, Object>> pendingOnDemandRequests(ProviderCache providerCache) {
     Collection<String> keys = providerCache.filterIdentifiers(
       ON_DEMAND.ns,
       Keys.getLoadBalancerKey("*", "*", "*", "*", "*")

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
@@ -165,7 +165,7 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
   }
 
   @Override
-  Collection<Map<String, ?>> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map<String, Object>> pendingOnDemandRequests(ProviderCache providerCache) {
     return []
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
@@ -459,7 +459,7 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
   }
 
   @Override
-  Collection<Map<String, ?>> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map<String, Object>> pendingOnDemandRequests(ProviderCache providerCache) {
     def keys = providerCache.filterIdentifiers(ON_DEMAND.ns, Keys.getServerGroupKey("*", "*", account.name, region))
     return fetchPendingOnDemandRequests(providerCache, keys)
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
@@ -22,30 +22,16 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.agent.AgentProvider
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonApplicationLoadBalancerCachingAgent
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCertificateCachingAgent
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCloudFormationCachingAgent
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonLaunchTemplateCachingAgent
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonLoadBalancerCachingAgent
-
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservedInstancesCachingAgent
+import com.netflix.spinnaker.clouddriver.aws.edda.EddaApiFactory
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservationReportCachingAgent
 import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3DataProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.model.ReservationReport
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.ProviderUtils
-import com.netflix.spinnaker.clouddriver.aws.edda.EddaApiFactory
-import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonLoadBalancerInstanceStateCachingAgent
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.ClusterCachingAgent
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.EddaLoadBalancerCachingAgent
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.ImageCachingAgent
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.InstanceCachingAgent
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.LaunchConfigCachingAgent
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservationReportCachingAgent
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -54,7 +40,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.DependsOn
 
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -76,7 +61,7 @@ class AwsProviderConfig {
                           EddaTimeoutConfig eddaTimeoutConfig,
                           DynamicConfigService dynamicConfigService) {
     def awsProvider =
-      new AwsProvider(accountCredentialsRepository, Collections.newSetFromMap(new ConcurrentHashMap<Agent, Boolean>()))
+      new AwsProvider(accountCredentialsRepository)
 
     synchronizeAwsProvider(awsProvider,
                            amazonCloudProvider,
@@ -118,9 +103,7 @@ class AwsProviderConfig {
                                       Collection<AgentProvider> agentProviders,
                                       EddaTimeoutConfig eddaTimeoutConfig,
                                       DynamicConfigService dynamicConfigService) {
-    def scheduledAccounts = ProviderUtils.getScheduledAccounts(awsProvider)
     Set<NetflixAmazonCredentials> allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials, AmazonCloudProvider.ID)
-
     List<Agent> newlyAddedAgents = []
 
     //only index public images once per region
@@ -129,44 +112,17 @@ class AwsProviderConfig {
     //sort the accounts in case of a reconfigure, we are more likely to re-index the public images in the same caching agent
     //TODO(cfieber)-rework this is after rework of AWS Image/NamedImage keys
     allAccounts.sort { it.name }.each { NetflixAmazonCredentials credentials ->
-      for (AmazonCredentials.AWSRegion region : credentials.regions) {
-        if (!scheduledAccounts.contains(credentials.name)) {
-          newlyAddedAgents << new ClusterCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name, objectMapper, registry, eddaTimeoutConfig)
-          newlyAddedAgents << new LaunchConfigCachingAgent(amazonClientProvider, credentials, region.name, objectMapper, registry)
-          newlyAddedAgents << new ImageCachingAgent(amazonClientProvider, credentials, region.name, objectMapper, registry, false, dynamicConfigService)
-          if (!publicRegions.contains(region.name)) {
-            newlyAddedAgents << new ImageCachingAgent(amazonClientProvider, credentials, region.name, objectMapper, registry, true, dynamicConfigService)
-            publicRegions.add(region.name)
-          }
-          newlyAddedAgents << new InstanceCachingAgent(amazonClientProvider, credentials, region.name, objectMapper, registry)
-          newlyAddedAgents << new AmazonLoadBalancerCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name, eddaApiFactory.createApi(credentials.edda, region.name), objectMapper, registry)
-          newlyAddedAgents << new AmazonApplicationLoadBalancerCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name, eddaApiFactory.createApi(credentials.edda, region.name), objectMapper, registry, eddaTimeoutConfig)
-          newlyAddedAgents << new ReservedInstancesCachingAgent(amazonClientProvider, credentials, region.name, objectMapper, registry)
-          newlyAddedAgents << new AmazonCertificateCachingAgent(amazonClientProvider, credentials, region.name, objectMapper, registry)
-
-          if (dynamicConfigService.isEnabled("aws.features.cloud-formation", false)) {
-            newlyAddedAgents << new AmazonCloudFormationCachingAgent(amazonClientProvider, credentials, region.name, registry)
-          }
-
-          if (credentials.eddaEnabled && !eddaTimeoutConfig.disabledRegions.contains(region.name)) {
-            newlyAddedAgents << new EddaLoadBalancerCachingAgent(eddaApiFactory.createApi(credentials.edda, region.name), credentials, region.name, objectMapper)
-          } else {
-            newlyAddedAgents << new AmazonLoadBalancerInstanceStateCachingAgent(
-              amazonClientProvider, credentials, region.name, objectMapper, ctx
-            )
-          }
-
-          if (dynamicConfigService.isEnabled("aws.features.launch-templates", false)) {
-            newlyAddedAgents << new AmazonLaunchTemplateCachingAgent(amazonClientProvider, credentials, region.name, objectMapper, registry)
-          }
-        }
-      }
+      def result = ProviderHelpers.buildAwsProviderAgents(credentials, amazonClientProvider, objectMapper,
+        registry, eddaTimeoutConfig, awsProvider, amazonCloudProvider, dynamicConfigService, eddaApiFactory, ctx, publicRegions
+      )
+      newlyAddedAgents.addAll(result.agents)
+      publicRegions.addAll(result.regionsToAdd)
     }
 
     // If there is an agent scheduler, then this provider has been through the AgentController in the past.
     if (reservationReportPool.isPresent()) {
       if (awsProvider.agentScheduler) {
-        synchronizeReservationReportCachingAgentAccounts(awsProvider, allAccounts)
+        ProviderHelpers.synchronizeReservationReportCachingAgentAccounts(awsProvider, allAccounts)
       } else {
         // This caching agent runs across all accounts in one iteration (to maintain consistency).
         newlyAddedAgents << new ReservationReportCachingAgent(
@@ -179,38 +135,7 @@ class AwsProviderConfig {
       newlyAddedAgents.addAll(it.agents())
     }
 
-    awsProvider.agents.addAll(newlyAddedAgents)
+    awsProvider.addAgents(newlyAddedAgents)
     awsProvider.synchronizeHealthAgents()
-  }
-
-  private static void synchronizeReservationReportCachingAgentAccounts(AwsProvider awsProvider,
-                                                                       Collection<NetflixAmazonCredentials> allAccounts) {
-    ReservationReportCachingAgent reservationReportCachingAgent = awsProvider.agents.find { agent ->
-      agent instanceof ReservationReportCachingAgent
-    }
-
-    if (reservationReportCachingAgent) {
-      def reservationReportAccounts = reservationReportCachingAgent.accounts
-      def oldAccountNames = reservationReportAccounts.collect { it.name }
-      def newAccountNames = allAccounts.collect { it.name }
-      def accountNamesToDelete = oldAccountNames - newAccountNames
-      def accountNamesToAdd = newAccountNames - oldAccountNames
-
-      accountNamesToDelete.each { accountNameToDelete ->
-        def accountToDelete = reservationReportAccounts.find { it.name == accountNameToDelete }
-
-        if (accountToDelete) {
-          reservationReportAccounts.remove(accountToDelete)
-        }
-      }
-
-      accountNamesToAdd.each { accountNameToAdd ->
-        def accountToAdd = allAccounts.find { it.name == accountNameToAdd }
-
-        if (accountToAdd) {
-          reservationReportAccounts.add(accountToAdd)
-        }
-      }
-    }
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.provider.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.agent.Agent;
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider;
+import com.netflix.spinnaker.clouddriver.aws.agent.ReconcileClassicLinkSecurityGroupsAgent;
+import com.netflix.spinnaker.clouddriver.aws.edda.EddaApiFactory;
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider;
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider;
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonApplicationLoadBalancerCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCertificateCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCloudFormationCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonElasticIpCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonInstanceTypeCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonKeyPairCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonLaunchTemplateCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonLoadBalancerCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonLoadBalancerInstanceStateCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonSecurityGroupCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonSubnetCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonVpcCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.ClusterCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.EddaLoadBalancerCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.ImageCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.InstanceCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.LaunchConfigCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservationReportCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservedInstancesCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import com.netflix.spinnaker.clouddriver.security.ProviderUtils;
+import com.netflix.spinnaker.config.AwsConfiguration;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationContext;
+
+public class ProviderHelpers {
+
+  @Getter
+  @RequiredArgsConstructor
+  public static class BuildResult {
+    private final List<Agent> agents;
+    private final Set<String> regionsToAdd;
+  }
+
+  public static BuildResult buildAwsInfrastructureAgents(
+      NetflixAmazonCredentials credentials,
+      AwsInfrastructureProvider awsInfrastructureProvider,
+      AccountCredentialsRepository accountCredentialsRepository,
+      AmazonClientProvider amazonClientProvider,
+      ObjectMapper amazonObjectMapper,
+      Registry registry,
+      EddaTimeoutConfig eddaTimeoutConfig,
+      Set<String> regions) {
+    Set<String> scheduledAccounts = ProviderUtils.getScheduledAccounts(awsInfrastructureProvider);
+    List<Agent> newlyAddedAgents = new ArrayList<>();
+    for (NetflixAmazonCredentials.AWSRegion region : credentials.getRegions()) {
+      if (!scheduledAccounts.contains(credentials.getName())) {
+        if (regions.add(region.getName())) {
+          newlyAddedAgents.add(
+              new AmazonInstanceTypeCachingAgent(region.getName(), accountCredentialsRepository));
+        }
+        newlyAddedAgents.add(
+            new AmazonElasticIpCachingAgent(amazonClientProvider, credentials, region.getName()));
+        newlyAddedAgents.add(
+            new AmazonKeyPairCachingAgent(amazonClientProvider, credentials, region.getName()));
+        newlyAddedAgents.add(
+            new AmazonSecurityGroupCachingAgent(
+                amazonClientProvider,
+                credentials,
+                region.getName(),
+                amazonObjectMapper,
+                registry,
+                eddaTimeoutConfig));
+        newlyAddedAgents.add(
+            new AmazonSubnetCachingAgent(
+                amazonClientProvider, credentials, region.getName(), amazonObjectMapper));
+        newlyAddedAgents.add(
+            new AmazonVpcCachingAgent(
+                amazonClientProvider, credentials, region.getName(), amazonObjectMapper));
+      }
+    }
+    return new BuildResult(newlyAddedAgents, regions);
+  }
+
+  public static BuildResult buildAwsProviderAgents(
+      NetflixAmazonCredentials credentials,
+      AmazonClientProvider amazonClientProvider,
+      ObjectMapper objectMapper,
+      Registry registry,
+      EddaTimeoutConfig eddaTimeoutConfig,
+      AwsProvider awsProvider,
+      AmazonCloudProvider amazonCloudProvider,
+      DynamicConfigService dynamicConfigService,
+      EddaApiFactory eddaApiFactory,
+      ApplicationContext ctx,
+      Set<String> publicRegions) {
+
+    Set<String> scheduledAccounts = ProviderUtils.getScheduledAccounts(awsProvider);
+    List<Agent> newlyAddedAgents = new ArrayList<>();
+
+    for (NetflixAmazonCredentials.AWSRegion region : credentials.getRegions()) {
+      if (!scheduledAccounts.contains(credentials.getName())) {
+        newlyAddedAgents.add(
+            new ClusterCachingAgent(
+                amazonCloudProvider,
+                amazonClientProvider,
+                credentials,
+                region.getName(),
+                objectMapper,
+                registry,
+                eddaTimeoutConfig));
+        newlyAddedAgents.add(
+            new LaunchConfigCachingAgent(
+                amazonClientProvider, credentials, region.getName(), objectMapper, registry));
+        boolean publicImages = false;
+        if (!publicRegions.contains(region.getName())) {
+          publicImages = true;
+          publicRegions.add(region.getName());
+        }
+        newlyAddedAgents.add(
+            new ImageCachingAgent(
+                amazonClientProvider,
+                credentials,
+                region.getName(),
+                objectMapper,
+                registry,
+                publicImages,
+                dynamicConfigService));
+        newlyAddedAgents.add(
+            new InstanceCachingAgent(
+                amazonClientProvider, credentials, region.getName(), objectMapper, registry));
+        newlyAddedAgents.add(
+            new AmazonLoadBalancerCachingAgent(
+                amazonCloudProvider,
+                amazonClientProvider,
+                credentials,
+                region.getName(),
+                eddaApiFactory.createApi(credentials.getEdda(), region.getName()),
+                objectMapper,
+                registry));
+        newlyAddedAgents.add(
+            new AmazonApplicationLoadBalancerCachingAgent(
+                amazonCloudProvider,
+                amazonClientProvider,
+                credentials,
+                region.getName(),
+                eddaApiFactory.createApi(credentials.getEdda(), region.getName()),
+                objectMapper,
+                registry,
+                eddaTimeoutConfig));
+        newlyAddedAgents.add(
+            new ReservedInstancesCachingAgent(
+                amazonClientProvider, credentials, region.getName(), objectMapper, registry));
+        newlyAddedAgents.add(
+            new AmazonCertificateCachingAgent(
+                amazonClientProvider, credentials, region.getName(), objectMapper, registry));
+
+        if (dynamicConfigService.isEnabled("aws.features.cloud-formation", false)) {
+          newlyAddedAgents.add(
+              new AmazonCloudFormationCachingAgent(
+                  amazonClientProvider, credentials, region.getName(), registry));
+        }
+        if (credentials.getEddaEnabled()
+            && !eddaTimeoutConfig.getDisabledRegions().contains(region.getName())) {
+          newlyAddedAgents.add(
+              new EddaLoadBalancerCachingAgent(
+                  eddaApiFactory.createApi(credentials.getEdda(), region.getName()),
+                  credentials,
+                  region.getName(),
+                  objectMapper));
+        } else {
+          newlyAddedAgents.add(
+              new AmazonLoadBalancerInstanceStateCachingAgent(
+                  amazonClientProvider, credentials, region.getName(), objectMapper, ctx));
+        }
+        if (dynamicConfigService.isEnabled("aws.features.launch-templates", false)) {
+          newlyAddedAgents.add(
+              new AmazonLaunchTemplateCachingAgent(
+                  amazonClientProvider, credentials, region.getName(), objectMapper, registry));
+        }
+      }
+    }
+    return new BuildResult(newlyAddedAgents, publicRegions);
+  }
+
+  public static List<Agent> buildAwsCleanupAgents(
+      NetflixAmazonCredentials credentials,
+      AmazonClientProvider amazonClientProvider,
+      AwsCleanupProvider awsCleanupProvider,
+      AwsConfiguration.DeployDefaults deployDefaults) {
+    Set<String> scheduledAccounts = ProviderUtils.getScheduledAccounts(awsCleanupProvider);
+    List<Agent> newlyAddedAgents = new ArrayList<>();
+    if (!scheduledAccounts.contains(credentials.getName())) {
+      for (NetflixAmazonCredentials.AWSRegion region : credentials.getRegions()) {
+        if (deployDefaults.isReconcileClassicLinkAccount(credentials)) {
+          newlyAddedAgents.add(
+              new ReconcileClassicLinkSecurityGroupsAgent(
+                  amazonClientProvider, credentials, region.getName(), deployDefaults));
+        }
+      }
+    }
+    return newlyAddedAgents;
+  }
+
+  public static void synchronizeReservationReportCachingAgentAccounts(
+      AwsProvider awsProvider, Collection<NetflixAmazonCredentials> allAccounts) {
+    ReservationReportCachingAgent reservationReportCachingAgent =
+        awsProvider.getAgents().stream()
+            .filter(agent -> agent instanceof ReservationReportCachingAgent)
+            .map(ReservationReportCachingAgent.class::cast)
+            .findFirst()
+            .orElse(null);
+    if (reservationReportCachingAgent != null) {
+      Collection<NetflixAmazonCredentials> reservationReportAccounts =
+          reservationReportCachingAgent.getAccounts();
+      List<String> oldAccountNames =
+          reservationReportAccounts.stream()
+              .map(NetflixAmazonCredentials::getName)
+              .collect(Collectors.toList());
+      List<String> newAccountNames =
+          allAccounts.stream().map(NetflixAmazonCredentials::getName).collect(Collectors.toList());
+      List<String> accountNamesToDelete =
+          oldAccountNames.stream()
+              .filter(it -> !newAccountNames.contains(it))
+              .collect(Collectors.toList());
+      List<String> accountNamesToAdd =
+          newAccountNames.stream()
+              .filter(it -> !oldAccountNames.contains(it))
+              .collect(Collectors.toList());
+      for (String name : accountNamesToDelete) {
+        reservationReportAccounts.removeIf(it -> it.getName().equals(name));
+      }
+    }
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
@@ -55,6 +55,7 @@ import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -256,7 +257,12 @@ public class ProviderHelpers {
               .filter(it -> !oldAccountNames.contains(it))
               .collect(Collectors.toList());
       for (String name : accountNamesToDelete) {
-        reservationReportAccounts.removeIf(it -> it.getName().equals(name));
+        reservationReportCachingAgent.getAccounts().removeIf(it -> it.getName().equals(name));
+      }
+      for (String name : accountNamesToAdd) {
+        Optional<NetflixAmazonCredentials> accountToAdd =
+            allAccounts.stream().filter(it -> it.getName().equals(name)).findFirst();
+        accountToAdd.ifPresent(account -> reservationReportCachingAgent.getAccounts().add(account));
       }
     }
   }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProviderSpec.groovy
@@ -81,7 +81,7 @@ class AwsProviderSpec extends Specification {
       getAll() >> eurekaAccounts
     }
 
-    eurekaAwsProvider = new AwsProvider(eurekaRepos, [])
+    eurekaAwsProvider = new AwsProvider(eurekaRepos)
 
     def account1 = new NetflixAmazonCredentials("my-ci-account",
             "ci",
@@ -134,7 +134,7 @@ class AwsProviderSpec extends Specification {
       getAll() >> accounts
     }
 
-    awsProvider = new AwsProvider(repos, [])
+    awsProvider = new AwsProvider(repos)
   }
 
   void "getInstanceKey returns CI account that matches both AWS account ID and eureka host"() {


### PR DESCRIPTION
This is the first step for AWS provider to use `CredentialsRepository`  introduced in https://github.com/spinnaker/governance/blob/master/rfc/account-management.md. 

- Use the new `BaseProvider` introduced in #4930 
- Move provider configuration to helper functions
