### PR TITLE
feat(aws): Implement Kork credentials and provider specific CredentialsRepository

### DIFF
--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/cats/agent/AgentProvider.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/cats/agent/AgentProvider.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.cats.agent;
 
+import com.netflix.spinnaker.credentials.Credentials;
 import com.netflix.spinnaker.kork.annotations.Beta;
 import java.util.Collection;
 
@@ -23,5 +24,7 @@ import java.util.Collection;
 public interface AgentProvider {
   boolean supports(String providerName);
 
-  Collection<Agent> agents();
+  default Collection<Agent> agents(Credentials credentials) {
+    return null;
+  }
 }

--- a/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver-aws/clouddriver-aws.gradle
@@ -21,6 +21,7 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-aws"
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation "com.netflix.spinnaker.kork:kork-security"
+  implementation "com.netflix.spinnaker.kork:kork-credentials"
   implementation "com.netflix.spinnaker.kork:kork-moniker"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.okhttp:okhttp-apache"

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupDetachedInstancesAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupDetachedInstancesAgent.groovy
@@ -28,8 +28,8 @@ import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.DetachInstancesAtomicOperation
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.ProviderUtils
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import groovy.util.logging.Slf4j
 
 import java.util.concurrent.TimeUnit
@@ -40,17 +40,17 @@ class CleanupDetachedInstancesAgent implements RunnableAgent, CustomScheduledAge
   public static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(20)
 
   final AmazonClientProvider amazonClientProvider
-  final AccountCredentialsRepository accountCredentialsRepository
+  final CredentialsRepository<NetflixAmazonCredentials> accountCredentialsRepository
   final long pollIntervalMillis
   final long timeoutMillis
 
   CleanupDetachedInstancesAgent(AmazonClientProvider amazonClientProvider,
-                                AccountCredentialsRepository accountCredentialsRepository) {
+                                CredentialsRepository<NetflixAmazonCredentials> accountCredentialsRepository) {
     this(amazonClientProvider, accountCredentialsRepository, DEFAULT_POLL_INTERVAL_MILLIS, DEFAULT_TIMEOUT_MILLIS)
   }
 
   CleanupDetachedInstancesAgent(AmazonClientProvider amazonClientProvider,
-                                AccountCredentialsRepository accountCredentialsRepository,
+                                CredentialsRepository<NetflixAmazonCredentials> accountCredentialsRepository,
                                 long pollIntervalMillis,
                                 long timeoutMills) {
     this.amazonClientProvider = amazonClientProvider
@@ -108,7 +108,7 @@ class CleanupDetachedInstancesAgent implements RunnableAgent, CustomScheduledAge
   }
 
   private Set<NetflixAmazonCredentials> getAccounts() {
-    ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials, AmazonCloudProvider.ID)
+    return accountCredentialsRepository.getAll()
   }
 
   /**

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonClusterController.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonClusterController.groovy
@@ -20,7 +20,7 @@ import com.amazonaws.services.autoscaling.model.Activity
 import com.amazonaws.services.autoscaling.model.DescribeScalingActivitiesRequest
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.*
 class AmazonClusterController {
 
   @Autowired
-  AccountCredentialsProvider accountCredentialsProvider
+  CredentialsRepository<NetflixAmazonCredentials> credentialsRepository
 
   @Autowired
   AmazonClientProvider amazonClientProvider
@@ -40,8 +40,8 @@ class AmazonClusterController {
 
   @RequestMapping(value = "/scalingActivities", method = RequestMethod.GET)
   ResponseEntity getScalingActivities(@PathVariable String account, @PathVariable String serverGroupName, @RequestParam(value = "region", required = true) String region) {
-    def credentials = accountCredentialsProvider.getCredentials(account)
-    if (!(credentials instanceof NetflixAmazonCredentials)) {
+    def credentials = credentialsRepository.getOne(account)
+    if (credentials == null) {
       return new ResponseEntity([message: "bad credentials"], HttpStatus.BAD_REQUEST)
     }
     def autoScaling = amazonClientProvider.getAutoScaling(credentials, region)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -46,7 +46,7 @@ import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import com.netflix.spinnaker.clouddriver.deploy.DeployHandler
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
 import com.netflix.spinnaker.clouddriver.orchestration.events.CreateServerGroupEvent
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
@@ -74,7 +74,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
   }
 
   private final RegionScopedProviderFactory regionScopedProviderFactory
-  private final AccountCredentialsRepository accountCredentialsRepository
+  private final CredentialsRepository<NetflixAmazonCredentials> accountCredentialsRepository
   private final AwsConfiguration.AmazonServerGroupProvider amazonServerGroupProvider
   private final AwsConfiguration.DeployDefaults deployDefaults
   private final ScalingPolicyCopier scalingPolicyCopier
@@ -84,7 +84,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
   private List<CreateServerGroupEvent> deployEvents = []
 
   BasicAmazonDeployHandler(RegionScopedProviderFactory regionScopedProviderFactory,
-                           AccountCredentialsRepository accountCredentialsRepository,
+                           CredentialsRepository<NetflixAmazonCredentials> accountCredentialsRepository,
                            AwsConfiguration.AmazonServerGroupProvider amazonServerGroupProvider,
                            AwsConfiguration.DeployDefaults deployDefaults,
                            ScalingPolicyCopier scalingPolicyCopier,
@@ -246,8 +246,8 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
       validateInstanceType(ami, description.instanceType)
 
       def account = accountCredentialsRepository.getOne(description.credentials.name)
-      if (!(account instanceof NetflixAmazonCredentials)) {
-        throw new IllegalArgumentException("Unsupported account type ${account.class.simpleName} for this operation")
+      if (account == null) {
+        throw new IllegalArgumentException("Account with name ${description.credentials.name} could not be found.")
       }
 
       if (description.useAmiBlockDeviceMappings) {
@@ -543,7 +543,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
                                                                                            BasicAmazonDeployDescription.Source source) {
     if (source.account && source.region && source.asgName) {
       def sourceRegion = source.region
-      def sourceAsgCredentials = accountCredentialsRepository.getOne(source.account) as NetflixAmazonCredentials
+      def sourceAsgCredentials = accountCredentialsRepository.getOne(source.account)
       def regionScopedProvider = regionScopedProviderFactory.forRegion(sourceAsgCredentials, sourceRegion)
 
       def sourceAsgs = regionScopedProvider.autoScaling.describeAutoScalingGroups(

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -15,6 +15,7 @@
  */
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
+
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import com.amazonaws.services.ec2.model.DescribeSubnetsRequest
@@ -22,21 +23,21 @@ import com.amazonaws.services.ec2.model.LaunchTemplateVersion
 import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
 import com.netflix.frigga.Names
 import com.netflix.frigga.autoscaling.AutoScalingGroupNameBuilder
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.BasicAmazonDeployDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.BasicAmazonDeployHandler
 import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.LocalFileUserDataProperties
 import com.netflix.spinnaker.clouddriver.aws.deploy.validators.BasicAmazonDeployDescriptionValidator
+import com.netflix.spinnaker.clouddriver.aws.model.SubnetData
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidationErrors
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidationException
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.BasicAmazonDeployDescription
-import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.BasicAmazonDeployHandler
-import com.netflix.spinnaker.clouddriver.aws.model.SubnetData
-import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import org.springframework.beans.factory.annotation.Autowired
 
 class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
@@ -56,7 +57,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
   AmazonClientProvider amazonClientProvider
 
   @Autowired
-  AccountCredentialsProvider accountCredentialsProvider
+  CredentialsRepository<NetflixAmazonCredentials> credentialsRepository
 
   @Autowired
   RegionScopedProviderFactory regionScopedProviderFactory
@@ -90,7 +91,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
       def sourceAsgCredentials
       if (description.source.account && description.source.region && description.source.asgName) {
         sourceRegion = description.source.region
-        sourceAsgCredentials = accountCredentialsProvider.getCredentials(description.source.account) as NetflixAmazonCredentials
+        sourceAsgCredentials = credentialsRepository.getOne(description.source.account)
         def sourceAutoScaling = amazonClientProvider.getAutoScaling(sourceAsgCredentials, sourceRegion, true)
         def request = new DescribeAutoScalingGroupsRequest(autoScalingGroupNames: [description.source.asgName])
         List<AutoScalingGroup> ancestorAsgs = sourceAutoScaling.describeAutoScalingGroups(request).autoScalingGroups

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/ModifyServerGroupLaunchTemplate.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/ModifyServerGroupLaunchTemplate.java
@@ -33,7 +33,7 @@ import com.netflix.spinnaker.clouddriver.event.EventMetadata;
 import com.netflix.spinnaker.clouddriver.saga.SagaCommand;
 import com.netflix.spinnaker.clouddriver.saga.flow.SagaAction;
 import com.netflix.spinnaker.clouddriver.saga.models.Saga;
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.Collections;
 import javax.annotation.Nonnull;
 import lombok.Builder;
@@ -46,12 +46,12 @@ import org.springframework.stereotype.Component;
 public class ModifyServerGroupLaunchTemplate
     implements SagaAction<ModifyServerGroupLaunchTemplate.ModifyServerGroupLaunchTemplateCommand> {
   private final BlockDeviceConfig blockDeviceConfig;
-  private final AccountCredentialsRepository credentialsRepository;
+  private final CredentialsRepository<NetflixAmazonCredentials> credentialsRepository;
   private final RegionScopedProviderFactory regionScopedProviderFactory;
 
   public ModifyServerGroupLaunchTemplate(
       BlockDeviceConfig blockDeviceConfig,
-      AccountCredentialsRepository credentialsRepository,
+      CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
       RegionScopedProviderFactory regionScopedProviderFactory) {
     this.blockDeviceConfig = blockDeviceConfig;
     this.credentialsRepository = credentialsRepository;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/PrepareModifyServerGroupLaunchTemplate.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/PrepareModifyServerGroupLaunchTemplate.java
@@ -20,7 +20,11 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions;
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
 import com.amazonaws.services.autoscaling.model.LaunchTemplateSpecification;
 import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.model.*;
+import com.amazonaws.services.ec2.model.LaunchTemplateBlockDeviceMapping;
+import com.amazonaws.services.ec2.model.LaunchTemplateIamInstanceProfileSpecification;
+import com.amazonaws.services.ec2.model.LaunchTemplateInstanceMarketOptions;
+import com.amazonaws.services.ec2.model.LaunchTemplateVersion;
+import com.amazonaws.services.ec2.model.ResponseLaunchTemplateData;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -37,7 +41,7 @@ import com.netflix.spinnaker.clouddriver.event.EventMetadata;
 import com.netflix.spinnaker.clouddriver.saga.SagaCommand;
 import com.netflix.spinnaker.clouddriver.saga.flow.SagaAction;
 import com.netflix.spinnaker.clouddriver.saga.models.Saga;
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -57,12 +61,12 @@ public class PrepareModifyServerGroupLaunchTemplate
     implements SagaAction<
         PrepareModifyServerGroupLaunchTemplate.PrepareModifyServerGroupLaunchTemplateCommand> {
   private final BlockDeviceConfig blockDeviceConfig;
-  private final AccountCredentialsRepository credentialsRepository;
+  private final CredentialsRepository<NetflixAmazonCredentials> credentialsRepository;
   private final RegionScopedProviderFactory regionScopedProviderFactory;
 
   public PrepareModifyServerGroupLaunchTemplate(
       BlockDeviceConfig blockDeviceConfig,
-      AccountCredentialsRepository credentialsRepository,
+      CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
       RegionScopedProviderFactory regionScopedProviderFactory) {
     this.blockDeviceConfig = blockDeviceConfig;
     this.credentialsRepository = credentialsRepository;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/UpdateAutoScalingGroup.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/UpdateAutoScalingGroup.java
@@ -30,7 +30,7 @@ import com.netflix.spinnaker.clouddriver.event.EventMetadata;
 import com.netflix.spinnaker.clouddriver.saga.SagaCommand;
 import com.netflix.spinnaker.clouddriver.saga.flow.SagaAction;
 import com.netflix.spinnaker.clouddriver.saga.models.Saga;
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
 import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Value;
@@ -42,11 +42,11 @@ import org.springframework.stereotype.Component;
 public class UpdateAutoScalingGroup
     implements SagaAction<UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand> {
   private final RegionScopedProviderFactory regionScopedProviderFactory;
-  private final AccountCredentialsRepository credentialsRepository;
+  private final CredentialsRepository<NetflixAmazonCredentials> credentialsRepository;
 
   public UpdateAutoScalingGroup(
       RegionScopedProviderFactory regionScopedProviderFactory,
-      AccountCredentialsRepository credentialsRepository) {
+      CredentialsRepository<NetflixAmazonCredentials> credentialsRepository) {
     this.regionScopedProviderFactory = regionScopedProviderFactory;
     this.credentialsRepository = credentialsRepository;
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
@@ -17,25 +17,12 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup
 
 import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.AuthorizeSecurityGroupIngressRequest
-import com.amazonaws.services.ec2.model.CreateSecurityGroupRequest
-import com.amazonaws.services.ec2.model.CreateTagsRequest
-import com.amazonaws.services.ec2.model.DeleteTagsRequest
-import com.amazonaws.services.ec2.model.DescribeSecurityGroupsRequest
-import com.amazonaws.services.ec2.model.DescribeTagsRequest
-import com.amazonaws.services.ec2.model.Filter
-import com.amazonaws.services.ec2.model.IpPermission
-import com.amazonaws.services.ec2.model.RevokeSecurityGroupIngressRequest
-import com.amazonaws.services.ec2.model.SecurityGroup
-import com.amazonaws.services.ec2.model.Tag
-import com.amazonaws.services.ec2.model.DescribeTagsResult
-import com.amazonaws.services.ec2.model.TagDescription
-import com.amazonaws.services.ec2.model.UpdateSecurityGroupRuleDescriptionsIngressRequest
+import com.amazonaws.services.ec2.model.*
 import com.google.common.collect.ImmutableSet
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import com.netflix.spinnaker.kork.core.RetrySupport
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -43,12 +30,12 @@ import org.slf4j.LoggerFactory
 class SecurityGroupLookupFactory {
 
   private final AmazonClientProvider amazonClientProvider
-  private final AccountCredentialsRepository accountCredentialsRepository
+  private final CredentialsRepository<NetflixAmazonCredentials> credentialsRepository
 
   SecurityGroupLookupFactory(AmazonClientProvider amazonClientProvider,
-                             AccountCredentialsRepository accountCredentialsRepository) {
+                             CredentialsRepository<NetflixAmazonCredentials> credentialsRepository) {
     this.amazonClientProvider = amazonClientProvider
-    this.accountCredentialsRepository = accountCredentialsRepository
+    this.credentialsRepository = credentialsRepository
   }
 
   SecurityGroupLookup getInstance(String region) {
@@ -56,9 +43,7 @@ class SecurityGroupLookupFactory {
   }
 
   SecurityGroupLookup getInstance(String region, boolean skipEdda) {
-    final allNetflixAmazonCredentials = (Set<NetflixAmazonCredentials>) accountCredentialsRepository.all.findAll {
-      it instanceof NetflixAmazonCredentials
-    }
+    final allNetflixAmazonCredentials = credentialsRepository.getAll()
     final accounts = ImmutableSet.copyOf(allNetflixAmazonCredentials)
     new SecurityGroupLookup(amazonClientProvider, region, accounts, skipEdda)
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AllowLaunchDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AllowLaunchDescriptionValidator.groovy
@@ -16,17 +16,18 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AllowLaunchDescription
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.AllowLaunchDescription
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component("allowLaunchDescriptionValidator")
 class AllowLaunchDescriptionValidator extends DescriptionValidator<AllowLaunchDescription> {
   @Autowired
-  AccountCredentialsProvider accountCredentialsProvider
+  CredentialsRepository<NetflixAmazonCredentials> credentialsRepository
 
   @Override
   void validate(List priorDescriptions, AllowLaunchDescription description, ValidationErrors errors) {
@@ -38,7 +39,7 @@ class AllowLaunchDescriptionValidator extends DescriptionValidator<AllowLaunchDe
     }
     if (!description.targetAccount) {
       errors.rejectValue("targetAccount", "allowLaunchDescription.targetAccount.empty")
-    } else if (!accountCredentialsProvider.all.collect { it.name }.contains(description.targetAccount)) {
+    } else if (credentialsRepository.getOne(description.targetAccount) == null) {
       errors.rejectValue("targetAccount", "allowLaunchDescription.targetAccount.not.configured")
     }
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AttachClassicLinkVpcDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AttachClassicLinkVpcDescriptionValidator.groovy
@@ -17,9 +17,9 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AttachClassicLinkVpcDescription
 import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.AttachClassicLinkVpcDescription
 import org.springframework.stereotype.Component
 
 @AmazonOperation(AtomicOperations.ATTACH_CLASSIC_LINK_VPC)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidator.groovy
@@ -17,12 +17,13 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.BasicAmazonDeployDescription
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.BasicAmazonDeployDescription
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import org.springframework.beans.factory.annotation.Autowired
@@ -32,7 +33,7 @@ import org.springframework.stereotype.Component
 @AmazonOperation(AtomicOperations.CREATE_SERVER_GROUP)
 class BasicAmazonDeployDescriptionValidator extends AmazonDescriptionValidationSupport<BasicAmazonDeployDescription> {
   @Autowired
-  AccountCredentialsProvider accountCredentialsProvider
+  CredentialsRepository<NetflixAmazonCredentials> credentialsRepository
 
   @Override
   void validate(List priorDescriptions, BasicAmazonDeployDescription description, ValidationErrors errors) {
@@ -41,8 +42,8 @@ class BasicAmazonDeployDescriptionValidator extends AmazonDescriptionValidationS
     if (!description.credentials) {
       errors.rejectValue "credentials", "basicAmazonDeployDescription.credentials.empty"
     } else {
-      credentials = accountCredentialsProvider.getCredentials(description?.credentials?.name)
-      if (!(credentials instanceof AmazonCredentials)) {
+      credentials = credentialsRepository.getOne(description?.credentials?.name)
+      if (credentials == null) {
         errors.rejectValue("credentials", "basicAmazonDeployDescription.credentials.invalid")
       }
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAmazonLoadBalancerDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAmazonLoadBalancerDescriptionValidator.groovy
@@ -17,9 +17,9 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAmazonLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAmazonLoadBalancerDescription
 import org.springframework.stereotype.Component
 
 @AmazonOperation(AtomicOperations.DELETE_LOAD_BALANCER)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAmazonSnapshotDescriptionValidator.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAmazonSnapshotDescriptionValidator.java
@@ -20,9 +20,10 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation;
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAmazonSnapshotDescription;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -32,12 +33,12 @@ import org.springframework.stereotype.Component;
 public class DeleteAmazonSnapshotDescriptionValidator
     extends AmazonDescriptionValidationSupport<DeleteAmazonSnapshotDescription> {
 
-  AccountCredentialsProvider accountCredentialsProvider;
+  CredentialsRepository<NetflixAmazonCredentials> credentialsRepository;
 
   @Autowired
   public DeleteAmazonSnapshotDescriptionValidator(
-      AccountCredentialsProvider accountCredentialsProvider) {
-    this.accountCredentialsProvider = accountCredentialsProvider;
+      CredentialsRepository<NetflixAmazonCredentials> credentialsRepository) {
+    this.credentialsRepository = credentialsRepository;
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteSecurityGroupDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteSecurityGroupDescriptionValidator.groovy
@@ -17,10 +17,10 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteSecurityGroupDescription
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ModifyAsgLaunchConfigurationDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ModifyAsgLaunchConfigurationDescriptionValidator.groovy
@@ -17,12 +17,13 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
-import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyAsgLaunchConfigurationDescription
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -30,7 +31,7 @@ import org.springframework.stereotype.Component
 @Component("modifyAsgLaunchConfigurationDescriptionValidator")
 class ModifyAsgLaunchConfigurationDescriptionValidator extends AmazonDescriptionValidationSupport<ModifyAsgLaunchConfigurationDescription> {
   @Autowired
-  AccountCredentialsProvider accountCredentialsProvider
+  CredentialsRepository<NetflixAmazonCredentials> credentialsRepository
 
   @Override
   void validate(List priorDescriptions, ModifyAsgLaunchConfigurationDescription description, ValidationErrors errors) {
@@ -40,8 +41,8 @@ class ModifyAsgLaunchConfigurationDescriptionValidator extends AmazonDescription
     if (!description.credentials) {
       errors.rejectValue "credentials", "modifyAsgLaunchConfigurationDescription.credentials.empty"
     } else {
-      def credentials = accountCredentialsProvider.getCredentials(description?.credentials?.name)
-      if (!(credentials instanceof AmazonCredentials)) {
+      def credentials = credentialsRepository.getOne(description?.credentials?.name)
+      if (credentials == null) {
         errors.rejectValue("credentials", "modifyAsgLaunchConfigurationDescription.credentials.invalid")
       }
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ModifyServerGroupLaunchTemplateValidator.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ModifyServerGroupLaunchTemplateValidator.java
@@ -20,11 +20,11 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators;
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation;
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription;
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice;
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -33,12 +33,12 @@ import org.springframework.stereotype.Component;
 @Component("modifyServerGroupLaunchTemplateDescriptionValidator")
 public class ModifyServerGroupLaunchTemplateValidator
     extends AmazonDescriptionValidationSupport<ModifyServerGroupLaunchTemplateDescription> {
-  private final AccountCredentialsProvider accountCredentialsProvider;
+  private final CredentialsRepository<NetflixAmazonCredentials> credentialsRepository;
 
   @Autowired
   public ModifyServerGroupLaunchTemplateValidator(
-      AccountCredentialsProvider accountCredentialsProvider) {
-    this.accountCredentialsProvider = accountCredentialsProvider;
+      CredentialsRepository<NetflixAmazonCredentials> credentialsRepository) {
+    this.credentialsRepository = credentialsRepository;
   }
 
   @Override
@@ -54,8 +54,8 @@ public class ModifyServerGroupLaunchTemplateValidator
           "credentials", "modifyservergrouplaunchtemplatedescription.credentials.empty");
     } else {
       AccountCredentials credentials =
-          accountCredentialsProvider.getCredentials(description.getCredentials().getName());
-      if (!(credentials instanceof AmazonCredentials)) {
+          credentialsRepository.getOne(description.getCredentials().getName());
+      if (credentials == null) {
         errors.rejectValue(
             "credentials", "modifyservergrouplaunchtemplatedescription.credentials.invalid");
       }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/RebootInstancesDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/RebootInstancesDescriptionValidator.groovy
@@ -17,9 +17,9 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.RebootInstancesDescription
 import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.RebootInstancesDescription
 import org.springframework.stereotype.Component
 
 @AmazonOperation(AtomicOperations.REBOOT_INSTANCES)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/TerminateInstancesDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/TerminateInstancesDescriptionValidator.groovy
@@ -16,9 +16,9 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.TerminateInstancesDescription
 import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.TerminateInstancesDescription
 import org.springframework.stereotype.Component
 
 @AmazonOperation(AtomicOperations.TERMINATE_INSTANCES)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonDNSDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonDNSDescriptionValidator.groovy
@@ -16,9 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonDNSDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonLoadBalancerDescription
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertSecurityGroupDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertSecurityGroupDescriptionValidator.groovy
@@ -17,11 +17,10 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription
+import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
 import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription
-import com.netflix.spinnaker.clouddriver.aws.model.SecurityGroupNotFoundException
-import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/ARN.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/ARN.java
@@ -53,4 +53,23 @@ class ARN {
                         new IllegalArgumentException(
                             "No account credentials found for " + accountId));
   }
+
+  ARN(NetflixAmazonCredentials netflixAmazonCredentials, String arn) {
+    this.arn = arn;
+
+    Matcher sqsMatcher = PATTERN.matcher(arn);
+    if (!sqsMatcher.matches()) {
+      throw new IllegalArgumentException(arn + " is not a valid SNS or SQS ARN");
+    }
+
+    this.region = sqsMatcher.group(1);
+    this.name = sqsMatcher.group(3);
+
+    String accountId = sqsMatcher.group(2);
+    if (accountId.equals(netflixAmazonCredentials.getAccountId())) {
+      this.account = netflixAmazonCredentials;
+    } else {
+      throw new IllegalArgumentException("No account credentials found for " + accountId);
+    }
+  }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
@@ -21,7 +21,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.AwsEurekaSupport;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -47,7 +47,7 @@ public class InstanceTerminationLifecycleWorkerProvider {
 
   private final ObjectMapper objectMapper;
   private final AmazonClientProvider amazonClientProvider;
-  private final AccountCredentialsProvider accountCredentialsProvider;
+  private final CredentialsRepository<NetflixAmazonCredentials> credentialsRepository;
   private final InstanceTerminationConfigurationProperties properties;
   private final Provider<AwsEurekaSupport> discoverySupport;
   private final Registry registry;
@@ -56,13 +56,13 @@ public class InstanceTerminationLifecycleWorkerProvider {
   InstanceTerminationLifecycleWorkerProvider(
       @Qualifier("amazonObjectMapper") ObjectMapper objectMapper,
       AmazonClientProvider amazonClientProvider,
-      AccountCredentialsProvider accountCredentialsProvider,
+      CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
       InstanceTerminationConfigurationProperties properties,
       Provider<AwsEurekaSupport> discoverySupport,
       Registry registry) {
     this.objectMapper = objectMapper;
     this.amazonClientProvider = amazonClientProvider;
-    this.accountCredentialsProvider = accountCredentialsProvider;
+    this.credentialsRepository = credentialsRepository;
     this.properties = properties;
     this.discoverySupport = discoverySupport;
     this.registry = registry;
@@ -71,8 +71,7 @@ public class InstanceTerminationLifecycleWorkerProvider {
   @PostConstruct
   public void start() {
     NetflixAmazonCredentials credentials =
-        (NetflixAmazonCredentials)
-            accountCredentialsProvider.getCredentials(properties.getAccountName());
+        credentialsRepository.getOne(properties.getAccountName());
     ExecutorService executorService =
         Executors.newFixedThreadPool(
             credentials.getRegions().size(),
@@ -89,7 +88,7 @@ public class InstanceTerminationLifecycleWorkerProvider {
                   new InstanceTerminationLifecycleWorker(
                       objectMapper,
                       amazonClientProvider,
-                      accountCredentialsProvider,
+                      credentialsRepository,
                       new InstanceTerminationConfigurationProperties(
                           properties.getAccountName(),
                           properties

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
@@ -33,9 +33,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 @Component
+@DependsOn("amazonCredentialsLoader")
 @ConditionalOnExpression(
     "${aws.lifecycle-subscribers.instance-termination.enabled:false} && ${caching.write-enabled:true}")
 public class InstanceTerminationLifecycleWorkerProvider {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LifecycleSubscriberConfiguration.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LifecycleSubscriberConfiguration.java
@@ -17,9 +17,13 @@
 package com.netflix.spinnaker.clouddriver.aws.lifecycle;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.tags.EntityTagger;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import java.util.ArrayList;
+import java.util.Collections;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -38,10 +42,16 @@ class LifecycleSubscriberConfiguration {
   LaunchFailureNotificationAgentProvider launchFailureNotificationAgentProvider(
       @Qualifier("amazonObjectMapper") ObjectMapper objectMapper,
       AmazonClientProvider amazonClientProvider,
-      AccountCredentialsProvider accountCredentialsProvider,
+      CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
       LaunchFailureConfigurationProperties properties,
-      EntityTagger entityTagger) {
+      EntityTagger entityTagger,
+      AwsProvider awsProvider) {
+    awsProvider.addAgents(
+        new ArrayList<>(
+            Collections.singletonList(
+                new LaunchFailureNotificationCleanupAgent(
+                    amazonClientProvider, credentialsRepository, entityTagger))));
     return new LaunchFailureNotificationAgentProvider(
-        objectMapper, amazonClientProvider, accountCredentialsProvider, properties, entityTagger);
+        objectMapper, amazonClientProvider, credentialsRepository, properties, entityTagger);
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ImageCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ImageCachingAgent.groovy
@@ -37,6 +37,8 @@ import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
 import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import lombok.Getter
+import lombok.Setter
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -60,7 +62,9 @@ class ImageCachingAgent implements CachingAgent, AccountAware, DriftMetric, Cust
   final String region
   final ObjectMapper objectMapper
   final Registry registry
-  final boolean includePublicImages
+  @Getter
+  @Setter
+  boolean includePublicImages
   final long pollIntervalMillis
   final DynamicConfigService dynamicConfigService
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
@@ -50,6 +50,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import groovy.util.logging.Slf4j
 import org.springframework.context.ApplicationContext
 
@@ -79,10 +80,9 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
 
   final AmazonClientProvider amazonClientProvider
   final AmazonS3DataProvider amazonS3DataProvider
-  final Collection<NetflixAmazonCredentials> accounts
+  final CredentialsRepository<NetflixAmazonCredentials> credentialsRepository;
   final ObjectMapper objectMapper
   final AccountReservationDetailSerializer accountReservationDetailSerializer
-  final Set<String> vpcOnlyAccounts
   final MetricsSupport metricsSupport
   final Registry registry
 
@@ -90,13 +90,13 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
   ReservationReportCachingAgent(Registry registry,
                                 AmazonClientProvider amazonClientProvider,
                                 AmazonS3DataProvider amazonS3DataProvider,
-                                Collection<NetflixAmazonCredentials> accounts,
+                                CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
                                 ObjectMapper objectMapper,
                                 ExecutorService reservationReportPool,
                                 ApplicationContext ctx) {
     this.amazonClientProvider = amazonClientProvider
     this.amazonS3DataProvider = amazonS3DataProvider
-    this.accounts = accounts
+    this.credentialsRepository = credentialsRepository
 
     def module = new SimpleModule()
     accountReservationDetailSerializer = new AccountReservationDetailSerializer()
@@ -105,7 +105,6 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
     this.objectMapper = objectMapper.copy().enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS).registerModule(module)
     this.reservationReportPool = reservationReportPool
     this.ctx = ctx
-    this.vpcOnlyAccounts = determineVpcOnlyAccounts()
     this.metricsSupport = new MetricsSupport(objectMapper, registry, { getCacheView() })
     this.registry = registry
   }
@@ -173,14 +172,13 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
   }
 
   public Collection<NetflixAmazonCredentials> getAccounts() {
-    return accounts;
+    return credentialsRepository.getAll();
   }
 
   @Override
   CacheResult loadData(ProviderCache providerCache) {
     long startTime = System.currentTimeMillis()
     log.info("Describing items in ${agentType}")
-
     ConcurrentHashMap<String, OverallReservationDetail> reservations = new ConcurrentHashMap<>()
     ConcurrentHashMap<String, Collection<String>> errorsByRegion = new ConcurrentHashMap<>()
 
@@ -319,7 +317,7 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
             def osType = operatingSystemType(it.productDescription)
             def reservation = getReservation(region.name, it.availabilityZone, osType.name, it.instanceType)
             reservation.totalReserved.addAndGet(it.instanceCount)
-
+            def vpcOnlyAccounts = determineVpcOnlyAccounts()
             if (osType.isVpc || vpcOnlyAccounts.contains(credentials.name)) {
               reservation.getAccount(credentials.name).reservedVpc.addAndGet(it.instanceCount)
             } else {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsInfrastructureProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsInfrastructureProviderConfig.groovy
@@ -16,16 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.config
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
+
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
-import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig
-import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
-import com.netflix.spinnaker.clouddriver.security.ProviderUtils
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.DependsOn
@@ -34,46 +26,7 @@ import org.springframework.context.annotation.DependsOn
 class AwsInfrastructureProviderConfig {
   @Bean
   @DependsOn('netflixAmazonCredentials')
-  AwsInfrastructureProvider awsInfrastructureProvider(AmazonClientProvider amazonClientProvider,
-                                                      AccountCredentialsRepository accountCredentialsRepository,
-                                                      @Qualifier("amazonObjectMapper") ObjectMapper amazonObjectMapper,
-                                                      Registry registry,
-                                                      EddaTimeoutConfig eddaTimeoutConfig) {
-    def awsInfrastructureProvider =
-      new AwsInfrastructureProvider()
-
-    synchronizeAwsInfrastructureProvider(awsInfrastructureProvider,
-                                         amazonClientProvider,
-                                         accountCredentialsRepository,
-                                         amazonObjectMapper,
-                                         registry,
-                                         eddaTimeoutConfig)
-
-    awsInfrastructureProvider
-  }
-
-  private static void synchronizeAwsInfrastructureProvider(AwsInfrastructureProvider awsInfrastructureProvider,
-                                                           AmazonClientProvider amazonClientProvider,
-                                                           AccountCredentialsRepository accountCredentialsRepository,
-                                                           @Qualifier("amazonObjectMapper") ObjectMapper amazonObjectMapper,
-                                                           Registry registry,
-                                                           EddaTimeoutConfig eddaTimeoutConfig) {
-    def allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials, AmazonCloudProvider.ID)
-
-    Set<String> regions = new HashSet<>()
-    def newlyAddedAgents = []
-    allAccounts.each { NetflixAmazonCredentials credentials ->
-      def result = ProviderHelpers.buildAwsInfrastructureAgents(credentials, awsInfrastructureProvider, accountCredentialsRepository,
-        amazonClientProvider, amazonObjectMapper, registry, eddaTimeoutConfig, regions)
-      regions.addAll(result.getRegionsToAdd())
-      newlyAddedAgents.addAll(result.getAgents())
-    }
-
-    // If there is an agent scheduler, then this provider has been through the AgentController in the past.
-    // In that case, we need to do the scheduling here (because accounts have been added to a running system).
-    if (awsInfrastructureProvider.agentScheduler) {
-      ProviderUtils.rescheduleAgents(awsInfrastructureProvider, newlyAddedAgents)
-    }
-    awsInfrastructureProvider.addAgents(newlyAddedAgents)
+  AwsInfrastructureProvider awsInfrastructureProvider() {
+    return new AwsInfrastructureProvider()
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
@@ -16,29 +16,15 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.config
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.util.concurrent.ThreadFactoryBuilder
-import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.cats.agent.Agent
-import com.netflix.spinnaker.cats.agent.AgentProvider
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
-import com.netflix.spinnaker.clouddriver.aws.edda.EddaApiFactory
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservationReportCachingAgent
-import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3DataProvider
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
-import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.model.ReservationReport
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
-import com.netflix.spinnaker.clouddriver.security.ProviderUtils
-import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
-import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.DependsOn
 
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -47,37 +33,8 @@ import java.util.concurrent.Executors
 @EnableConfigurationProperties(ReservationReportConfigurationProperties)
 class AwsProviderConfig {
   @Bean
-  @DependsOn('netflixAmazonCredentials')
-  AwsProvider awsProvider(AmazonCloudProvider amazonCloudProvider,
-                          AmazonClientProvider amazonClientProvider,
-                          AmazonS3DataProvider amazonS3DataProvider,
-                          AccountCredentialsRepository accountCredentialsRepository,
-                          ObjectMapper objectMapper,
-                          EddaApiFactory eddaApiFactory,
-                          ApplicationContext ctx,
-                          Registry registry,
-                          Optional<ExecutorService> reservationReportPool,
-                          Optional<Collection<AgentProvider>> agentProviders,
-                          EddaTimeoutConfig eddaTimeoutConfig,
-                          DynamicConfigService dynamicConfigService) {
-    def awsProvider =
-      new AwsProvider(accountCredentialsRepository)
-
-    synchronizeAwsProvider(awsProvider,
-                           amazonCloudProvider,
-                           amazonClientProvider,
-                           amazonS3DataProvider,
-                           accountCredentialsRepository,
-                           objectMapper,
-                           eddaApiFactory,
-                           ctx,
-                           registry,
-                           reservationReportPool,
-                           agentProviders.orElse(Collections.emptyList()),
-                           eddaTimeoutConfig,
-                           dynamicConfigService)
-
-    awsProvider
+  AwsProvider awsProvider(CredentialsRepository<NetflixAmazonCredentials> accountCredentialsRepository) {
+      return new AwsProvider(accountCredentialsRepository)
   }
 
   @Bean
@@ -88,54 +45,5 @@ class AwsProviderConfig {
         new ThreadFactoryBuilder()
           .setNameFormat(ReservationReport.class.getSimpleName() + "-%d")
           .build());
-  }
-
-  private void synchronizeAwsProvider(AwsProvider awsProvider,
-                                      AmazonCloudProvider amazonCloudProvider,
-                                      AmazonClientProvider amazonClientProvider,
-                                      AmazonS3DataProvider amazonS3DataProvider,
-                                      AccountCredentialsRepository accountCredentialsRepository,
-                                      ObjectMapper objectMapper,
-                                      EddaApiFactory eddaApiFactory,
-                                      ApplicationContext ctx,
-                                      Registry registry,
-                                      Optional<ExecutorService> reservationReportPool,
-                                      Collection<AgentProvider> agentProviders,
-                                      EddaTimeoutConfig eddaTimeoutConfig,
-                                      DynamicConfigService dynamicConfigService) {
-    Set<NetflixAmazonCredentials> allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials, AmazonCloudProvider.ID)
-    List<Agent> newlyAddedAgents = []
-
-    //only index public images once per region
-    Set<String> publicRegions = []
-
-    //sort the accounts in case of a reconfigure, we are more likely to re-index the public images in the same caching agent
-    //TODO(cfieber)-rework this is after rework of AWS Image/NamedImage keys
-    allAccounts.sort { it.name }.each { NetflixAmazonCredentials credentials ->
-      def result = ProviderHelpers.buildAwsProviderAgents(credentials, amazonClientProvider, objectMapper,
-        registry, eddaTimeoutConfig, awsProvider, amazonCloudProvider, dynamicConfigService, eddaApiFactory, ctx, publicRegions
-      )
-      newlyAddedAgents.addAll(result.agents)
-      publicRegions.addAll(result.regionsToAdd)
-    }
-
-    // If there is an agent scheduler, then this provider has been through the AgentController in the past.
-    if (reservationReportPool.isPresent()) {
-      if (awsProvider.agentScheduler) {
-        ProviderHelpers.synchronizeReservationReportCachingAgentAccounts(awsProvider, allAccounts)
-      } else {
-        // This caching agent runs across all accounts in one iteration (to maintain consistency).
-        newlyAddedAgents << new ReservationReportCachingAgent(
-          registry, amazonClientProvider, amazonS3DataProvider, allAccounts, objectMapper, reservationReportPool.get(), ctx
-        )
-      }
-    }
-
-    agentProviders.findAll { it.supports(AwsProvider.PROVIDER_NAME) }.each {
-      newlyAddedAgents.addAll(it.agents())
-    }
-
-    awsProvider.addAgents(newlyAddedAgents)
-    awsProvider.synchronizeHealthAgents()
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
@@ -20,7 +20,11 @@ package com.netflix.spinnaker.clouddriver.aws.provider.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.Agent;
+import com.netflix.spinnaker.cats.agent.AgentProvider;
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider;
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.aws.agent.CleanupAlarmsAgent;
+import com.netflix.spinnaker.clouddriver.aws.agent.CleanupDetachedInstancesAgent;
 import com.netflix.spinnaker.clouddriver.aws.agent.ReconcileClassicLinkSecurityGroupsAgent;
 import com.netflix.spinnaker.clouddriver.aws.edda.EddaApiFactory;
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider;
@@ -45,19 +49,16 @@ import com.netflix.spinnaker.clouddriver.aws.provider.agent.InstanceCachingAgent
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.LaunchConfigCachingAgent;
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservationReportCachingAgent;
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservedInstancesCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3DataProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 import com.netflix.spinnaker.clouddriver.security.ProviderUtils;
 import com.netflix.spinnaker.config.AwsConfiguration;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationContext;
@@ -74,7 +75,7 @@ public class ProviderHelpers {
   public static BuildResult buildAwsInfrastructureAgents(
       NetflixAmazonCredentials credentials,
       AwsInfrastructureProvider awsInfrastructureProvider,
-      AccountCredentialsRepository accountCredentialsRepository,
+      CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
       AmazonClientProvider amazonClientProvider,
       ObjectMapper amazonObjectMapper,
       Registry registry,
@@ -86,7 +87,7 @@ public class ProviderHelpers {
       if (!scheduledAccounts.contains(credentials.getName())) {
         if (regions.add(region.getName())) {
           newlyAddedAgents.add(
-              new AmazonInstanceTypeCachingAgent(region.getName(), accountCredentialsRepository));
+              new AmazonInstanceTypeCachingAgent(region.getName(), credentialsRepository));
         }
         newlyAddedAgents.add(
             new AmazonElasticIpCachingAgent(amazonClientProvider, credentials, region.getName()));
@@ -113,6 +114,7 @@ public class ProviderHelpers {
 
   public static BuildResult buildAwsProviderAgents(
       NetflixAmazonCredentials credentials,
+      CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
       AmazonClientProvider amazonClientProvider,
       ObjectMapper objectMapper,
       Registry registry,
@@ -121,12 +123,13 @@ public class ProviderHelpers {
       AmazonCloudProvider amazonCloudProvider,
       DynamicConfigService dynamicConfigService,
       EddaApiFactory eddaApiFactory,
+      Optional<ExecutorService> reservationReportPool,
+      Optional<Collection<AgentProvider>> agentProviders,
       ApplicationContext ctx,
+      AmazonS3DataProvider amazonS3DataProvider,
       Set<String> publicRegions) {
-
     Set<String> scheduledAccounts = ProviderUtils.getScheduledAccounts(awsProvider);
     List<Agent> newlyAddedAgents = new ArrayList<>();
-
     for (NetflixAmazonCredentials.AWSRegion region : credentials.getRegions()) {
       if (!scheduledAccounts.contains(credentials.getName())) {
         newlyAddedAgents.add(
@@ -142,9 +145,8 @@ public class ProviderHelpers {
             new LaunchConfigCachingAgent(
                 amazonClientProvider, credentials, region.getName(), objectMapper, registry));
         boolean publicImages = false;
-        if (!publicRegions.contains(region.getName())) {
+        if (publicRegions.add(region.getName())) {
           publicImages = true;
-          publicRegions.add(region.getName());
         }
         newlyAddedAgents.add(
             new ImageCachingAgent(
@@ -209,14 +211,32 @@ public class ProviderHelpers {
         }
       }
     }
+    if (reservationReportPool.isPresent() && awsProvider.getAgentScheduler() == null) {
+      newlyAddedAgents.add(
+          new ReservationReportCachingAgent(
+              registry,
+              amazonClientProvider,
+              amazonS3DataProvider,
+              credentialsRepository,
+              objectMapper,
+              reservationReportPool.get(),
+              ctx));
+    }
+    agentProviders.ifPresent(
+        providers ->
+            providers.stream()
+                .filter(it -> it.supports(AwsProvider.PROVIDER_NAME))
+                .forEach(provider -> newlyAddedAgents.addAll(provider.agents(credentials))));
     return new BuildResult(newlyAddedAgents, publicRegions);
   }
 
   public static List<Agent> buildAwsCleanupAgents(
       NetflixAmazonCredentials credentials,
+      CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
       AmazonClientProvider amazonClientProvider,
       AwsCleanupProvider awsCleanupProvider,
-      AwsConfiguration.DeployDefaults deployDefaults) {
+      AwsConfiguration.DeployDefaults deployDefaults,
+      AwsConfigurationProperties awsConfigurationProperties) {
     Set<String> scheduledAccounts = ProviderUtils.getScheduledAccounts(awsCleanupProvider);
     List<Agent> newlyAddedAgents = new ArrayList<>();
     if (!scheduledAccounts.contains(credentials.getName())) {
@@ -228,42 +248,17 @@ public class ProviderHelpers {
         }
       }
     }
-    return newlyAddedAgents;
-  }
-
-  public static void synchronizeReservationReportCachingAgentAccounts(
-      AwsProvider awsProvider, Collection<NetflixAmazonCredentials> allAccounts) {
-    ReservationReportCachingAgent reservationReportCachingAgent =
-        awsProvider.getAgents().stream()
-            .filter(agent -> agent instanceof ReservationReportCachingAgent)
-            .map(ReservationReportCachingAgent.class::cast)
-            .findFirst()
-            .orElse(null);
-    if (reservationReportCachingAgent != null) {
-      Collection<NetflixAmazonCredentials> reservationReportAccounts =
-          reservationReportCachingAgent.getAccounts();
-      List<String> oldAccountNames =
-          reservationReportAccounts.stream()
-              .map(NetflixAmazonCredentials::getName)
-              .collect(Collectors.toList());
-      List<String> newAccountNames =
-          allAccounts.stream().map(NetflixAmazonCredentials::getName).collect(Collectors.toList());
-      List<String> accountNamesToDelete =
-          oldAccountNames.stream()
-              .filter(it -> !newAccountNames.contains(it))
-              .collect(Collectors.toList());
-      List<String> accountNamesToAdd =
-          newAccountNames.stream()
-              .filter(it -> !oldAccountNames.contains(it))
-              .collect(Collectors.toList());
-      for (String name : accountNamesToDelete) {
-        reservationReportCachingAgent.getAccounts().removeIf(it -> it.getName().equals(name));
+    if (awsCleanupProvider.getAgentScheduler() != null) {
+      if (awsConfigurationProperties.getCleanup().getAlarms().getEnabled()) {
+        newlyAddedAgents.add(
+            new CleanupAlarmsAgent(
+                amazonClientProvider,
+                credentialsRepository,
+                awsConfigurationProperties.getCleanup().getAlarms().getDaysToKeep()));
       }
-      for (String name : accountNamesToAdd) {
-        Optional<NetflixAmazonCredentials> accountToAdd =
-            allAccounts.stream().filter(it -> it.getName().equals(name)).findFirst();
-        accountToAdd.ifPresent(account -> reservationReportCachingAgent.getAccounts().add(account));
-      }
+      newlyAddedAgents.add(
+          new CleanupDetachedInstancesAgent(amazonClientProvider, credentialsRepository));
     }
+    return newlyAddedAgents;
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
@@ -147,10 +147,8 @@ public class ProviderHelpers {
         newlyAddedAgents.add(
             new LaunchConfigCachingAgent(
                 amazonClientProvider, credentials, region.getName(), objectMapper, registry));
-        boolean publicImages = false;
-        if (publicRegions.add(region.getName())) {
-          publicImages = true;
-        }
+
+        // always index private images per account/region
         newlyAddedAgents.add(
             new ImageCachingAgent(
                 amazonClientProvider,
@@ -158,8 +156,23 @@ public class ProviderHelpers {
                 region.getName(),
                 objectMapper,
                 registry,
-                publicImages,
+                false,
                 dynamicConfigService));
+
+        if (!publicRegions.contains(region.getName())) {
+          // only index public images once per region (regardless of account)
+          publicRegions.add(region.getName());
+          newlyAddedAgents.add(
+              new ImageCachingAgent(
+                  amazonClientProvider,
+                  credentials,
+                  region.getName(),
+                  objectMapper,
+                  registry,
+                  true,
+                  dynamicConfigService));
+        }
+
         newlyAddedAgents.add(
             new InstanceCachingAgent(
                 amazonClientProvider, credentials, region.getName(), objectMapper, registry));

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
@@ -47,7 +47,6 @@ import com.netflix.spinnaker.clouddriver.aws.provider.agent.EddaLoadBalancerCach
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.ImageCachingAgent;
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.InstanceCachingAgent;
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.LaunchConfigCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservationReportCachingAgent;
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservedInstancesCachingAgent;
 import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3DataProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
@@ -57,7 +56,11 @@ import com.netflix.spinnaker.clouddriver.security.ProviderUtils;
 import com.netflix.spinnaker.config.AwsConfiguration;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -210,17 +213,6 @@ public class ProviderHelpers {
                   amazonClientProvider, credentials, region.getName(), objectMapper, registry));
         }
       }
-    }
-    if (reservationReportPool.isPresent() && awsProvider.getAgentScheduler() == null) {
-      newlyAddedAgents.add(
-          new ReservationReportCachingAgent(
-              registry,
-              amazonClientProvider,
-              amazonS3DataProvider,
-              credentialsRepository,
-              objectMapper,
-              reservationReportPool.get(),
-              ctx));
     }
     agentProviders.ifPresent(
         providers ->

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudMetricProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudMetricProvider.groovy
@@ -17,19 +17,14 @@
 package com.netflix.spinnaker.clouddriver.aws.provider.view
 
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.amazonaws.services.cloudwatch.model.Dimension
-import com.amazonaws.services.cloudwatch.model.DimensionFilter
-import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsRequest
-import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsResult
-import com.amazonaws.services.cloudwatch.model.ListMetricsRequest
+import com.amazonaws.services.cloudwatch.model.*
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
-import com.netflix.spinnaker.clouddriver.aws.model.AmazonMetricDatapoint
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonMetricDescriptor
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonMetricStatistics
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.model.CloudMetricProvider
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -37,15 +32,15 @@ import org.springframework.stereotype.Component
 class AmazonCloudMetricProvider implements CloudMetricProvider<AmazonMetricDescriptor> {
 
   final AmazonClientProvider amazonClientProvider
-  final AccountCredentialsProvider accountCredentialsProvider
+  final CredentialsRepository<NetflixAmazonCredentials> credentialsRepository
   final AmazonCloudProvider amazonCloudProvider
 
   @Autowired
   AmazonCloudMetricProvider(AmazonClientProvider amazonClientProvider,
-                            AccountCredentialsProvider accountCredentialsProvider,
+                            CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
                             AmazonCloudProvider amazonCloudProvider) {
     this.amazonClientProvider = amazonClientProvider
-    this.accountCredentialsProvider = accountCredentialsProvider
+    this.credentialsRepository = credentialsRepository
     this.amazonCloudProvider = amazonCloudProvider
   }
 
@@ -120,7 +115,7 @@ class AmazonCloudMetricProvider implements CloudMetricProvider<AmazonMetricDescr
   }
 
   private AmazonCloudWatch getCloudWatch(String account, String region) {
-    def credentials = accountCredentialsProvider.getCredentials(account)
+    def credentials = credentialsRepository.getOne(account)
     if (!(credentials instanceof NetflixAmazonCredentials)) {
       throw new IllegalArgumentException("Invalid credentials: ${account}:${region}")
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceProvider.groovy
@@ -20,19 +20,17 @@ import com.amazonaws.services.ec2.model.GetConsoleOutputRequest
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
+import com.netflix.spinnaker.clouddriver.aws.data.Keys
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonInstance
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.core.provider.agent.ExternalHealthProvider
 import com.netflix.spinnaker.clouddriver.model.InstanceProvider
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import com.netflix.spinnaker.clouddriver.aws.data.Keys
-import com.netflix.spinnaker.clouddriver.aws.model.AmazonInstance
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
-import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH
-import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
-import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.SERVER_GROUPS
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*
 
 @Component
 class AmazonInstanceProvider implements InstanceProvider<AmazonInstance, String> {
@@ -52,7 +50,7 @@ class AmazonInstanceProvider implements InstanceProvider<AmazonInstance, String>
   AmazonClientProvider amazonClientProvider
 
   @Autowired
-  AccountCredentialsProvider accountCredentialsProvider
+  CredentialsRepository<NetflixAmazonCredentials> credentialsRepository
 
   @Override
   AmazonInstance getInstance(String account, String region, String id) {
@@ -86,7 +84,7 @@ class AmazonInstanceProvider implements InstanceProvider<AmazonInstance, String>
   }
 
   String getConsoleOutput(String account, String region, String id) {
-    def credentials = accountCredentialsProvider.getCredentials(account)
+    def credentials = credentialsRepository.getOne(account)
     if (!(credentials instanceof NetflixAmazonCredentials)) {
       throw new IllegalArgumentException("Invalid credentials: ${account}:${region}")
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProvider.java
@@ -16,7 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.view;
 
-import static com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3StaticDataProviderConfiguration.*;
+import static com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3StaticDataProviderConfiguration.AdhocRecord;
+import static com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3StaticDataProviderConfiguration.StaticRecord;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3Object;
@@ -29,7 +30,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.model.DataProvider;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
@@ -49,7 +50,7 @@ import org.springframework.stereotype.Component;
 public class AmazonS3DataProvider implements DataProvider {
   private final ObjectMapper objectMapper;
   private final AmazonClientProvider amazonClientProvider;
-  private final AccountCredentialsRepository accountCredentialsRepository;
+  private final CredentialsRepository<NetflixAmazonCredentials> accountCredentialsRepository;
   private final AmazonS3StaticDataProviderConfiguration configuration;
 
   private final Set<String> supportedIdentifiers;
@@ -84,7 +85,7 @@ public class AmazonS3DataProvider implements DataProvider {
   public AmazonS3DataProvider(
       @Qualifier("amazonObjectMapper") ObjectMapper objectMapper,
       AmazonClientProvider amazonClientProvider,
-      AccountCredentialsRepository accountCredentialsRepository,
+      CredentialsRepository<NetflixAmazonCredentials> accountCredentialsRepository,
       AmazonS3StaticDataProviderConfiguration configuration) {
     this.objectMapper = objectMapper;
     this.amazonClientProvider = amazonClientProvider;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoader.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoader.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security;
+
+import com.amazonaws.SDKGlobalConfiguration;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.util.CollectionUtils;
+import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import com.netflix.spinnaker.credentials.definition.BasicCredentialsLoader;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsParser;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+public class AmazonBasicCredentialsLoader<
+        T extends CredentialsConfig.Account, U extends NetflixAmazonCredentials>
+    extends BasicCredentialsLoader<T, U> {
+  protected final CredentialsConfig credentialsConfig;
+  protected final DefaultAccountConfigurationProperties defaultAccountConfigurationProperties;
+  protected String defaultEnvironment;
+  protected String defaultAccountType;
+
+  public AmazonBasicCredentialsLoader(
+      CredentialsDefinitionSource<T> definitionSource,
+      CredentialsParser<T, U> parser,
+      CredentialsRepository<U> credentialsRepository,
+      CredentialsConfig credentialsConfig,
+      DefaultAccountConfigurationProperties defaultAccountConfigurationProperties) {
+    super(definitionSource, parser, credentialsRepository);
+    this.credentialsConfig = credentialsConfig;
+    this.defaultAccountConfigurationProperties = defaultAccountConfigurationProperties;
+    this.defaultEnvironment =
+        defaultAccountConfigurationProperties.getEnvironment() != null
+            ? defaultAccountConfigurationProperties.getEnvironment()
+            : defaultAccountConfigurationProperties.getEnv();
+    this.defaultAccountType =
+        defaultAccountConfigurationProperties.getAccountType() != null
+            ? defaultAccountConfigurationProperties.getAccountType()
+            : defaultAccountConfigurationProperties.getEnv();
+    if (!StringUtils.isEmpty(credentialsConfig.getAccessKeyId())) {
+      System.setProperty(
+          SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY, credentialsConfig.getAccessKeyId());
+    }
+    if (!StringUtils.isEmpty(credentialsConfig.getSecretAccessKey())) {
+      System.setProperty(
+          SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY,
+          credentialsConfig.getSecretAccessKey());
+    }
+  }
+
+  @Override
+  public void load() {
+    if (CollectionUtils.isNullOrEmpty(credentialsConfig.getAccounts())
+        && (StringUtils.isEmpty(credentialsConfig.getDefaultAssumeRole()))) {
+      credentialsConfig.setAccounts(
+          Collections.singletonList(
+              new CredentialsConfig.Account() {
+                {
+                  setName(defaultAccountConfigurationProperties.getEnv());
+                  setEnvironment(defaultEnvironment);
+                  setAccountType(defaultAccountType);
+                }
+              }));
+      if (CollectionUtils.isNullOrEmpty(credentialsConfig.getDefaultRegions())) {
+        List<Regions> regions =
+            new ArrayList<>(
+                Arrays.asList(
+                    Regions.US_EAST_1, Regions.US_WEST_1, Regions.US_WEST_2, Regions.EU_WEST_1));
+        credentialsConfig.setDefaultRegions(
+            regions.stream()
+                .map(
+                    it ->
+                        new CredentialsConfig.Region() {
+                          {
+                            setName(it.getName());
+                          }
+                        })
+                .collect(Collectors.toList()));
+      }
+    }
+    this.parse(definitionSource.getCredentialsDefinitions());
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsInitializer.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsInitializer.groovy
@@ -17,14 +17,30 @@
 package com.netflix.spinnaker.clouddriver.aws.security
 
 import com.amazonaws.auth.AWSCredentialsProvider
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
+import com.netflix.spinnaker.clouddriver.aws.security.config.AmazonCredentialsParser
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig
+import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig.Account
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsLoader
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.clouddriver.security.CredentialsInitializerSynchronizable
+import com.netflix.spinnaker.credentials.CredentialsLifecycleHandler
+import com.netflix.spinnaker.credentials.CredentialsRepository
+import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository
+import com.netflix.spinnaker.credentials.definition.AbstractCredentialsLoader
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource
+import com.netflix.spinnaker.credentials.definition.CredentialsParser
+import com.netflix.spinnaker.credentials.poller.Poller
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.DependsOn
+import org.springframework.context.annotation.Lazy
+import org.springframework.context.annotation.Primary
+
+import javax.annotation.Nullable
 
 @Configuration
 @EnableConfigurationProperties(DefaultAccountConfigurationProperties)
@@ -38,7 +54,9 @@ class AmazonCredentialsInitializer {
   }
 
   @Bean
-  Class<? extends NetflixAmazonCredentials> credentialsType(CredentialsConfig credentialsConfig) {
+  Class<? extends NetflixAmazonCredentials> credentialsType(
+    CredentialsConfig credentialsConfig
+  ) {
     if (!credentialsConfig.accounts && !credentialsConfig.defaultAssumeRole) {
       NetflixAmazonCredentials
     } else {
@@ -71,4 +89,69 @@ class AmazonCredentialsInitializer {
     amazonAccountsSynchronizer.synchronize(credentialsLoader, credentialsConfig, accountCredentialsRepository, defaultAccountConfigurationProperties, null)
   }
 
+  @Bean
+  @ConditionalOnMissingBean(
+    value = [Account.class, NetflixAmazonCredentials.class],
+    parameterizedContainer = CredentialsRepository.class
+  )
+  CredentialsParser<Account, NetflixAmazonCredentials> amazonCredentialsParser(
+    AWSCredentialsProvider awsCredentialsProvider,
+    AmazonClientProvider amazonClientProvider,
+    Class<? extends NetflixAmazonCredentials> credentialsType, CredentialsConfig credentialsConfig
+  ) {
+    new AmazonCredentialsParser<>(awsCredentialsProvider, amazonClientProvider, credentialsType, credentialsConfig)
+  }
+
+  @Bean
+  @Primary
+  @ConditionalOnMissingBean(
+    value = NetflixAmazonCredentials.class,
+    parameterizedContainer = CredentialsRepository.class
+  )
+  CredentialsRepository<NetflixAmazonCredentials> amazonCredentialsRepository(
+    @Lazy CredentialsLifecycleHandler<NetflixAmazonCredentials> eventHandler
+  ) {
+    return new MapBackedCredentialsRepository<NetflixAmazonCredentials>(AmazonCloudProvider.ID, eventHandler)
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(
+    value = NetflixAmazonCredentials.class,
+    parameterizedContainer = AbstractCredentialsLoader.class
+  )
+  AbstractCredentialsLoader<? extends NetflixAmazonCredentials> amazonCredentialsLoader(
+    CredentialsParser<Account, NetflixAmazonCredentials>  amazonCredentialsParser,
+    @Nullable CredentialsDefinitionSource<Account> amazonCredentialsSource,
+    CredentialsConfig credentialsConfig,
+    CredentialsRepository<NetflixAmazonCredentials> repository,
+    DefaultAccountConfigurationProperties defaultAccountConfigurationProperties
+  ) {
+    if (amazonCredentialsSource == null) {
+      amazonCredentialsSource = { -> credentialsConfig.getAccounts() } as CredentialsDefinitionSource
+    }
+    return new AmazonBasicCredentialsLoader<Account, NetflixAmazonCredentials>(
+      amazonCredentialsSource,
+      amazonCredentialsParser,
+      repository,
+      credentialsConfig,
+      defaultAccountConfigurationProperties
+    )
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(
+    value = Account.class,
+    parameterizedContainer = CredentialsDefinitionSource.class
+  )
+  CredentialsInitializerSynchronizable amazonCredentialsInitializerSynchronizable(
+    AbstractCredentialsLoader<? extends NetflixAmazonCredentials> amazonCredentialsLoader
+  ) {
+    final Poller<? extends NetflixAmazonCredentials> poller = new Poller<>(amazonCredentialsLoader);
+    return new CredentialsInitializerSynchronizable() {
+      @Override
+      void synchronize() {
+        poller.run()
+      }
+    }
+  }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandler.java
@@ -17,6 +17,9 @@
 
 package com.netflix.spinnaker.clouddriver.aws.security;
 
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.DescribeAccountAttributesRequest;
+import com.amazonaws.services.ec2.model.DescribeAccountAttributesResult;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.Agent;
@@ -85,6 +88,9 @@ public class AmazonCredentialsLifecycleHandler
   public void credentialsAdded(@NotNull NetflixAmazonCredentials credentials) {
     scheduleAgents(credentials);
     scheduleReservationReportCachingAgent();
+    if (reservationReportCachingAgentScheduled) {
+      addVPCOnlyAccountMapping(credentials);
+    }
   }
 
   @Override
@@ -97,6 +103,9 @@ public class AmazonCredentialsLifecycleHandler
   public void credentialsDeleted(@NotNull NetflixAmazonCredentials credentials) {
     replaceCurrentImageCachingAgent(credentials);
     unscheduleAgents(credentials);
+    if (reservationReportCachingAgentScheduled) {
+      deleteVPCOnlyAccountMapping(credentials);
+    }
   }
 
   private void replaceCurrentImageCachingAgent(NetflixAmazonCredentials credentials) {
@@ -156,6 +165,9 @@ public class AmazonCredentialsLifecycleHandler
     scheduleAWSProviderAgents(credentials);
     scheduleAwsInfrastructureProviderAgents(credentials);
     scheduleAwsCleanupAgents(credentials);
+    if (reservationReportCachingAgentScheduled) {
+      addVPCOnlyAccountMapping(credentials);
+    }
   }
 
   private void scheduleAwsInfrastructureProviderAgents(NetflixAmazonCredentials credentials) {
@@ -230,5 +242,39 @@ public class AmazonCredentialsLifecycleHandler
                   ctx)));
       reservationReportCachingAgentScheduled = true;
     }
+  }
+
+  private void addVPCOnlyAccountMapping(NetflixAmazonCredentials credentials) {
+    ReservationReportCachingAgent reservationReportCachingAgent =
+        awsProvider.getAgents().stream()
+            .filter(agent -> agent instanceof ReservationReportCachingAgent)
+            .map(agent -> (ReservationReportCachingAgent) agent)
+            .findFirst()
+            .orElse(null);
+    if (reservationReportCachingAgent != null) {
+      AmazonEC2 amazonEC2 =
+          amazonClientProvider.getAmazonEC2(credentials, credentials.getRegions().get(0).getName());
+      DescribeAccountAttributesResult describeAccountAttributesResult =
+          amazonEC2.describeAccountAttributes(
+              new DescribeAccountAttributesRequest().withAttributeNames("supported-platforms"));
+      reservationReportCachingAgent.addVPCOnlyAccounts(
+          credentials.getName(),
+          describeAccountAttributesResult
+              .getAccountAttributes()
+              .get(0)
+              .getAttributeValues()
+              .stream()
+              .allMatch(attribute -> "VPC".equals(attribute.getAttributeValue())));
+    }
+  }
+
+  private void deleteVPCOnlyAccountMapping(NetflixAmazonCredentials credentials) {
+    awsProvider.getAgents().stream()
+        .filter(agent -> agent instanceof ReservationReportCachingAgent)
+        .map(agent -> (ReservationReportCachingAgent) agent)
+        .findFirst()
+        .ifPresent(
+            reservationReportCachingAgent ->
+                reservationReportCachingAgent.deleteVPCOnlyAccounts(credentials.getName()));
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandler.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.agent.Agent;
+import com.netflix.spinnaker.cats.agent.AgentProvider;
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider;
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.aws.edda.EddaApiFactory;
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider;
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider;
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.ImageCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.config.ProviderHelpers;
+import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3DataProvider;
+import com.netflix.spinnaker.config.AwsConfiguration.DeployDefaults;
+import com.netflix.spinnaker.credentials.CredentialsLifecycleHandler;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+@Lazy
+@Slf4j
+@RequiredArgsConstructor
+public class AmazonCredentialsLifecycleHandler
+    implements CredentialsLifecycleHandler<NetflixAmazonCredentials> {
+  private final AwsCleanupProvider awsCleanupProvider;
+  private final AwsInfrastructureProvider awsInfrastructureProvider;
+  private final AwsProvider awsProvider;
+  private final AmazonCloudProvider amazonCloudProvider;
+  private final AmazonClientProvider amazonClientProvider;
+  private final AmazonS3DataProvider amazonS3DataProvider;
+
+  private final AwsConfigurationProperties awsConfigurationProperties;
+  private final ObjectMapper objectMapper;
+  private final @Qualifier("amazonObjectMapper") ObjectMapper amazonObjectMapper;
+  private final EddaApiFactory eddaApiFactory;
+  private final ApplicationContext ctx;
+  private final Registry registry;
+  private final Optional<ExecutorService> reservationReportPool;
+  private final Optional<Collection<AgentProvider>> agentProviders;
+  private final EddaTimeoutConfig eddaTimeoutConfig;
+  private final DynamicConfigService dynamicConfigService;
+  private final DeployDefaults deployDefaults;
+  private final CredentialsRepository<NetflixAmazonCredentials>
+      credentialsRepository; // Circular dependency.
+  protected Set<String> publicRegions = new HashSet<>();
+  protected Set<String> awsInfraRegions = new HashSet<>();
+
+  @Override
+  public void credentialsAdded(@NotNull NetflixAmazonCredentials credentials) {
+    scheduleAgents(credentials);
+  }
+
+  @Override
+  public void credentialsUpdated(@NotNull NetflixAmazonCredentials credentials) {
+    unscheduleAgents(credentials);
+    scheduleAgents(credentials);
+  }
+
+  @Override
+  public void credentialsDeleted(@NotNull NetflixAmazonCredentials credentials) {
+    replaceCurrentImageCachingAgent(credentials);
+    unscheduleAgents(credentials);
+  }
+
+  private void replaceCurrentImageCachingAgent(NetflixAmazonCredentials credentials) {
+    List<ImageCachingAgent> currentImageCachingAgents =
+        awsProvider.getAgents().stream()
+            .filter(
+                agent ->
+                    agent.handlesAccount(credentials.getName())
+                        && agent instanceof ImageCachingAgent
+                        && ((ImageCachingAgent) agent).getIncludePublicImages())
+            .map(agent -> (ImageCachingAgent) agent)
+            .collect(Collectors.toList());
+
+    for (ImageCachingAgent imageCachingAgent : currentImageCachingAgents) {
+      boolean found = false;
+      List<NetflixAmazonCredentials> replacementCredentials =
+          credentialsRepository.getAll().stream()
+              .filter(
+                  cred ->
+                      cred.getRegions().stream()
+                          .map(AmazonCredentials.AWSRegion::getName)
+                          .collect(Collectors.toSet())
+                          .contains(imageCachingAgent.getRegion()))
+              .collect(Collectors.toList());
+      for (NetflixAmazonCredentials creds : replacementCredentials) {
+        ImageCachingAgent nextPublicImageCahcingAgent =
+            awsProvider.getAgents().stream()
+                .filter(
+                    agent ->
+                        agent.handlesAccount(creds.getName())
+                            && agent instanceof ImageCachingAgent
+                            && !((ImageCachingAgent) agent)
+                                .getAccountName()
+                                .equals(credentials.getName()))
+                .map(agent -> (ImageCachingAgent) agent)
+                .findFirst()
+                .orElse(null);
+        if (nextPublicImageCahcingAgent != null) {
+          nextPublicImageCahcingAgent.setIncludePublicImages(true);
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        publicRegions.remove(imageCachingAgent.getRegion());
+      }
+    }
+  }
+
+  private void unscheduleAgents(NetflixAmazonCredentials credentials) {
+    awsInfrastructureProvider.removeAgentsForAccounts(Collections.singleton(credentials.getName()));
+    awsCleanupProvider.removeAgentsForAccounts(Collections.singleton(credentials.getName()));
+    awsProvider.removeAgentsForAccounts(Collections.singleton(credentials.getName()));
+  }
+
+  private void scheduleAgents(NetflixAmazonCredentials credentials) {
+    scheduleAWSProviderAgents(credentials);
+    scheduleAwsInfrastructureProviderAgents(credentials);
+    scheduleAwsCleanupAgents(credentials);
+  }
+
+  private void scheduleAwsInfrastructureProviderAgents(NetflixAmazonCredentials credentials) {
+    ProviderHelpers.BuildResult result =
+        ProviderHelpers.buildAwsInfrastructureAgents(
+            credentials,
+            awsInfrastructureProvider,
+            credentialsRepository,
+            amazonClientProvider,
+            amazonObjectMapper,
+            registry,
+            eddaTimeoutConfig,
+            this.awsInfraRegions);
+    awsInfrastructureProvider.addAgents(result.getAgents());
+    this.awsInfraRegions.addAll(result.getRegionsToAdd());
+  }
+
+  private void scheduleAWSProviderAgents(NetflixAmazonCredentials credentials) {
+    ProviderHelpers.BuildResult buildResult =
+        ProviderHelpers.buildAwsProviderAgents(
+            credentials,
+            credentialsRepository,
+            amazonClientProvider,
+            objectMapper,
+            registry,
+            eddaTimeoutConfig,
+            awsProvider,
+            amazonCloudProvider,
+            dynamicConfigService,
+            eddaApiFactory,
+            reservationReportPool,
+            agentProviders,
+            ctx,
+            amazonS3DataProvider,
+            publicRegions);
+
+    awsProvider.addAgents(buildResult.getAgents());
+    this.publicRegions.addAll(buildResult.getRegionsToAdd());
+    awsProvider.synchronizeHealthAgents();
+  }
+
+  private void scheduleAwsCleanupAgents(NetflixAmazonCredentials credentials) {
+    List<Agent> newlyAddedAgents =
+        ProviderHelpers.buildAwsCleanupAgents(
+            credentials,
+            credentialsRepository,
+            amazonClientProvider,
+            awsCleanupProvider,
+            deployDefaults,
+            awsConfigurationProperties);
+
+    awsCleanupProvider.addAgents(newlyAddedAgents);
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/AmazonCredentialsParser.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/AmazonCredentialsParser.java
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.config;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.aws.security.*;
+import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig.Account;
+import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig.Region;
+import com.netflix.spinnaker.credentials.definition.CredentialsParser;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class AmazonCredentialsParser<U extends Account, V extends NetflixAmazonCredentials>
+    implements CredentialsParser<U, V> {
+
+  private final AWSCredentialsProvider credentialsProvider;
+  private final AWSAccountInfoLookup awsAccountInfoLookup;
+  private final Map<String, String> templateValues;
+  private final CredentialTranslator<V> credentialTranslator;
+  private final ObjectMapper objectMapper;
+  private final CredentialsConfig credentialsConfig;
+  private Lazy<List<Region>> defaultRegions;
+
+  public AmazonCredentialsParser(
+      AWSCredentialsProvider credentialsProvider,
+      AmazonClientProvider amazonClientProvider,
+      Class<V> credentialsType,
+      CredentialsConfig credentialsConfig) {
+    this.credentialsProvider = Objects.requireNonNull(credentialsProvider, "credentialsProvider");
+    this.awsAccountInfoLookup =
+        new DefaultAWSAccountInfoLookup(credentialsProvider, amazonClientProvider);
+    this.templateValues = Collections.emptyMap();
+    this.objectMapper = new ObjectMapper();
+    this.credentialTranslator = findTranslator(credentialsType, this.objectMapper);
+    this.credentialsConfig = credentialsConfig;
+    this.defaultRegions = createDefaults(credentialsConfig.getDefaultRegions());
+  }
+
+  public AmazonCredentialsParser(
+      AWSCredentialsProvider credentialsProvider,
+      AWSAccountInfoLookup awsAccountInfoLookup,
+      Class<V> credentialsType,
+      CredentialsConfig credentialsConfig) {
+    this.credentialsProvider = Objects.requireNonNull(credentialsProvider, "credentialsProvider");
+    this.awsAccountInfoLookup = awsAccountInfoLookup;
+    this.templateValues = Collections.emptyMap();
+    this.objectMapper = new ObjectMapper();
+    this.credentialTranslator = findTranslator(credentialsType, this.objectMapper);
+    this.credentialsConfig = credentialsConfig;
+    this.defaultRegions = createDefaults(credentialsConfig.getDefaultRegions());
+  }
+
+  private Lazy<List<Region>> createDefaults(final List<Region> defaults) {
+    return new Lazy<>(
+        new Lazy.Loader<List<Region>>() {
+          @Override
+          public List<Region> get() {
+            if (defaults == null) {
+              return toRegion(awsAccountInfoLookup.listRegions());
+            } else {
+              List<Region> result = new ArrayList<>(defaults.size());
+              List<String> toLookup = new ArrayList<>();
+              for (Region def : defaults) {
+                if (def.getAvailabilityZones() == null || def.getAvailabilityZones().isEmpty()) {
+                  toLookup.add(def.getName());
+                } else {
+                  result.add(def);
+                }
+              }
+              if (!toLookup.isEmpty()) {
+                List<Region> resolved = toRegion(awsAccountInfoLookup.listRegions(toLookup));
+                for (Region region : resolved) {
+                  Region fromDefault = find(defaults, region.getName());
+                  if (fromDefault != null) {
+                    region.setPreferredZones(fromDefault.getPreferredZones());
+                    region.setDeprecated(fromDefault.getDeprecated());
+                  }
+                }
+                result.addAll(resolved);
+              }
+              return result;
+            }
+          }
+        });
+  }
+
+  private List<Region> initRegions(Lazy<List<Region>> defaults, List<Region> toInit) {
+    if (toInit == null) {
+      return defaults.get();
+    }
+
+    Map<String, Region> toInitByName =
+        toInit.stream().collect(Collectors.toMap(Region::getName, Function.identity()));
+
+    List<Region> result = new ArrayList<>(toInit.size());
+    List<String> toLookup = new ArrayList<>();
+    for (Region r : toInit) {
+      if (r.getAvailabilityZones() == null || r.getAvailabilityZones().isEmpty()) {
+        toLookup.add(r.getName());
+      } else {
+        result.add(r);
+      }
+    }
+
+    for (Iterator<String> lookups = toLookup.iterator(); lookups.hasNext(); ) {
+      List<Region> r = defaults.get();
+      String a = lookups.next();
+      Region fromDefault = find(r, a);
+      if (fromDefault != null) {
+        lookups.remove();
+        result.add(fromDefault);
+      }
+    }
+    if (!toLookup.isEmpty()) {
+      List<Region> resolved = toRegion(awsAccountInfoLookup.listRegions(toLookup));
+      for (Region region : resolved) {
+        Region src = find(toInit, region.getName());
+        if (src == null || src.getPreferredZones() == null) {
+          src = find(defaults.get(), region.getName());
+        }
+
+        if (src != null) {
+          region.setPreferredZones(src.getPreferredZones());
+        }
+      }
+      result.addAll(resolved);
+    }
+
+    // make a clone of all regions such that modifications apply only to this specific instance (and
+    // not global defaults)
+    result = result.stream().map(Region::copyOf).collect(Collectors.toList());
+
+    for (Region r : result) {
+      Region toInitRegion = toInitByName.get(r.getName());
+      if (toInitRegion != null && toInitRegion.getDeprecated() != null) {
+        r.setDeprecated(toInitRegion.getDeprecated());
+      }
+    }
+
+    return result;
+  }
+
+  private static Region find(List<Region> src, String name) {
+    if (src != null) {
+      for (Region r : src) {
+        if (r.getName().equals(name)) {
+          return r;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static List<Region> toRegion(List<AmazonCredentials.AWSRegion> src) {
+    List<Region> result = new ArrayList<>(src.size());
+    for (AmazonCredentials.AWSRegion r : src) {
+      Region region = new Region();
+      region.setName(r.getName());
+      region.setAvailabilityZones(new ArrayList<>(r.getAvailabilityZones()));
+      region.setPreferredZones(new ArrayList<>(r.getPreferredZones()));
+      result.add(region);
+    }
+    return result;
+  }
+
+  public List<V> load(CredentialsConfig source) throws Throwable {
+    final CredentialsConfig config = objectMapper.convertValue(source, CredentialsConfig.class);
+
+    if (config.getAccounts() == null || config.getAccounts().isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<V> initializedAccounts = new ArrayList<>(config.getAccounts().size());
+    for (Account account : config.getAccounts()) {
+      initializedAccounts.add(parseAccount(config, account));
+    }
+    return initializedAccounts.stream()
+        .filter(AmazonCredentials::isEnabled)
+        .collect(Collectors.toList());
+  }
+
+  @Nullable
+  @Override
+  public V parse(@NotNull U account) {
+    try {
+      V a = parseAccount(credentialsConfig, account);
+      if (a.isEnabled()) {
+        return a;
+      }
+    } catch (Throwable t) {
+      t.printStackTrace();
+      return null;
+    }
+    return null;
+  }
+
+  private V parseAccount(CredentialsConfig config, Account account) throws Throwable {
+    if (account.getAccountId() == null) {
+      if (!credentialTranslator.resolveAccountId()) {
+        throw new IllegalArgumentException(
+            "accountId is required and not resolvable for this credentials type");
+      }
+      account.setAccountId(awsAccountInfoLookup.findAccountId());
+    }
+
+    if (account.getEnvironment() == null) {
+      account.setEnvironment(account.getName());
+    }
+
+    if (account.getAccountType() == null) {
+      account.setAccountType(account.getName());
+    }
+
+    account.setRegions(initRegions(defaultRegions, account.getRegions()));
+    account.setDefaultSecurityGroups(
+        account.getDefaultSecurityGroups() != null
+            ? account.getDefaultSecurityGroups()
+            : config.getDefaultSecurityGroups());
+    account.setLifecycleHooks(
+        account.getLifecycleHooks() != null
+            ? account.getLifecycleHooks()
+            : config.getDefaultLifecycleHooks());
+    account.setEnabled(Optional.ofNullable(account.getEnabled()).orElse(true));
+
+    Map<String, String> templateContext = new HashMap<>(templateValues);
+    templateContext.put("name", account.getName());
+    templateContext.put("accountId", account.getAccountId());
+    templateContext.put("environment", account.getEnvironment());
+    templateContext.put("accountType", account.getAccountType());
+
+    account.setDefaultKeyPair(
+        templateFirstNonNull(
+            templateContext, account.getDefaultKeyPair(), config.getDefaultKeyPairTemplate()));
+    account.setEdda(
+        templateFirstNonNull(templateContext, account.getEdda(), config.getDefaultEddaTemplate()));
+    account.setFront50(
+        templateFirstNonNull(
+            templateContext, account.getFront50(), config.getDefaultFront50Template()));
+    account.setDiscovery(
+        templateFirstNonNull(
+            templateContext, account.getDiscovery(), config.getDefaultDiscoveryTemplate()));
+    account.setAssumeRole(
+        templateFirstNonNull(
+            templateContext, account.getAssumeRole(), config.getDefaultAssumeRole()));
+    account.setSessionName(
+        templateFirstNonNull(
+            templateContext, account.getSessionName(), config.getDefaultSessionName()));
+    account.setBastionHost(
+        templateFirstNonNull(
+            templateContext, account.getBastionHost(), config.getDefaultBastionHostTemplate()));
+
+    if (account.getLifecycleHooks() != null) {
+      for (CredentialsConfig.LifecycleHook lifecycleHook : account.getLifecycleHooks()) {
+        lifecycleHook.setRoleARN(
+            templateFirstNonNull(
+                templateContext,
+                lifecycleHook.getRoleARN(),
+                config.getDefaultLifecycleHookRoleARNTemplate()));
+        lifecycleHook.setNotificationTargetARN(
+            templateFirstNonNull(
+                templateContext,
+                lifecycleHook.getNotificationTargetARN(),
+                config.getDefaultLifecycleHookNotificationTargetARNTemplate()));
+      }
+    }
+    return credentialTranslator.translate(credentialsProvider, account);
+  }
+
+  private static class Lazy<T> {
+    public static interface Loader<T> {
+      T get();
+    }
+
+    private final Loader<T> loader;
+    private final AtomicReference<T> ref = new AtomicReference<>();
+
+    public Lazy(Loader<T> loader) {
+      this.loader = loader;
+    }
+
+    public T get() {
+      if (ref.get() == null) {
+        ref.set(loader.get());
+      }
+      return ref.get();
+    }
+  }
+
+  private static String templateFirstNonNull(Map<String, String> substitutions, String... values) {
+    for (String value : values) {
+      if (value != null) {
+        return StringTemplater.render(value, substitutions);
+      }
+    }
+    return null;
+  }
+
+  static <T extends AmazonCredentials> CredentialTranslator<T> findTranslator(
+      Class<T> credentialsType, ObjectMapper objectMapper) {
+    return new CopyConstructorTranslator<>(objectMapper, credentialsType);
+  }
+
+  static interface CredentialTranslator<T extends AmazonCredentials> {
+    Class<T> getCredentialType();
+
+    boolean resolveAccountId();
+
+    T translate(AWSCredentialsProvider credentialsProvider, Account account) throws Throwable;
+  }
+
+  static class CopyConstructorTranslator<T extends AmazonCredentials>
+      implements CredentialTranslator<T> {
+
+    private final ObjectMapper objectMapper;
+    private final Class<T> credentialType;
+    private final Constructor<T> copyConstructor;
+
+    public CopyConstructorTranslator(ObjectMapper objectMapper, Class<T> credentialType) {
+      this.objectMapper = objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+      this.credentialType = credentialType;
+      try {
+        copyConstructor =
+            credentialType.getConstructor(credentialType, AWSCredentialsProvider.class);
+      } catch (NoSuchMethodException nsme) {
+        throw new IllegalArgumentException(
+            "Class "
+                + credentialType
+                + " must supply a constructor with "
+                + credentialType
+                + ", "
+                + AWSCredentialsProvider.class
+                + " args.");
+      }
+    }
+
+    @Override
+    public Class<T> getCredentialType() {
+      return credentialType;
+    }
+
+    @Override
+    public boolean resolveAccountId() {
+      try {
+        credentialType.getMethod("getAssumeRole");
+        return false;
+      } catch (NoSuchMethodException nsme) {
+        return true;
+      }
+    }
+
+    @Override
+    public T translate(AWSCredentialsProvider credentialsProvider, Account account)
+        throws Throwable {
+      T immutableInstance = objectMapper.convertValue(account, credentialType);
+      try {
+        return copyConstructor.newInstance(immutableInstance, credentialsProvider);
+      } catch (InvocationTargetException ite) {
+        throw ite.getTargetException();
+      }
+    }
+  }
+
+  static class StringTemplater {
+    public static String render(String template, Map<String, String> substitutions) {
+      String base = template;
+      int iterations = 0;
+      boolean changed = true;
+      while (changed && iterations < 10) {
+        iterations++;
+        String previous = base;
+        for (Map.Entry<String, String> substitution : substitutions.entrySet()) {
+          base =
+              base.replaceAll(
+                  Pattern.quote("{{" + substitution.getKey() + "}}"), substitution.getValue());
+        }
+        changed = !previous.equals(base);
+      }
+      if (changed) {
+        throw new RuntimeException("too many levels of templatery");
+      }
+      return base;
+    }
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsConfig.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsConfig.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.security.config;
 
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import java.util.List;
 
@@ -62,7 +63,7 @@ public class CredentialsConfig {
       this.deprecated = deprecated;
     }
 
-    Region copyOf() {
+    public Region copyOf() {
       Region clone = new Region();
       clone.setName(getName());
       clone.setAvailabilityZones(getAvailabilityZones());
@@ -130,7 +131,7 @@ public class CredentialsConfig {
     }
   }
 
-  public static class Account {
+  public static class Account implements CredentialsDefinition {
     private String name;
     private String environment;
     private String accountType;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/config/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/config/AwsConfiguration.groovy
@@ -21,11 +21,7 @@ import com.amazonaws.retry.RetryPolicy.RetryCondition
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.cats.agent.Agent
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties
-import com.netflix.spinnaker.clouddriver.aws.agent.CleanupAlarmsAgent
-import com.netflix.spinnaker.clouddriver.aws.agent.CleanupDetachedInstancesAgent
 import com.netflix.spinnaker.clouddriver.aws.deploy.BlockDeviceConfig
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.BasicAmazonDeployHandler
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory
@@ -39,7 +35,6 @@ import com.netflix.spinnaker.clouddriver.aws.event.DefaultAfterResizeEventHandle
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonServerGroup
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider
-import com.netflix.spinnaker.clouddriver.aws.provider.config.ProviderHelpers
 import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonClusterProvider
 import com.netflix.spinnaker.clouddriver.aws.security.*
 import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig.Builder
@@ -48,8 +43,7 @@ import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactor
 import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfiguration
 import com.netflix.spinnaker.clouddriver.event.SpinnakerEvent
 import com.netflix.spinnaker.clouddriver.saga.config.SagaAutoConfiguration
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
-import com.netflix.spinnaker.clouddriver.security.ProviderUtils
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import com.netflix.spinnaker.kork.aws.AwsComponents
 import com.netflix.spinnaker.kork.aws.bastion.BastionConfig
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
@@ -61,8 +55,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.*
-
-import java.util.concurrent.ConcurrentHashMap
 
 @Configuration
 @ConditionalOnProperty('aws.enabled')
@@ -184,17 +176,19 @@ class AwsConfiguration {
   }
 
   @Bean
-  @DependsOn('netflixAmazonCredentials')
-  BasicAmazonDeployHandler basicAmazonDeployHandler(RegionScopedProviderFactory regionScopedProviderFactory,
-                                                    AccountCredentialsRepository accountCredentialsRepository,
-                                                    DeployDefaults deployDefaults,
-                                                    ScalingPolicyCopier scalingPolicyCopier,
-                                                    BlockDeviceConfig blockDeviceConfig,
-                                                    DynamicConfigService dynamicConfigService,
-                                                    AmazonServerGroupProvider amazonServerGroupProvider) {
+  @DependsOn('amazonCredentialsRepository')
+  BasicAmazonDeployHandler basicAmazonDeployHandler(
+    RegionScopedProviderFactory regionScopedProviderFactory,
+    CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
+    DeployDefaults deployDefaults,
+    ScalingPolicyCopier scalingPolicyCopier,
+    BlockDeviceConfig blockDeviceConfig,
+    DynamicConfigService dynamicConfigService,
+    AmazonServerGroupProvider amazonServerGroupProvider
+  ) {
     new BasicAmazonDeployHandler(
       regionScopedProviderFactory,
-      accountCredentialsRepository,
+      credentialsRepository,
       amazonServerGroupProvider,
       deployDefaults,
       scalingPolicyCopier,
@@ -210,48 +204,17 @@ class AwsConfiguration {
   }
 
   @Bean
-  @DependsOn('netflixAmazonCredentials')
-  AwsCleanupProvider awsOperationProvider(AwsConfigurationProperties awsConfigurationProperties,
-                                          AmazonClientProvider amazonClientProvider,
-                                          AccountCredentialsRepository accountCredentialsRepository,
-                                          DeployDefaults deployDefaults) {
-    def awsCleanupProvider = new AwsCleanupProvider()
-
-    synchronizeAwsCleanupProvider(awsConfigurationProperties, awsCleanupProvider, amazonClientProvider, accountCredentialsRepository, deployDefaults)
-
-    awsCleanupProvider
+  AwsCleanupProvider awsOperationProvider() {
+    return new AwsCleanupProvider()
   }
 
   @Bean
-  @DependsOn('netflixAmazonCredentials')
-  SecurityGroupLookupFactory securityGroupLookup(AmazonClientProvider amazonClientProvider,
-                                          AccountCredentialsRepository accountCredentialsRepository) {
-    new SecurityGroupLookupFactory(amazonClientProvider, accountCredentialsRepository)
-  }
-
-  private static void synchronizeAwsCleanupProvider(AwsConfigurationProperties awsConfigurationProperties,
-                                                    AwsCleanupProvider awsCleanupProvider,
-                                                    AmazonClientProvider amazonClientProvider,
-                                                    AccountCredentialsRepository accountCredentialsRepository,
-                                                    DeployDefaults deployDefaults) {
-    Set<NetflixAmazonCredentials> allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials, AmazonCloudProvider.ID)
-
-    List<Agent> newlyAddedAgents = []
-
-    allAccounts.each { account ->
-      List<Agent> result = ProviderHelpers.buildAwsCleanupAgents(account, amazonClientProvider, awsCleanupProvider, deployDefaults)
-      newlyAddedAgents.addAll(result)
-    }
-
-    if (!awsCleanupProvider.agentScheduler) {
-      if (awsConfigurationProperties.cleanup.alarms.enabled) {
-        awsCleanupProvider.addAgents(Collections.singletonList(
-          new CleanupAlarmsAgent(amazonClientProvider, accountCredentialsRepository, awsConfigurationProperties.cleanup.alarms.daysToKeep)))
-      }
-      awsCleanupProvider.addAgents(Collections.singletonList(
-        new CleanupDetachedInstancesAgent(amazonClientProvider, accountCredentialsRepository)))
-    }
-    awsCleanupProvider.addAgents(newlyAddedAgents)
+  @DependsOn('amazonCredentialsRepository')
+  SecurityGroupLookupFactory securityGroupLookup(
+    AmazonClientProvider amazonClientProvider,
+    CredentialsRepository<NetflixAmazonCredentials> credentialsRepository
+  ) {
+    new SecurityGroupLookupFactory(amazonClientProvider, credentialsRepository)
   }
 
   @Bean

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgentSpec.groovy
@@ -25,7 +25,7 @@ import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult
 import com.amazonaws.services.cloudwatch.model.MetricAlarm
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import org.joda.time.DateTime
 import spock.lang.Shared
 import spock.lang.Specification
@@ -40,7 +40,7 @@ class CleanupAlarmsAgentSpec extends Specification {
   AmazonCloudWatch cloudWatchUSW
   AmazonCloudWatch cloudWatchUSE
   AmazonClientProvider amazonClientProvider
-  AccountCredentialsRepository accountCredentialsRepository
+  CredentialsRepository credentialsRepository
   CleanupAlarmsAgent agent
   String validUuid = UUID.randomUUID().toString()
   String deletableAlarmName = "clouddriver-test-v123-alarm-" + validUuid
@@ -59,12 +59,12 @@ class CleanupAlarmsAgentSpec extends Specification {
       0 * _
     }
 
-    accountCredentialsRepository = Mock(AccountCredentialsRepository) {
+    credentialsRepository = Mock(CredentialsRepository) {
       1 * getAll() >> [test]
       0 * _
     }
 
-    agent = new CleanupAlarmsAgent(amazonClientProvider, accountCredentialsRepository, 10L, 10L, 90)
+    agent = new CleanupAlarmsAgent(amazonClientProvider, credentialsRepository, 10L, 10L, 90)
   }
 
   void "should run across all regions/accounts and delete in each"() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupDetachedInstancesAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupDetachedInstancesAgentSpec.groovy
@@ -17,17 +17,12 @@
 package com.netflix.spinnaker.clouddriver.aws.agent
 
 import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.DescribeInstancesRequest
-import com.amazonaws.services.ec2.model.DescribeInstancesResult
-import com.amazonaws.services.ec2.model.Instance
-import com.amazonaws.services.ec2.model.InstanceState
-import com.amazonaws.services.ec2.model.Reservation
-import com.amazonaws.services.ec2.model.Tag
-import com.amazonaws.services.ec2.model.TerminateInstancesRequest
+import com.amazonaws.services.ec2.model.*
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.DetachInstancesAtomicOperation
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -46,12 +41,10 @@ class CleanupDetachedInstancesAgentSpec extends Specification {
       1 * getAmazonEC2(test, "us-east-1", true) >> { amazonEC2USE }
       0 * _
     }
-
-    def accountCredentialsRepository = Mock(AccountCredentialsRepository) {
-      1 * getAll() >> [test]
-      0 * _
+    CredentialsRepository<NetflixAmazonCredentials> credentialsRepository = Stub(CredentialsRepository) {
+      getAll() >> [test]
     }
-    def agent = new CleanupDetachedInstancesAgent(amazonClientProvider, accountCredentialsRepository)
+    def agent = new CleanupDetachedInstancesAgent(amazonClientProvider, credentialsRepository)
 
     when:
     agent.run()

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonClusterControllerSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonClusterControllerSpec.groovy
@@ -23,6 +23,7 @@ import com.amazonaws.services.autoscaling.model.DescribeScalingActivitiesResult
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import org.springframework.http.HttpStatus
 import spock.lang.Specification
 import spock.lang.Subject
@@ -34,13 +35,14 @@ class AmazonClusterControllerSpec extends Specification {
   void "should perform real-time AWS call for auto-scaling activities"() {
     setup:
     def creds = Stub(NetflixAmazonCredentials)
-    def credsProvider = Stub(AccountCredentialsProvider)
-    credsProvider.getCredentials(account) >> creds
+    def credsProvider = Stub(CredentialsRepository) {
+      getOne(account) >> creds
+    }
     def autoScaling = Mock(AmazonAutoScaling)
     def provider = Stub(AmazonClientProvider)
     provider.getAutoScaling(creds, region) >> autoScaling
     controller.amazonClientProvider = provider
-    controller.accountCredentialsProvider = credsProvider
+    controller.credentialsRepository = credsProvider
 
     when:
     def result = controller.getScalingActivities(account, asgName, region)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
@@ -63,6 +63,7 @@ import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactor
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import spock.lang.Shared
 import spock.lang.Specification
@@ -111,8 +112,9 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
       }
     }
     def defaults = new AwsConfiguration.DeployDefaults(iamRole: 'IamRole')
-    def credsRepo = new MapBackedAccountCredentialsRepository()
-    credsRepo.save('baz', TestCredential.named('baz'))
+    def credsRepo = Stub(CredentialsRepository) {
+      getOne("baz") >> {TestCredential.named("baz")}
+    }
     this.handler = new BasicAmazonDeployHandler(
       rspf, credsRepo, amazonServerGroupProvider, defaults, scalingPolicyCopier, blockDeviceConfig, Mock(DynamicConfigService)
     ) {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperationUnitSpec.groovy
@@ -17,22 +17,14 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.CreateTagsRequest
-import com.amazonaws.services.ec2.model.DeleteTagsRequest
-import com.amazonaws.services.ec2.model.DescribeImagesRequest
-import com.amazonaws.services.ec2.model.DescribeImagesResult
-import com.amazonaws.services.ec2.model.DescribeTagsResult
-import com.amazonaws.services.ec2.model.Image
-import com.amazonaws.services.ec2.model.ModifyImageAttributeRequest
-import com.amazonaws.services.ec2.model.Tag
-import com.amazonaws.services.ec2.model.TagDescription
+import com.amazonaws.services.ec2.model.*
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AllowLaunchDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import spock.lang.Specification
 
 class AllowLaunchAtomicOperationUnitSpec extends Specification {
@@ -56,11 +48,11 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
       getAccountId() >> '67890'
     }
 
-    def creds = Stub(AccountCredentialsProvider) {
-      getCredentials('target') >> target
+    def creds = Stub(CredentialsRepository) {
+      getOne('target') >> target
     }
     def op = new AllowLaunchAtomicOperation(new AllowLaunchDescription(amiName: 'super-awesome-ami', targetAccount: 'target', credentials: source))
-    op.accountCredentialsProvider = creds
+    op.credentialsRepository = creds
     op.amazonClientProvider = provider
 
     when:
@@ -98,14 +90,14 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def description = new AllowLaunchDescription(targetAccount: "prod", amiName: "ami-123456", region: "us-west-1", credentials: testCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = provider
-    op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    op.credentialsRepository = Mock(CredentialsRepository)
 
     when:
     op.operate([])
 
     then:
-    with(op.accountCredentialsProvider){
-      1 * getCredentials("prod") >> prodCredentials
+    with(op.credentialsRepository){
+      1 * getOne("prod") >> prodCredentials
     }
     with(provider) {
       1 * getAmazonEC2(testCredentials, _, true) >> sourceAmazonEc2
@@ -129,14 +121,14 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def description = new AllowLaunchDescription(targetAccount: "prod", amiName: "ami-123456", region: "us-west-1", credentials: testCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = provider
-    op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    op.credentialsRepository = Mock(CredentialsRepository)
 
     when:
     op.operate([])
 
     then:
-    with(op.accountCredentialsProvider){
-      1 * getCredentials("prod") >> prodCredentials
+    with(op.credentialsRepository){
+      1 * getOne("prod") >> prodCredentials
     }
     with(provider) {
       1 * getAmazonEC2(testCredentials, _, true) >> sourceAmazonEc2
@@ -164,14 +156,14 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def description = new AllowLaunchDescription(targetAccount: "test", amiName: "ami-123456", region: "us-west-1", credentials: testCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = provider
-    op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    op.credentialsRepository = Mock(CredentialsRepository)
 
     when:
     op.operate([])
 
     then:
-    with(op.accountCredentialsProvider){
-      1 * getCredentials("test") >> testCredentials
+    with(op.credentialsRepository){
+      1 * getOne("test") >> testCredentials
     }
     with(provider) {
       1 * getAmazonEC2(testCredentials, _, true) >> sourceAmazonEc2
@@ -197,14 +189,14 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def description = new AllowLaunchDescription(targetAccount: 'target', amiName: 'ami-123456', region: 'us-west-1', credentials: sourceCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = Mock(AmazonClientProvider)
-    op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    op.credentialsRepository = Mock(CredentialsRepository)
 
     when:
     op.operate([])
 
     then:
-    with(op.accountCredentialsProvider) {
-      1 * getCredentials('target') >> targetCredentials
+    with(op.credentialsRepository) {
+      1 * getOne('target') >> targetCredentials
       1 * getAll() >> [sourceCredentials, targetCredentials, ownerCredentials]
     }
 
@@ -238,15 +230,15 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def description = new AllowLaunchDescription(targetAccount: 'target', amiName: 'ami-123456', region: 'us-west-1', credentials: ownerCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = Mock(AmazonClientProvider)
-    op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    op.credentialsRepository = Mock(CredentialsRepository)
 
     when:
     op.operate([])
 
     then:
 
-    with(op.accountCredentialsProvider) {
-      1 * getCredentials('target') >> targetCredentials
+    with(op.credentialsRepository) {
+      1 * getOne('target') >> targetCredentials
     }
 
     with(op.amazonClientProvider) {
@@ -275,14 +267,14 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def description = new AllowLaunchDescription(targetAccount: 'target', amiName: 'ami-123456', region: 'us-west-2', credentials: sourceCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = Mock(AmazonClientProvider)
-    op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    op.credentialsRepository = Mock(CredentialsRepository)
 
     when:
     op.operate([])
 
     then:
-    with(op.accountCredentialsProvider) {
-      1 * getCredentials('target') >> targetCredentials
+    with(op.credentialsRepository) {
+      1 * getOne('target') >> targetCredentials
     }
     with(op.amazonClientProvider) {
       1 * getAmazonEC2(targetCredentials, _, true) >> targetAmazonEc2
@@ -317,14 +309,14 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def description = new AllowLaunchDescription(targetAccount: 'target', amiName: 'ami-123456', region: 'us-west-1', credentials: ownerCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = Mock(AmazonClientProvider)
-    op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    op.credentialsRepository = Mock(CredentialsRepository)
 
     when:
     op.operate([])
 
     then:
-    with(op.accountCredentialsProvider) {
-      1 * getCredentials('target') >> targetCredentials
+    with(op.credentialsRepository) {
+      1 * getOne('target') >> targetCredentials
     }
 
     with(op.amazonClientProvider) {
@@ -359,14 +351,14 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def description = new AllowLaunchDescription(targetAccount: 'target', amiName: 'ami-123456', region: 'us-west-1', credentials: sourceCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = Mock(AmazonClientProvider)
-    op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    op.credentialsRepository = Mock(CredentialsRepository)
 
     when:
     op.operate([])
 
     then:
-    with(op.accountCredentialsProvider) {
-      1 * getCredentials('target') >> targetCredentials
+    with(op.credentialsRepository) {
+      1 * getOne('target') >> targetCredentials
       1 * getAll() >> [sourceCredentials, targetCredentials]
     }
     with(op.amazonClientProvider) {
@@ -392,15 +384,15 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def description = new AllowLaunchDescription(targetAccount: 'target', amiName: 'ami-123456', region: 'us-west-1', credentials: sourceCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = Mock(AmazonClientProvider)
-    op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    op.credentialsRepository = Mock(CredentialsRepository)
 
     when:
     op.operate([])
 
     then:
     thrown IllegalArgumentException
-    with(op.accountCredentialsProvider) {
-      1 * getCredentials('target') >> targetCredentials
+    with(op.credentialsRepository) {
+      1 * getOne('target') >> targetCredentials
       1 * getAll() >> [sourceCredentials, targetCredentials]
     }
     with(op.amazonClientProvider) {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/PrepareModifyServerGroupLaunchTemplateSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/PrepareModifyServerGroupLaunchTemplateSpec.groovy
@@ -3,14 +3,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup
 import com.amazonaws.services.autoscaling.model.LaunchTemplateSpecification
 import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.Image
-import com.amazonaws.services.ec2.model.DescribeImagesRequest
-import com.amazonaws.services.ec2.model.DescribeImagesResult
-import com.amazonaws.services.ec2.model.LaunchTemplateBlockDeviceMapping
-import com.amazonaws.services.ec2.model.LaunchTemplateEbsBlockDevice
-import com.amazonaws.services.ec2.model.LaunchTemplateInstanceNetworkInterfaceSpecification
-import com.amazonaws.services.ec2.model.LaunchTemplateVersion
-import com.amazonaws.services.ec2.model.ResponseLaunchTemplateData
+import com.amazonaws.services.ec2.model.*
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.BlockDeviceConfig
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription
@@ -19,7 +12,7 @@ import com.netflix.spinnaker.clouddriver.aws.services.AsgService
 import com.netflix.spinnaker.clouddriver.aws.services.LaunchTemplateService
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
 import com.netflix.spinnaker.clouddriver.saga.models.Saga
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -29,7 +22,7 @@ class PrepareModifyServerGroupLaunchTemplateSpec extends Specification {
   def asgService = Mock(AsgService)
   def ec2 = Mock(AmazonEC2)
   def blockDeviceConfig = Mock(BlockDeviceConfig)
-  def credentialsRepository = Mock(AccountCredentialsRepository) {
+  def credentialsRepository = Stub(MapBackedCredentialsRepository) {
     getOne(_) >> credentials
   }
 
@@ -48,9 +41,9 @@ class PrepareModifyServerGroupLaunchTemplateSpec extends Specification {
     forRegion(_, _) >> regionScopedProvider
   }
 
-
   @Subject
-  def prepareAction = new PrepareModifyServerGroupLaunchTemplate(blockDeviceConfig, credentialsRepository, regionScopedProviderFactory)
+  def prepareAction = new PrepareModifyServerGroupLaunchTemplate(
+    blockDeviceConfig, credentialsRepository, regionScopedProviderFactory)
 
   def "should prepare for launch template update"() {
     given:

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupSpec.groovy
@@ -17,18 +17,12 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup
 
 import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.AuthorizeSecurityGroupIngressRequest
-import com.amazonaws.services.ec2.model.CreateSecurityGroupRequest
-import com.amazonaws.services.ec2.model.CreateSecurityGroupResult
-import com.amazonaws.services.ec2.model.DescribeSecurityGroupsResult
-import com.amazonaws.services.ec2.model.IpPermission
-import com.amazonaws.services.ec2.model.RevokeSecurityGroupIngressRequest
-import com.amazonaws.services.ec2.model.SecurityGroup
+import com.amazonaws.services.ec2.model.*
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory.SecurityGroupUpdater
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -38,7 +32,7 @@ class SecurityGroupLookupSpec extends Specification {
   def amazonClientProvider = Stub(AmazonClientProvider) {
     getAmazonEC2(_, "us-east-1", _) >> amazonEC2
   }
-  def accountCredentialsRepository = Stub(AccountCredentialsRepository) {
+  def accountCredentialsRepository = Stub(CredentialsRepository) {
     getAll() >> [
       Stub(NetflixAmazonCredentials) {
         getName() >> "test"

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AllowLaunchDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AllowLaunchDescriptionValidatorSpec.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AllowLaunchDescription
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import spock.lang.Specification
 
 class AllowLaunchDescriptionValidatorSpec extends Specification {
@@ -42,8 +43,8 @@ class AllowLaunchDescriptionValidatorSpec extends Specification {
   void "unconfigured account is rejected"() {
     setup:
     AllowLaunchDescriptionValidator validator = new AllowLaunchDescriptionValidator()
-    def credentialsHolder = Mock(AccountCredentialsProvider)
-    validator.accountCredentialsProvider = credentialsHolder
+    def credentialsHolder = Mock(CredentialsRepository)
+    validator.credentialsRepository = credentialsHolder
     def description = new AllowLaunchDescription(targetAccount: "foo")
     def errors = Mock(ValidationErrors)
 
@@ -51,7 +52,7 @@ class AllowLaunchDescriptionValidatorSpec extends Specification {
     validator.validate([], description, errors)
 
     then:
-    1 * credentialsHolder.getAll() >> { [TestCredential.named('prod')] }
+    1 * credentialsHolder.getOne("foo") >> { null }
     1 * errors.rejectValue("targetAccount", _)
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidatorSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRep
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.BasicAmazonDeployDescription
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -36,12 +37,13 @@ class BasicAmazonDeployDescriptionValidatorSpec extends Specification {
   @Shared
   NetflixAmazonCredentials amazonCredentials = TestCredential.named(ACCOUNT_NAME)
 
+  @Shared
+  def credentialsRepository = Stub(CredentialsRepository) {
+    getOne("auto") >> {amazonCredentials}
+  }
   void setupSpec() {
     validator = new BasicAmazonDeployDescriptionValidator()
-    def credentialsRepo = new MapBackedAccountCredentialsRepository()
-    def credentialsProvider = new DefaultAccountCredentialsProvider(credentialsRepo)
-    credentialsRepo.save(ACCOUNT_NAME, amazonCredentials)
-    validator.accountCredentialsProvider = credentialsProvider
+    validator.credentialsRepository = credentialsRepository
   }
 
   void "pass validation with proper description inputs"() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerSpec.groovy
@@ -28,7 +28,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.eureka.api.Eureka
 import com.netflix.spinnaker.clouddriver.eureka.deploy.ops.AbstractEurekaSupport.DiscoveryStatus
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import retrofit.RetrofitError
 import retrofit.RetrofitError.Kind
 import retrofit.client.Response
@@ -52,7 +52,7 @@ class InstanceTerminationLifecycleWorkerSpec extends Specification {
 
   AmazonSQS amazonSQS = Mock()
   AmazonSNS amazonSNS = Mock()
-  AccountCredentialsProvider accountCredentialsProvider = Mock() {
+  CredentialsRepository credentialsRepository = Mock(CredentialsRepository) {
     getAll() >>[mgmtCredentials, testCredentials]
   }
   Provider<AwsEurekaSupport> awsEurekaSupportProvider = Mock()
@@ -70,7 +70,7 @@ class InstanceTerminationLifecycleWorkerSpec extends Specification {
   def subject = new InstanceTerminationLifecycleWorker(
     objectMapper,
     Mock(AmazonClientProvider),
-    accountCredentialsProvider,
+    credentialsRepository,
     new InstanceTerminationConfigurationProperties(
       'mgmt',
       queueARN.arn,
@@ -133,7 +133,7 @@ class InstanceTerminationLifecycleWorkerSpec extends Specification {
     subject.handleMessage(message)
 
     then:
-    1 * accountCredentialsProvider.getAll() >> [mgmtCredentials, testCredentials]
+    1 * credentialsRepository.getAll() >> [mgmtCredentials, testCredentials]
     1 * awsEurekaSupportProvider.get() >> awsEurekaSupport
     1 * awsEurekaSupport.getEureka(_, 'us-west-2') >> eureka
     1 * eureka.updateInstanceStatus('clouddriver', 'i-1234', DiscoveryStatus.OUT_OF_SERVICE.value)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgentProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgentProviderSpec.groovy
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import com.netflix.spinnaker.clouddriver.tags.EntityTagger
 import spock.lang.Specification
 import spock.lang.Subject
@@ -46,7 +46,7 @@ import spock.lang.Subject
 class LaunchFailureNotificationAgentProviderSpec extends Specification {
   def objectMapper = Mock(ObjectMapper)
   def amazonClientProvider = Mock(AmazonClientProvider)
-  def accountCredentialsProvider = Mock(AccountCredentialsProvider)
+  def credentialsRepository = Mock(CredentialsRepository)
   def serverGroupTagger = Mock(EntityTagger)
 
   def launchFailureConfigurationProperties = new LaunchFailureConfigurationProperties(
@@ -62,7 +62,7 @@ class LaunchFailureNotificationAgentProviderSpec extends Specification {
   def agentProvider = new LaunchFailureNotificationAgentProvider(
     objectMapper,
     amazonClientProvider,
-    accountCredentialsProvider,
+    credentialsRepository,
     launchFailureConfigurationProperties,
     serverGroupTagger
   )
@@ -85,14 +85,11 @@ class LaunchFailureNotificationAgentProviderSpec extends Specification {
     }
 
     when:
-    def agents = agentProvider.agents()
+    def agents = agentProvider.agents(mgmtCredentials)
 
     then:
     regions.each { String region ->
       assert agents.find { it.agentType == "mgmt/${region}/LaunchFailureNotificationAgent".toString() } != null
     }
-
-    1 * accountCredentialsProvider.getCredentials("mgmt") >> { return mgmtCredentials }
-    4 * accountCredentialsProvider.getAll() >> { return [mgmtCredentials] }
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationCleanupAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationCleanupAgentSpec.groovy
@@ -23,21 +23,21 @@ import com.amazonaws.services.autoscaling.model.DescribeScalingActivitiesResult
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.model.EntityTags
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.tags.EntityTagger
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.lang.reflect.InvocationTargetException
-import java.lang.reflect.UndeclaredThrowableException;
+import java.lang.reflect.UndeclaredThrowableException
 
 class LaunchFailureNotificationCleanupAgentSpec extends Specification {
   static final LAUNCH_FAILURE_TAG_NAME = "spinnaker_ui_alert:autoscaling:ec2_instance_launch_error"
 
   def serverGroupTagger = Mock(EntityTagger)
   def amazonAutoScaling = Mock(AmazonAutoScaling)
-  def accountCredentialsProvider = Stub(AccountCredentialsProvider) {
-    getCredentials(_) >> { String name ->
+  def credentialsRepository = Stub(CredentialsRepository) {
+    getOne(_) >> { String name ->
       TestCredential.named(name)
     }
   }
@@ -45,7 +45,7 @@ class LaunchFailureNotificationCleanupAgentSpec extends Specification {
   void "should delete launch failure notification tag if server group has no launch failures"() {
     given:
     def agent = new LaunchFailureNotificationCleanupAgent(
-      Mock(AmazonClientProvider), accountCredentialsProvider, serverGroupTagger
+      Mock(AmazonClientProvider), credentialsRepository, serverGroupTagger
     ) {
       @Override
       protected boolean hasLaunchFailures(AmazonAutoScaling amazonAutoScaling, EntityTags entityTags) {
@@ -84,7 +84,7 @@ class LaunchFailureNotificationCleanupAgentSpec extends Specification {
     given:
     def entityTags = new EntityTags(entityRef: new EntityTags.EntityRef(account: "test", entityId: "test-v002"))
     def agent = new LaunchFailureNotificationCleanupAgent(
-      Mock(AmazonClientProvider), accountCredentialsProvider, Mock(EntityTagger)
+      Mock(AmazonClientProvider), credentialsRepository, Mock(EntityTagger)
     )
 
     when:
@@ -109,7 +109,7 @@ class LaunchFailureNotificationCleanupAgentSpec extends Specification {
     given:
     def entityTags = new EntityTags(entityRef: new EntityTags.EntityRef(account: "test", entityId: "test-v002"))
     def agent = new LaunchFailureNotificationCleanupAgent(
-      Mock(AmazonClientProvider), accountCredentialsProvider, Mock(EntityTagger)
+      Mock(AmazonClientProvider), credentialsRepository, Mock(EntityTagger)
     )
 
     and:

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProviderSpec.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.provider
 
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -77,7 +77,9 @@ class AwsProviderSpec extends Specification {
 
     def eurekaAccounts = [ eurekaAccount1, eurekaAccount2 ]
 
-    def eurekaRepos = Stub(AccountCredentialsRepository) {
+    def eurekaRepos = Stub(CredentialsRepository) {
+      getOne("my-ci-account") >> eurekaAccount1
+      getOne("my-qa-account") >> eurekaAccount2
       getAll() >> eurekaAccounts
     }
 
@@ -130,7 +132,9 @@ class AwsProviderSpec extends Specification {
 
     def accounts = [ account1, account2 ]
 
-    def repos = Stub(AccountCredentialsRepository) {
+    def repos = Stub(CredentialsRepository) {
+      getOne("my-ci-account") >> account1
+      getOne("my-qa-account") >> account2
       getAll() >> accounts
     }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgentSpec.groovy
@@ -6,7 +6,7 @@ import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import org.apache.http.HttpHost
 import org.apache.http.ProtocolVersion
 import org.apache.http.client.HttpClient
@@ -28,7 +28,7 @@ class AmazonInstanceTypeCachingAgentSpec extends Specification {
       ]
     ]])
 
-  AccountCredentialsRepository repo = Stub(AccountCredentialsRepository) {
+  CredentialsRepository repo = Stub(CredentialsRepository) {
     getAll() >> [US_WEST_2_ACCT]
   }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudMetricProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudMetricProviderSpec.groovy
@@ -17,16 +17,12 @@
 package com.netflix.spinnaker.clouddriver.aws.provider.view
 
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.amazonaws.services.cloudwatch.model.Dimension
-import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsRequest
-import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsResult
-import com.amazonaws.services.cloudwatch.model.ListMetricsResult
-import com.amazonaws.services.cloudwatch.model.Metric
+import com.amazonaws.services.cloudwatch.model.*
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonMetricDescriptor
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -41,14 +37,14 @@ class AmazonCloudMetricProviderSpec extends Specification {
 
   def setup() {
     cloudWatch = Mock(AmazonCloudWatch)
-    AccountCredentialsProvider accountCredentialsProvider = Stub(AccountCredentialsProvider) {
-      getCredentials(_) >> Stub(NetflixAmazonCredentials)
+    CredentialsRepository credentialsRepository = Stub(CredentialsRepository) {
+      getOne(_) >> Stub(NetflixAmazonCredentials)
     }
     AmazonClientProvider amazonClientProvider = Stub(AmazonClientProvider) {
       getCloudWatch(_, _) >> cloudWatch
     }
     AmazonCloudProvider amazonCloudProvider = Mock(AmazonCloudProvider)
-    provider = new AmazonCloudMetricProvider(amazonClientProvider, accountCredentialsProvider, amazonCloudProvider)
+    provider = new AmazonCloudMetricProvider(amazonClientProvider, credentialsRepository, amazonCloudProvider)
   }
 
   void "getMetric returns null when none found"() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProviderSpec.groovy
@@ -20,22 +20,24 @@ import com.amazonaws.services.s3.model.S3Object
 import com.amazonaws.services.s3.model.S3ObjectInputStream
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
-import com.netflix.spinnaker.clouddriver.security.AccountCredentials
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import org.springframework.security.access.AccessDeniedException
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
-import java.util.regex.Pattern;
+import java.util.regex.Pattern
 
-import static com.netflix.spinnaker.clouddriver.model.DataProvider.IdentifierType.*
-import static com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3StaticDataProviderConfiguration.StaticRecordType.*
+import static com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3StaticDataProviderConfiguration.StaticRecordType.list
+import static com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3StaticDataProviderConfiguration.StaticRecordType.string
+import static com.netflix.spinnaker.clouddriver.model.DataProvider.IdentifierType.Adhoc
+import static com.netflix.spinnaker.clouddriver.model.DataProvider.IdentifierType.Static
 
 class AmazonS3DataProviderSpec extends Specification {
   def objectMapper = new ObjectMapper()
   def amazonClientProvider = Mock(AmazonClientProvider)
-  def accountCredentialsRepository = Mock(AccountCredentialsRepository)
+  def accountCredentialsRepository = Stub(CredentialsRepository)
   def configuration = new AmazonS3StaticDataProviderConfiguration([
     new AmazonS3StaticDataProviderConfiguration.StaticRecord("staticId", string, "accountName", "us-east-1", "bucket", "key"),
     new AmazonS3StaticDataProviderConfiguration.StaticRecord("staticListId", list, "accountName", "us-east-1", "bucket", "listKey")
@@ -60,7 +62,7 @@ class AmazonS3DataProviderSpec extends Specification {
   void setup() {
     accountCredentialsRepository.getAll() >> {
       [
-        Mock(AccountCredentials) {
+        Mock(NetflixAmazonCredentials) {
           getAccountId() >> "12345678910"
           getName() >> "accountName"
         }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProviderSpec.groovy
@@ -16,25 +16,20 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.view
 
-import com.amazonaws.services.ec2.model.IpPermission
-import com.amazonaws.services.ec2.model.IpRange
-import com.amazonaws.services.ec2.model.Ipv6Range
-import com.amazonaws.services.ec2.model.SecurityGroup
-import com.amazonaws.services.ec2.model.UserIdGroupPair
+import com.amazonaws.services.ec2.model.*
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.cache.WriteableCache
 import com.netflix.spinnaker.cats.mem.InMemoryCache
+import com.netflix.spinnaker.clouddriver.aws.cache.Keys
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonSecurityGroup
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.model.securitygroups.IpRangeRule
 import com.netflix.spinnaker.clouddriver.model.securitygroups.Rule
 import com.netflix.spinnaker.clouddriver.model.securitygroups.SecurityGroupRule
-import com.netflix.spinnaker.clouddriver.security.AccountCredentials
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import com.netflix.spinnaker.clouddriver.aws.cache.Keys
-import com.netflix.spinnaker.clouddriver.aws.model.AmazonSecurityGroup
-import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider
+import com.netflix.spinnaker.credentials.CredentialsRepository
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -57,22 +52,13 @@ class AmazonSecurityGroupProviderSpec extends Specification {
     getAccountId() >> "accountId2"
   }
 
-  def accountCredentialsProvider = new AccountCredentialsProvider() {
-
-    @Override
-    Set<? extends AccountCredentials> getAll() {
-      [credential1, credential2]
-    }
-
-    @Override
-    AccountCredentials getCredentials(String name) {
-      return null
-    }
+  def credentialsRepository = Stub(CredentialsRepository) {
+    getAll() >> [credential1, credential2]
   }
 
 
   def setup() {
-    provider = new AmazonSecurityGroupProvider(accountCredentialsProvider, cache, mapper)
+    provider = new AmazonSecurityGroupProvider(credentialsRepository, cache, mapper)
     cache.mergeAll(Keys.Namespace.SECURITY_GROUPS.ns, getAllGroups())
   }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoaderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoaderSpec.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security
+
+import com.amazonaws.SDKGlobalConfiguration
+import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig
+import com.netflix.spinnaker.credentials.CredentialsRepository
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource
+import spock.lang.Shared
+import spock.lang.Specification
+
+class AmazonBasicCredentialsLoaderSpec extends Specification{
+  @Shared
+  def credentialsConfig = new CredentialsConfig(){{
+    setAccessKeyId("accessKey")
+    setSecretAccessKey("secret")
+  }}
+  @Shared
+  def defaultAccountConfigurationProperties = new DefaultAccountConfigurationProperties()
+  @Shared
+  def credentialsRepository = Mock(CredentialsRepository) {
+    getAll() >> []
+  }
+  @Shared
+  def definitionSource = Mock(CredentialsDefinitionSource) {
+    getCredentialsDefinitions() >> []
+  }
+
+  def 'should set defaults'() {
+    def loader = new AmazonBasicCredentialsLoader<CredentialsConfig.Account, NetflixAmazonCredentials>(
+      definitionSource, null, credentialsRepository, credentialsConfig, defaultAccountConfigurationProperties
+    )
+
+    when:
+    loader.load()
+
+    then:
+    credentialsConfig.getAccounts().size() == 1
+    credentialsConfig.getDefaultRegions().size() == 4
+    System.getProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY) == "accessKey"
+    System.getProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY) == "secret"
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandlerSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandlerSpec.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.ImageCachingAgent
+import com.netflix.spinnaker.credentials.CredentialsRepository
+import spock.lang.Shared
+import spock.lang.Specification
+
+class AmazonCredentialsLifecycleHandlerSpec extends Specification {
+  @Shared
+  def awsCleanupProvider = Spy(AwsCleanupProvider) {
+    removeAgentsForAccounts(_) >> void
+  }
+  @Shared
+  def awsInfrastructureProvider = Spy(AwsInfrastructureProvider) {
+    removeAgentsForAccounts(_) >> void
+  }
+  @Shared
+  def objectMapper = Mock(ObjectMapper) {
+    enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) >> Mock(ObjectMapper)
+  }
+  @Shared
+  def credOne = TestCredential.named('one')
+  @Shared
+  def credTwo = TestCredential.named('two')
+  @Shared
+  def credentialsRepository = Mock(CredentialsRepository) {
+    getAll() >> [credOne, credTwo]
+  }
+
+
+  def 'it should replace current public image caching agent'() {
+    def imageCachingAgentOne = new ImageCachingAgent(null, credOne, "us-east-1", objectMapper, null, true, null)
+    def imageCachingAgentTwo = new ImageCachingAgent(null, credTwo, "us-east-1", objectMapper, null, false, null)
+    def awsProvider = new AwsProvider(credentialsRepository)
+    awsProvider.addAgents([imageCachingAgentOne, imageCachingAgentTwo])
+    def handler = new AmazonCredentialsLifecycleHandler(awsCleanupProvider, awsInfrastructureProvider, awsProvider,
+      null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+      credentialsRepository)
+
+    when:
+    handler.credentialsDeleted(credOne)
+
+    then:
+    imageCachingAgentTwo.includePublicImages
+  }
+
+  def 'it should remove region not used by public image caching agent'() {
+    def imageCachingAgentOne = new ImageCachingAgent(null, credOne, "us-west-2", objectMapper, null, true, null)
+    def imageCachingAgentTwo = new ImageCachingAgent(null, credTwo, "us-east-1", objectMapper, null, false, null)
+    def awsProvider = new AwsProvider(credentialsRepository)
+    awsProvider.addAgents([imageCachingAgentOne, imageCachingAgentTwo])
+    def handler = new AmazonCredentialsLifecycleHandler(awsCleanupProvider, awsInfrastructureProvider, awsProvider,
+      null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+      credentialsRepository)
+    handler.publicRegions.add("us-west-2")
+
+    when:
+    handler.credentialsDeleted(credOne)
+
+    then:
+    !handler.publicRegions.contains("us-west-2")
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/StringTemplaterSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/StringTemplaterSpec.groovy
@@ -22,7 +22,7 @@ class StringTemplaterSpec extends Specification {
 
     def 'it should work'(String template, Map<String, String> params, String expected) {
         expect:
-        CredentialsLoader.StringTemplater.render(template, params) == expected
+        AmazonCredentialsParser.StringTemplater.render(template, params) == expected
 
         where:
         template                                      | params                              || expected

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaAgentProvider.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaAgentProvider.java
@@ -24,7 +24,7 @@ import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import com.netflix.spinnaker.credentials.Credentials;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -34,17 +34,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class LambdaAgentProvider implements AgentProvider {
   private final ObjectMapper objectMapper;
-
-  private final AccountCredentialsProvider accountCredentialsProvider;
   private final AmazonClientProvider amazonClientProvider;
 
   @Autowired
-  public LambdaAgentProvider(
-      AccountCredentialsProvider accountCredentialsProvider,
-      AmazonClientProvider amazonClientProvider) {
+  public LambdaAgentProvider(AmazonClientProvider amazonClientProvider) {
     this.objectMapper = AmazonObjectMapperConfigurer.createConfigured();
-
-    this.accountCredentialsProvider = accountCredentialsProvider;
     this.amazonClientProvider = amazonClientProvider;
   }
 
@@ -54,24 +48,18 @@ public class LambdaAgentProvider implements AgentProvider {
   }
 
   @Override
-  public Collection<Agent> agents() {
+  public Collection<Agent> agents(Credentials credentials) {
     List<Agent> agents = new ArrayList<>();
-
-    accountCredentialsProvider.getAll().stream()
-        .filter(c -> c instanceof NetflixAmazonCredentials)
-        .map(c -> (NetflixAmazonCredentials) c)
-        .filter(NetflixAmazonCredentials::getLambdaEnabled)
-        .forEach(
-            credentials -> {
-              agents.add(new IamRoleCachingAgent(objectMapper, credentials, amazonClientProvider));
-
-              for (AmazonCredentials.AWSRegion region : credentials.getRegions()) {
-                agents.add(
-                    new LambdaCachingAgent(
-                        objectMapper, amazonClientProvider, credentials, region.getName()));
-              }
-            });
-
+    NetflixAmazonCredentials netflixAmazonCredentials = (NetflixAmazonCredentials) credentials;
+    if (netflixAmazonCredentials.getLambdaEnabled()) {
+      agents.add(
+          new IamRoleCachingAgent(objectMapper, netflixAmazonCredentials, amazonClientProvider));
+      for (AmazonCredentials.AWSRegion region : netflixAmazonCredentials.getRegions()) {
+        agents.add(
+            new LambdaCachingAgent(
+                objectMapper, amazonClientProvider, netflixAmazonCredentials, region.getName()));
+      }
+    }
     return agents;
   }
 }


### PR DESCRIPTION
This is the AWS implementation of `CredentialsRepository` introduced in https://github.com/spinnaker/governance/blob/master/rfc/account-management.md 
Once ECS implements its own `CredentialsRepository`, `CredentialsLoader` and `AmazonAccountSynchronizer` files and beans should be removed. 

* Keep `CredentialsLoader` and `AmazonAccountSynchronizer` due to clouddriver-ecs' dependency on them
* Replace uses or `AccountCredentialsProvider` with `CredentialsRepository`
* Update `AgentProvider` and its implementatons to take `Credentials` in agents() since agents must be generated before credentials are added to repository
* Move agent generation tasks to `AmazonCredentialsLifecycleHandler` to generate/remove agents when credentials are added/removed.

@ajordens @nimakaviani @ncknt 
