### PR TITLE
fix(lambda): Fix NPE when delete operation is called on nonexistent function

### DIFF
--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/DeleteLambdaAtomicOperation.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/DeleteLambdaAtomicOperation.java
@@ -47,14 +47,20 @@ public class DeleteLambdaAtomicOperation
         (LambdaFunction) lambdaFunctionProvider.getFunction(account, region, functionName);
 
     AWSLambda client = getLambdaClient();
-    DeleteFunctionRequest request =
-        new DeleteFunctionRequest().withFunctionName(cache.getFunctionArn());
 
-    request.withQualifier(description.getQualifier());
+    if (cache != null && client != null) {
+      DeleteFunctionRequest request =
+          new DeleteFunctionRequest().withFunctionName(cache.getFunctionArn());
 
-    DeleteFunctionResult result = client.deleteFunction(request);
-    updateTaskStatus("Finished deletion of AWS Lambda Function  Operation...");
+      request.withQualifier(description.getQualifier());
 
-    return result;
+      DeleteFunctionResult result = client.deleteFunction(request);
+
+      updateTaskStatus("Finished deletion of AWS Lambda Function  Operation...");
+
+      return result;
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
Attempting to delete an AWS Lambda function that doesn't exist will throw a Null Pointer Error.

The delete request is attempting to access the function ARN without checking for `null` values.

_Fix_ : Ensure that neither the retrieved function nor the lambda client are `null` before attempting delete