### PR TITLE
fix(provider/aws): handle SGs with `:` in the name

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
@@ -88,8 +88,13 @@ class Keys implements KeyParser {
 
     switch (result.type) {
       case Namespace.SECURITY_GROUPS.ns:
-        def names = Names.parseName(parts[2])
-        result << [application: names.app, name: parts[2], id: parts[3], region: parts[4], account: parts[5], vpcId: parts[6] == "null" ? null : parts[6]]
+        // AWS Security Group names can contain `:` which breaks simple splitting
+        // However, security group IDs must always start with `sg-` so we can use
+        // that to find the end of the group name as the ID is always after the name
+        def idIndex = parts.findIndexOf {it.startsWith('sg-') }
+        def name = parts[2..<idIndex].join(':')
+        def frigga = Names.parseName(name)
+        result << [application: frigga.app, name: name, id: parts[idIndex], region: parts[idIndex + 1], account: parts[idIndex + 2], vpcId: parts[idIndex + 3] == "null" ? null : parts[idIndex + 3]]
         break
       case Namespace.VPCS.ns:
         result << [id: parts[2], account: parts[3], region: parts[4]]

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/cache/KeysSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/cache/KeysSpec.groovy
@@ -29,7 +29,28 @@ class KeysSpec extends Specification {
 
     where:
 
-    key                                                                                                         | namespace
-    "aws:securityGroups:appname:appname-stack-detail:test:us-west-1:appname-stack-detail-v000:stack:detail:000" | Keys.Namespace.SECURITY_GROUPS
+    key                                                                          | namespace
+    "aws:securityGroups:app-stack-detail:sg-12345:us-west-2:0123456789:vpc-1234" | Keys.Namespace.SECURITY_GROUPS
+  }
+
+  @Unroll
+  def 'parse security group keys with special characters'() {
+    given:
+    def parsedKey = Keys.parse(key)
+
+    expect:
+    with(parsedKey) {
+      name == expectedName
+      application == expectedApp
+    }
+
+    where:
+
+    key                                                                          || expectedName       | expectedApp
+    "aws:securityGroups:app-stack-detail:sg-12345:us-west-2:0123456789:vpc-1234" || 'app-stack-detail' | 'app'
+    "aws:securityGroups:app:stack%detail:sg-12345:us-west-2:0123456789:vpc-1234" || 'app:stack%detail' | null
+    "aws:securityGroups:app:stack:detail:sg-12345:us-west-2:0123456789:vpc-1234" || 'app:stack:detail' | null
+    "aws:securityGroups:app%stack%detail:sg-12345:us-west-2:0123456789:vpc-1234" || 'app%stack%detail' | null
+    "aws:securityGroups:app%stack:detail:sg-12345:us-west-2:0123456789:vpc-1234" || 'app%stack:detail' | null
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProviderSpec.groovy
@@ -176,12 +176,12 @@ class AmazonSecurityGroupProviderSpec extends Specification {
     where:
     account = 'prod'
     region = 'us-east-1'
-    id = 'a'
+    id = 'sg-a'
   }
 
   void "should add both ipRangeRules and securityGroup rules"() {
     given:
-    String groupId = 'id-a'
+    String groupId = 'sg-a'
     String groupName = 'name-a'
     String vpcId = null
     SecurityGroup mixedRangedGroupA = new SecurityGroup(
@@ -197,7 +197,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
           ipv4Ranges: [new IpRange(cidrIp: '0.0.0.0/32'), new IpRange(cidrIp: '0.0.0.1/31')],
           ipv6Ranges: [new Ipv6Range(cidrIpv6: '::/0')],
           userIdGroupPairs: [
-            new UserIdGroupPair(groupId: 'id-b', groupName: 'name-b', userId: 'test')
+            new UserIdGroupPair(groupId: 'sg-b', groupName: 'name-b', userId: 'test')
           ]
         )
       ])
@@ -227,8 +227,8 @@ class AmazonSecurityGroupProviderSpec extends Specification {
 
   void "should add security group ingress with different protocols"() {
     given:
-    SecurityGroup securityGroupA = new SecurityGroup(ownerId: "accountId1", groupId: 'id-a', groupName: 'name-a', description: 'a')
-    SecurityGroup securityGroupB = new SecurityGroup(ownerId: "accountId1", groupId: 'id-b', groupName: 'name-b', description: 'b')
+    SecurityGroup securityGroupA = new SecurityGroup(ownerId: "accountId1", groupId: 'sg-a', groupName: 'name-a', description: 'a')
+    SecurityGroup securityGroupB = new SecurityGroup(ownerId: "accountId1", groupId: 'sg-b', groupName: 'name-b', description: 'b')
     securityGroupB.ipPermissions = [
       new IpPermission(ipProtocol: "TCP", fromPort: 7001, toPort: 7001, userIdGroupPairs: [
         new UserIdGroupPair(userId: "accountId1", groupId: securityGroupA.groupId, groupName: securityGroupA.groupName)
@@ -239,7 +239,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
     ]
     String account = 'test'
     String region = 'us-east-1'
-    def key = Keys.getSecurityGroupKey('name-b', 'id-b', region, account, null)
+    def key = Keys.getSecurityGroupKey('name-b', 'sg-b', region, account, null)
     Map<String, Object> attributes = mapper.convertValue(securityGroupB, AwsInfrastructureProvider.ATTRIBUTES)
     def cacheData = new DefaultCacheData(key, attributes, [:])
     cache.merge(Keys.Namespace.SECURITY_GROUPS.ns, cacheData)
@@ -248,11 +248,11 @@ class AmazonSecurityGroupProviderSpec extends Specification {
     def sg = provider.get(account, region, 'name-b', null)
 
     then:
-    sg == new AmazonSecurityGroup(id: "id-b", name: "name-b", description: "b",
+    sg == new AmazonSecurityGroup(id: "sg-b", name: "name-b", description: "b",
       accountName: account, region: region, inboundRules: [
       new SecurityGroupRule(protocol: "TCP",
         securityGroup: new AmazonSecurityGroup(
-          id: 'id-a',
+          id: 'sg-a',
           name: 'name-a',
           accountName: "accountName1",
           accountId: "accountId1",
@@ -264,7 +264,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
       ),
       new SecurityGroupRule(protocol: "UDP",
         securityGroup: new AmazonSecurityGroup(
-          id: 'id-a',
+          id: 'sg-a',
           name: 'name-a',
           accountName: "accountName1",
           accountId: "accountId1",
@@ -284,7 +284,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
     String account = 'test'
     String region = 'us-east-1'
     SecurityGroup group = new SecurityGroup(
-      groupId: 'id-a',
+      groupId: 'sg-a',
       groupName: 'name-a',
       description: 'a',
       ipPermissions: [
@@ -301,7 +301,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
           ipRanges: ['0.0.0.0/32', '0.0.0.1/31']
         )
       ])
-    def key = Keys.getSecurityGroupKey('name-a', 'id-a', region, account, null)
+    def key = Keys.getSecurityGroupKey('name-a', 'sg-a', region, account, null)
     Map<String, Object> attributes = mapper.convertValue(group, AwsInfrastructureProvider.ATTRIBUTES)
     def cacheData = new DefaultCacheData(key, attributes, [:])
     cache.merge(Keys.Namespace.SECURITY_GROUPS.ns, cacheData)
@@ -325,7 +325,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
     String account = 'test'
     String region = 'us-east-1'
     SecurityGroup group = new SecurityGroup(
-      groupId: 'id-a',
+      groupId: 'sg-a',
       groupName: 'name-a',
       description: 'a',
       ipPermissions: [
@@ -342,7 +342,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
           ipRanges: ['0.0.0.0/32', '0.0.0.1/31']
         )
       ])
-    def key = Keys.getSecurityGroupKey('name-a', 'id-a', region, account, null)
+    def key = Keys.getSecurityGroupKey('name-a', 'sg-a', region, account, null)
     Map<String, Object> attributes = mapper.convertValue(group, AwsInfrastructureProvider.ATTRIBUTES)
     def cacheData = new DefaultCacheData(key, attributes, [:])
     cache.merge(Keys.Namespace.SECURITY_GROUPS.ns, cacheData)
@@ -364,15 +364,15 @@ class AmazonSecurityGroupProviderSpec extends Specification {
     String vpcId = 'vpc-1234'
     String account = 'accountName1'
     String region = 'us-east-1'
-    SecurityGroup securityGroupA = new SecurityGroup(ownerId: account, groupId: 'id-a', groupName: 'name-a', description: 'a', vpcId: vpcId)
-    SecurityGroup securityGroupB = new SecurityGroup(ownerId: account, groupId: 'id-b', groupName: 'name-b', description: 'b', vpcId: vpcId)
+    SecurityGroup securityGroupA = new SecurityGroup(ownerId: account, groupId: 'sg-a', groupName: 'name-a', description: 'a', vpcId: vpcId)
+    SecurityGroup securityGroupB = new SecurityGroup(ownerId: account, groupId: 'sg-b', groupName: 'name-b', description: 'b', vpcId: vpcId)
     securityGroupA.ipPermissions = [
         new IpPermission(ipProtocol: "TCP", fromPort: 7001, toPort: 7001, userIdGroupPairs: [
             new UserIdGroupPair(userId: "accountId1", groupId: securityGroupB.groupId)
         ])
     ]
-    def keyA = Keys.getSecurityGroupKey('name-a', 'id-a', region, account, vpcId)
-    def keyB = Keys.getSecurityGroupKey('name-b', 'id-b', region, account, vpcId)
+    def keyA = Keys.getSecurityGroupKey('name-a', 'sg-a', region, account, vpcId)
+    def keyB = Keys.getSecurityGroupKey('name-b', 'sg-b', region, account, vpcId)
     Map<String, Object> attributesA = mapper.convertValue(securityGroupA, AwsInfrastructureProvider.ATTRIBUTES)
     Map<String, Object> attributesB = mapper.convertValue(securityGroupB, AwsInfrastructureProvider.ATTRIBUTES)
     def cacheDataA = new DefaultCacheData(keyA, attributesA, [:])
@@ -395,15 +395,15 @@ class AmazonSecurityGroupProviderSpec extends Specification {
     String account1 = 'accountName1'
     String account2 = 'accountName2'
     String region = 'us-east-1'
-    SecurityGroup securityGroupA = new SecurityGroup(ownerId: account1, groupId: 'id-a', groupName: 'name-a', description: 'a', vpcId: vpcId1)
-    SecurityGroup securityGroupB = new SecurityGroup(ownerId: account2, groupId: 'id-b', groupName: 'name-b', description: 'b', vpcId: vpcId2)
+    SecurityGroup securityGroupA = new SecurityGroup(ownerId: account1, groupId: 'sg-a', groupName: 'name-a', description: 'a', vpcId: vpcId1)
+    SecurityGroup securityGroupB = new SecurityGroup(ownerId: account2, groupId: 'sg-b', groupName: 'name-b', description: 'b', vpcId: vpcId2)
     securityGroupA.ipPermissions = [
         new IpPermission(ipProtocol: "TCP", fromPort: 7001, toPort: 7001, userIdGroupPairs: [
             new UserIdGroupPair(userId: "accountId2", groupId: securityGroupB.groupId)
         ])
     ]
-    def keyA = Keys.getSecurityGroupKey('name-a', 'id-a', region, account1, vpcId1)
-    def keyB = Keys.getSecurityGroupKey('name-b', 'id-b', region, account2, vpcId2)
+    def keyA = Keys.getSecurityGroupKey('name-a', 'sg-a', region, account1, vpcId1)
+    def keyB = Keys.getSecurityGroupKey('name-b', 'sg-b', region, account2, vpcId2)
     Map<String, Object> attributesA = mapper.convertValue(securityGroupA, AwsInfrastructureProvider.ATTRIBUTES)
     Map<String, Object> attributesB = mapper.convertValue(securityGroupB, AwsInfrastructureProvider.ATTRIBUTES)
     def cacheDataA = new DefaultCacheData(keyA, attributesA, [:])
@@ -424,22 +424,22 @@ class AmazonSecurityGroupProviderSpec extends Specification {
   Map<String, Map<String, List<SecurityGroup>>> securityGroupMap = [
     prod: [
       'us-east-1': [
-        new SecurityGroup(groupId: 'a', groupName: 'a'),
-        new SecurityGroup(groupId: 'b', groupName: 'b'),
+        new SecurityGroup(groupId: 'sg-a', groupName: 'a'),
+        new SecurityGroup(groupId: 'sg-b', groupName: 'b'),
       ],
       'us-west-1': [
-        new SecurityGroup(groupId: 'a', groupName: 'a'),
-        new SecurityGroup(groupId: 'b', groupName: 'b'),
+        new SecurityGroup(groupId: 'sg-a', groupName: 'a'),
+        new SecurityGroup(groupId: 'sg-b', groupName: 'b'),
       ]
     ],
     test: [
       'us-east-1': [
-        new SecurityGroup(groupId: 'a', groupName: 'a'),
-        new SecurityGroup(groupId: 'b', groupName: 'b'),
+        new SecurityGroup(groupId: 'sg-a', groupName: 'a'),
+        new SecurityGroup(groupId: 'sg-b', groupName: 'b'),
       ],
       'us-west-1': [
-        new SecurityGroup(groupId: 'a', groupName: 'a'),
-        new SecurityGroup(groupId: 'b', groupName: 'b'),
+        new SecurityGroup(groupId: 'sg-a', groupName: 'a'),
+        new SecurityGroup(groupId: 'sg-b', groupName: 'b'),
       ]
     ]
   ]


### PR DESCRIPTION
Security group names in AWS can contain `:` which breaks the
cache key splitting. This patch uses the fact that the security group
ID must always start with `sg-` to find the actual end of the security
group name.

Resolves spinnaker/spinnaker/issues/6100 and closes #4984
