### PR TITLE
fix(titus): Map /titus/images to elastic search docker image controller

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
@@ -30,7 +30,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/dockerRegistry/images")
+@RequestMapping(["/dockerRegistry/images", "/titus/images"])
 class DockerRegistryImageLookupController {
   @Autowired
   private final Cache cacheView


### PR DESCRIPTION
Depends on https://github.com/spinnaker/orca/pull/3967