### PR TITLE
feat(titus): `upsertScalingPolicy` is now implemented as a saga for Titus

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/MonitorTitusScalingPolicy.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/MonitorTitusScalingPolicy.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.titus.deploy.actions;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.netflix.spinnaker.clouddriver.event.EventMetadata;
+import com.netflix.spinnaker.clouddriver.saga.SagaCommand;
+import com.netflix.spinnaker.clouddriver.saga.flow.SagaAction;
+import com.netflix.spinnaker.clouddriver.saga.models.Saga;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import com.netflix.spinnaker.clouddriver.titus.TitusClientProvider;
+import com.netflix.spinnaker.clouddriver.titus.client.TitusAutoscalingClient;
+import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentials;
+import com.netflix.spinnaker.clouddriver.titus.deploy.events.TitusScalingPolicyModified;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.exceptions.IntegrationException;
+import com.netflix.spinnaker.kork.exceptions.UserException;
+import com.netflix.titus.grpc.protogen.ScalingPolicyResult;
+import com.netflix.titus.grpc.protogen.ScalingPolicyStatus;
+import lombok.Builder;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MonitorTitusScalingPolicy
+    implements SagaAction<MonitorTitusScalingPolicy.MonitorTitusScalingPolicyCommand> {
+  private final AccountCredentialsProvider accountCredentialsProvider;
+  private final TitusClientProvider titusClientProvider;
+  private final RetrySupport retrySupport;
+
+  @Autowired
+  public MonitorTitusScalingPolicy(
+      AccountCredentialsProvider accountCredentialsProvider,
+      TitusClientProvider titusClientProvider,
+      RetrySupport retrySupport) {
+    this.accountCredentialsProvider = accountCredentialsProvider;
+    this.titusClientProvider = titusClientProvider;
+    this.retrySupport = retrySupport;
+  }
+
+  @NotNull
+  @Override
+  public Result apply(
+      @NotNull MonitorTitusScalingPolicy.MonitorTitusScalingPolicyCommand command,
+      @NotNull Saga saga) {
+    TitusScalingPolicyModified event = saga.getEvent(TitusScalingPolicyModified.class);
+
+    saga.log(
+        "Monitored Titus Scaling Policy %s:%s:%s (scalingPolicyId: %s",
+        event.getAccount(), event.getRegion(), event.getJobId(), event.getScalingPolicyId());
+
+    AccountCredentials accountCredentials =
+        accountCredentialsProvider.getCredentials(event.getAccount());
+
+    TitusAutoscalingClient titusClient =
+        titusClientProvider.getTitusAutoscalingClient(
+            (NetflixTitusCredentials) accountCredentials, event.getRegion());
+
+    if (titusClient == null) {
+      throw new UserException("Autoscaling is not supported for this account/region");
+    }
+
+    // make sure the new policy was applied
+    retrySupport.retry(
+        () -> {
+          ScalingPolicyResult updatedPolicy =
+              titusClient.getScalingPolicy(event.getScalingPolicyId());
+          if (updatedPolicy == null
+              || (updatedPolicy.getPolicyState().getState()
+                  != ScalingPolicyStatus.ScalingPolicyState.Applied)) {
+            throw new IntegrationException("Scaling policy updates have not been applied")
+                .setRetryable(true);
+          }
+          return true;
+        },
+        10,
+        5000,
+        false);
+
+    saga.log(
+        "Monitored Titus Scaling Policy %s:%s:%s (scalingPolicyId: %s)",
+        event.getAccount(), event.getRegion(), event.getJobId(), event.getScalingPolicyId());
+
+    return new Result();
+  }
+
+  @Builder(builderClassName = "MonitorTitusScalingPolicyCommandBuilder", toBuilder = true)
+  @JsonDeserialize(
+      builder =
+          MonitorTitusScalingPolicy.MonitorTitusScalingPolicyCommand
+              .MonitorTitusScalingPolicyCommandBuilder.class)
+  @JsonTypeName("MonitorTitusScalingPolicyCommand")
+  @Value
+  public static class MonitorTitusScalingPolicyCommand implements SagaCommand {
+    @NonFinal EventMetadata metadata;
+
+    @Override
+    public void setMetadata(EventMetadata metadata) {
+      this.metadata = metadata;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class MonitorTitusScalingPolicyCommandBuilder {}
+  }
+}

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/UpsertTitusScalingPolicy.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/UpsertTitusScalingPolicy.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.titus.deploy.actions;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.netflix.spinnaker.clouddriver.event.EventMetadata;
+import com.netflix.spinnaker.clouddriver.saga.SagaCommand;
+import com.netflix.spinnaker.clouddriver.saga.flow.SagaAction;
+import com.netflix.spinnaker.clouddriver.saga.models.Saga;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import com.netflix.spinnaker.clouddriver.titus.TitusClientProvider;
+import com.netflix.spinnaker.clouddriver.titus.client.TitusAutoscalingClient;
+import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentials;
+import com.netflix.spinnaker.clouddriver.titus.deploy.description.UpsertTitusScalingPolicyDescription;
+import com.netflix.spinnaker.clouddriver.titus.deploy.events.TitusScalingPolicyModified;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.exceptions.UserException;
+import com.netflix.titus.grpc.protogen.PutPolicyRequest;
+import com.netflix.titus.grpc.protogen.ScalingPolicy;
+import com.netflix.titus.grpc.protogen.ScalingPolicyID;
+import com.netflix.titus.grpc.protogen.UpdatePolicyRequest;
+import java.util.Collections;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UpsertTitusScalingPolicy
+    implements SagaAction<UpsertTitusScalingPolicy.UpsertTitusScalingPolicyCommand> {
+  private final AccountCredentialsProvider accountCredentialsProvider;
+  private final TitusClientProvider titusClientProvider;
+  private final RetrySupport retrySupport;
+
+  @Autowired
+  public UpsertTitusScalingPolicy(
+      AccountCredentialsProvider accountCredentialsProvider,
+      TitusClientProvider titusClientProvider,
+      RetrySupport retrySupport) {
+    this.accountCredentialsProvider = accountCredentialsProvider;
+    this.titusClientProvider = titusClientProvider;
+    this.retrySupport = retrySupport;
+  }
+
+  @NotNull
+  @Override
+  public Result apply(
+      @NotNull UpsertTitusScalingPolicy.UpsertTitusScalingPolicyCommand command,
+      @NotNull Saga saga) {
+    AccountCredentials accountCredentials =
+        accountCredentialsProvider.getCredentials(command.description.getAccount());
+
+    TitusAutoscalingClient titusClient =
+        titusClientProvider.getTitusAutoscalingClient(
+            (NetflixTitusCredentials) accountCredentials, command.description.getRegion());
+
+    if (titusClient == null) {
+      throw new UserException("Autoscaling is not supported for this account/region");
+    }
+
+    String scalingPolicyId = command.description.getScalingPolicyID();
+
+    boolean shouldCreate = scalingPolicyId == null;
+    if (shouldCreate) {
+      scalingPolicyId = createScalingPolicy(command, saga, titusClient);
+    } else {
+      scalingPolicyId = updateScalingPolicy(command, saga, titusClient);
+    }
+
+    return new Result(
+        MonitorTitusScalingPolicy.MonitorTitusScalingPolicyCommand.builder().build(),
+        Collections.singletonList(
+            TitusScalingPolicyModified.builder()
+                .account(command.description.getAccount())
+                .region(command.description.getRegion())
+                .jobId(command.description.getJobId())
+                .scalingPolicyId(scalingPolicyId)
+                .build()));
+  }
+
+  @Nonnull
+  private String createScalingPolicy(
+      @NotNull UpsertTitusScalingPolicy.UpsertTitusScalingPolicyCommand command,
+      @NotNull Saga saga,
+      TitusAutoscalingClient titusClient) {
+    saga.log(
+        "Creating Titus Scaling Policy %s:%s:%s",
+        command.description.getAccount(),
+        command.description.getRegion(),
+        command.description.getJobId());
+
+    ScalingPolicy.Builder builder = command.description.toScalingPolicyBuilder();
+
+    PutPolicyRequest.Builder requestBuilder =
+        PutPolicyRequest.newBuilder()
+            .setScalingPolicy(builder)
+            .setJobId(command.description.getJobId());
+
+    ScalingPolicyID result =
+        retrySupport.retry(
+            () -> titusClient.createScalingPolicy(requestBuilder.build()), 10, 3000, false);
+
+    saga.log(
+        "Created Titus Scaling Policy %s:%s:%s (scalingPolicyId: %s)",
+        command.description.getAccount(),
+        command.description.getRegion(),
+        command.description.getJobId(),
+        result.getId());
+
+    return result.getId();
+  }
+
+  @Nonnull
+  private String updateScalingPolicy(
+      @NotNull UpsertTitusScalingPolicy.UpsertTitusScalingPolicyCommand command,
+      @NotNull Saga saga,
+      TitusAutoscalingClient titusClient) {
+    saga.log(
+        "Updating Titus Scaling Policy %s:%s:%s (scalingPolicyId: %s)",
+        command.description.getAccount(),
+        command.description.getRegion(),
+        command.description.getJobId(),
+        command.description.getScalingPolicyID());
+
+    retrySupport.retry(
+        () -> {
+          titusClient.updateScalingPolicy(
+              UpdatePolicyRequest.newBuilder()
+                  .setScalingPolicy(command.description.toScalingPolicyBuilder().build())
+                  .setPolicyId(
+                      ScalingPolicyID.newBuilder()
+                          .setId(command.description.getScalingPolicyID())
+                          .build())
+                  .build());
+          return true;
+        },
+        10,
+        3000,
+        false);
+
+    saga.log(
+        "Updated Titus Scaling Policy %s:%s:%s (scalingPolicyId: %s)",
+        command.description.getAccount(),
+        command.description.getRegion(),
+        command.description.getJobId(),
+        command.description.getScalingPolicyID());
+
+    return command.description.getScalingPolicyID();
+  }
+
+  @Builder(builderClassName = "UpsertTitusScalingPolicyCommandBuilder", toBuilder = true)
+  @JsonDeserialize(
+      builder =
+          UpsertTitusScalingPolicy.UpsertTitusScalingPolicyCommand
+              .UpsertTitusScalingPolicyCommandBuilder.class)
+  @JsonTypeName("upsertTitusScalingPolicyCommand")
+  @Value
+  public static class UpsertTitusScalingPolicyCommand implements SagaCommand {
+    @Nonnull UpsertTitusScalingPolicyDescription description;
+
+    @NonFinal EventMetadata metadata;
+
+    @Override
+    public void setMetadata(EventMetadata metadata) {
+      this.metadata = metadata;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class UpsertTitusScalingPolicyCommandBuilder {}
+  }
+}

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/events/TitusScalingPolicyModified.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/events/TitusScalingPolicyModified.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.titus.deploy.events;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.netflix.spinnaker.clouddriver.event.EventMetadata;
+import com.netflix.spinnaker.clouddriver.saga.SagaEvent;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import org.jetbrains.annotations.NotNull;
+
+@Builder(builderClassName = "TitusScalingPolicyModifiedBuilder", toBuilder = true)
+@JsonDeserialize(builder = TitusScalingPolicyModified.TitusScalingPolicyModifiedBuilder.class)
+@JsonTypeName("titusScalingPolicyModified")
+@Value
+public class TitusScalingPolicyModified implements SagaEvent {
+  @Nonnull private final String account;
+
+  @Nonnull private final String region;
+
+  @Nonnull private final String jobId;
+
+  @Nonnull private final String scalingPolicyId;
+
+  @NonFinal private EventMetadata metadata;
+
+  @Override
+  public void setMetadata(@NotNull EventMetadata metadata) {
+    this.metadata = metadata;
+  }
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class TitusScalingPolicyModifiedBuilder {}
+}

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/UpsertTitusScalingPolicyCompletionHandler.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/UpsertTitusScalingPolicyCompletionHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.titus.deploy.handlers;
+
+import com.netflix.spinnaker.clouddriver.saga.flow.SagaCompletionHandler;
+import com.netflix.spinnaker.clouddriver.saga.models.Saga;
+import com.netflix.spinnaker.clouddriver.titus.deploy.events.TitusScalingPolicyModified;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UpsertTitusScalingPolicyCompletionHandler
+    implements SagaCompletionHandler<TitusScalingPolicyModified> {
+
+  @Nullable
+  @Override
+  public TitusScalingPolicyModified handle(@Nonnull Saga completedSaga) {
+    return completedSaga.getEvent(TitusScalingPolicyModified.class);
+  }
+}


### PR DESCRIPTION
Fairly straightforward conversion into two idempotent actions:
1) `UpsertTitusScalingPolicy` is responsible for creating or updating the scaling policy.
2) `MonitorTitusScalingPolicy` is responsible for ensuring the create/update is applied.

State between the two actions is passed via a new `TitusScalingPolicyModified` event.
