### PR TITLE
fix(upgrade): Docker image bump to 3.12 to fix potential JVM error on Git handling

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.12
 LABEL maintainer="sig-platform@spinnaker.io"
 
 ENV KUBECTL_VERSION v1.17.6


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8229872

We encountered this bug in java 11.0.5 which is the jdk on alpine 3.11.  Alpine 3.12 uses 11.0.8 which fixes it.  Of course other updates, but this is a safeguard.  Requires having enough overlays to go over 1024 in total overalay size which unlikely to be an issue on most builds but can't be entirely ruled out.