### PR TITLE
fix(lambda): Fix Lambda being created when Lambda not enabled

### DIFF
--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/exception/InvalidAccountException.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/exception/InvalidAccountException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.lambda.deploy.exception;
+
+public class InvalidAccountException extends IllegalArgumentException {
+  public InvalidAccountException(String message) {
+    super(message);
+  }
+
+  public InvalidAccountException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/AbstractLambdaAtomicOperation.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/AbstractLambdaAtomicOperation.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.lambda.deploy.description.AbstractLambdaFunctionDescription;
+import com.netflix.spinnaker.clouddriver.lambda.deploy.exception.InvalidAccountException;
 import com.netflix.spinnaker.clouddriver.lambda.provider.view.LambdaFunctionProvider;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
@@ -52,7 +53,9 @@ public abstract class AbstractLambdaAtomicOperation<T extends AbstractLambdaFunc
   AWSLambda getLambdaClient() {
     String region = getRegion();
     NetflixAmazonCredentials credentialAccount = description.getCredentials();
-
+    if (!credentialAccount.getLambdaEnabled()) {
+      throw new InvalidAccountException("AWS Lambda is not enabled for provided account. \n");
+    }
     return amazonClientProvider.getAmazonLambda(credentialAccount, region);
   }
 


### PR DESCRIPTION
When Lambda operations are performed for an account that does not have Lambda enabled, the operations are successful but Cache refreshes fail to load Lambda resources

Lambda should not allow operations to be performed when an account does not have Lambda enabled

_fix_: check whether lambda is enabled when getLambdaClient is called
