### PR TITLE
fix(aws): Tweaked error message when security group tagging fails

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
@@ -151,7 +151,7 @@ class SecurityGroupLookupFactory {
           try {
             amazonEC2.createTags(createTagRequest)
           } catch (Exception e) {
-            log.info("Unable to tag newly created security group '${description.name}, reason: ${e}")
+            log.info("Unable to tag newly created security group '${description.name}, reason: ${e.getMessage()}")
           }
         }, 15, 3000, false);
       } catch (Exception e) {


### PR DESCRIPTION
Only intended to include `e.getMessage()`.
