### PR TITLE
fix(aws/asg): Launch template security groups from network interfaces

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -172,6 +172,12 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
           if (!launchTemplateData.networkInterfaces?.empty && launchTemplateData.networkInterfaces*.associatePublicIpAddress?.any()) {
             associatePublicIpAddress = true
           }
+          if (!launchTemplateData.networkInterfaces?.empty) {
+            def networkInterface = launchTemplateData.networkInterfaces.find({it.deviceIndex == 0 })
+            if (networkInterface != null) {
+              securityGroups = networkInterface.groups
+            }
+          }
         } else {
           def ancestorLaunchConfiguration = sourceRegionScopedProvider
             .asgService.getLaunchConfiguration(ancestorAsg.launchConfigurationName)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -173,6 +173,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
             associatePublicIpAddress = true
           }
           if (!launchTemplateData.networkInterfaces?.empty) {
+            // Network interfaces are the source of truth for launch template security groups
             def networkInterface = launchTemplateData.networkInterfaces.find({it.deviceIndex == 0 })
             if (networkInterface != null) {
               securityGroups = networkInterface.groups


### PR DESCRIPTION
**Problem:** When cloning a launch template-backed ASG via pipelines that need to `copyLastAsgAtomicOperation`, security groups were missing.

**Solution:** Security group IDs for launch templates are stored in the network interfaces. If the stage context does not explicitly have `launchTemplate.securityGroups`, the `networkInterfaces` need to be the source of truth for setting the security groups. 