### PR TITLE
feat(aws): Some additional logging around upsert security group operations

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
@@ -147,8 +147,13 @@ class SecurityGroupLookupFactory {
             entry -> tags.add(new Tag(entry.key, entry.value))
           }
           createTagRequest.withResources(result.groupId).withTags(tags)
-          amazonEC2.createTags(createTagRequest)
-        }, 10, 3000, false);
+
+          try {
+            amazonEC2.createTags(createTagRequest)
+          } catch (Exception e) {
+            log.info("Unable to tag newly created security group '${description.name}, reason: ${e}")
+          }
+        }, 15, 3000, false);
       } catch (Exception e) {
         log.error(
           "Unable to tag newly created security group (groupName: {}, groupId: {}, accountId: {})",

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperationUnitSpec.groovy
@@ -346,7 +346,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
 
     then:
     IllegalStateException ex = thrown()
-    ex.message == "The following security groups do not exist: 'bar' in 'test' vpc-123"
+    ex.message == "The following security groups do not exist: 'bar' in 'test' vpc-123 (ignoreSelfReferencingRules: true)"
   }
 
   void "should two-phase create self-referential security group in vpc"() {


### PR DESCRIPTION
Short of rewriting this operation as a Saga, I'm looking to get a better indication
of how often the eventual consistency of AWS causes a problem.

This PR also increases the amount of time we'll wait for the upsert security group
tags operation to complete. This is a proxy for waiting for consistency around the
security group creation.
