### PR TITLE
fix(aws): fixed failure to create launch template backed server group with spot instances

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -174,11 +174,7 @@ public class LaunchTemplateService {
     }
 
     // instance market options
-    request.withInstanceMarketOptions(
-        new LaunchTemplateInstanceMarketOptionsRequest()
-            .withSpotOptions(
-                new LaunchTemplateSpotMarketOptionsRequest()
-                    .withMaxPrice(description.getSpotPrice())));
+    setSpotInstanceMarketOptions(request, description.getSpotPrice());
 
     // network interfaces
     LaunchTemplateInstanceNetworkInterfaceSpecificationRequest networkInterfaceRequest =
@@ -258,11 +254,7 @@ public class LaunchTemplateService {
     }
 
     // instance market options
-    request.withInstanceMarketOptions(
-        new LaunchTemplateInstanceMarketOptionsRequest()
-            .withSpotOptions(
-                new LaunchTemplateSpotMarketOptionsRequest()
-                    .withMaxPrice(settings.getSpotPrice())));
+    setSpotInstanceMarketOptions(request, settings.getSpotPrice());
 
     // network interfaces
     request.withNetworkInterfaces(
@@ -273,6 +265,21 @@ public class LaunchTemplateService {
             .withDeviceIndex(0));
 
     return request;
+  }
+
+  /**
+   * Set instance market options, required when launching spot instances
+   * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-launchtemplatedata-instancemarketoptions.html
+   */
+  private void setSpotInstanceMarketOptions(
+      RequestLaunchTemplateData request, String maxSpotPrice) {
+    if (maxSpotPrice != null) {
+      request.setInstanceMarketOptions(
+          new LaunchTemplateInstanceMarketOptionsRequest()
+              .withMarketType("spot")
+              .withSpotOptions(
+                  new LaunchTemplateSpotMarketOptionsRequest().withMaxPrice(maxSpotPrice)));
+    }
   }
 
   private void setUserData(


### PR DESCRIPTION
## Summary
fix(aws): fixed failure to create launch template backed server group with spot instances
- added missing marketType
- using market options only to launch spot instances

## Issue
https://github.com/spinnaker/spinnaker/issues/6114
https://github.com/spinnaker/spinnaker/issues/5989

## Testing
1. Enable launch template support in Clouddriver
2. Create a server group backed by launch template like 
```
curl -H 'Content-Type: application/json' -d '{ "job": [ { "application": "hello", \
"setLaunchTemplate": true, "credentials": "my-aws-devel-acct", "strategy": "", "capacity": { "min": 1, "max": 1, "desired": 1 }, "targetHealthyDeployPercentage": 100, "cooldown": 10, "enabledMetrics": [], "healthCheckType": "EC2", "healthCheckGracePeriod": 600, "instanceMonitoring": false, "ebsOptimized": false, "iamRole": "BaseInstanceProfile", "terminationPolicies": [ "Default" ], "subnetType": "public-subnet", "availabilityZones": { "eu-central-1": [ "eu-central-1a", "eu-central-1b", "eu-central-1c" ] }, "keyPair": "my-keypair", "suspendedProcesses": [], "securityGroups": [], "stack": "mystack", "freeFormDetails": "", \
"spotPrice": "5", "tags": {}, "useAmiBlockDeviceMappings": false, "copySourceCustomBlockDeviceMappings": false, "virtualizationType": "hvm", "amiName": "hello_aws", "instanceType": "t2.small", "type": "createServerGroup", "cloudProvider": "aws", "loadBalancers": [], "targetGroups": [], "account": "my-aws-acct", "user": "[anonymous]" } ], "application": "hello", "description": "Create New Server Group in cluster hello"}' -X POST http://localhost:8084/tasks
``` 
3. Server group gets created successfully without exception from AWS.
