### PR TITLE
fix(helm): Semver version sorting

### DIFF
--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -33,6 +33,7 @@ dependencies {
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit-pioneer:junit-pioneer:0.3.0"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "ru.lanwen.wiremock:wiremock-junit5:1.2.0"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/IndexParser.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/IndexParser.java
@@ -23,14 +23,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 
 @Slf4j
 @Data
@@ -105,7 +103,11 @@ public class IndexParser {
   }
 
   private String findLatestVersion(List<EntryConfig> configs) {
-    return configs.stream().max(Comparator.comparing(EntryConfig::getVersion)).get().getVersion();
+    return configs.stream()
+        .map(c -> new ComparableVersion(c.getVersion()))
+        .max(ComparableVersion::compareTo)
+        .orElseGet(() -> new ComparableVersion(""))
+        .toString();
   }
 
   private IndexConfig buildIndexConfig(InputStream in) throws IOException {


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/6020 , by using existing `ComparableVersion` to compare two version strings instead of a full lexicographical comparison.