### PR TITLE
refactor(aws): Update launch template rollout flags and revert regex

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -472,7 +472,7 @@ class AutoScalingWorker {
             return true
           }
         } catch (Exception e) {
-          log.warn("Unable to verify if application is allowed in shouldSetLaunchTemplate: ${appAccountRegion}")
+          log.error("Unable to verify if application is allowed in shouldSetLaunchTemplate: ${appAccountRegion}")
           return false
         }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -466,10 +466,17 @@ class AutoScalingWorker {
 
     for (appAccountRegion in applicationAccountRegions) {
       if (appAccountRegion && appAccountRegion.contains(":")) {
-        def (app, account, regions) = appAccountRegion.split(":")
-        if (app == application && account == accountName && region in (regions as String).split(",")) {
-          return true
+        try {
+          def (app, account, regions) = appAccountRegion.split(":")
+          if (app == application && account == accountName && region in (regions as String).split(",")) {
+            return true
+          }
+        } catch (Exception e) {
+          log.warn("Unable to verify if application is allowed in shouldSetLaunchTemplate: ${appAccountRegion}")
+          return false
         }
+
+
       }
     }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -48,7 +48,6 @@ import groovy.util.logging.Slf4j
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.function.Supplier
-import java.util.regex.Pattern
 
 /**
  * A worker class dedicated to the deployment of "applications", following many of Netflix's common AWS conventions.
@@ -402,12 +401,27 @@ class AutoScalingWorker {
     // This is a comma separated list of applications to exclude
     String excludedApps = dynamicConfigService
       .getConfig(String.class, "aws.features.launch-templates.excluded-applications", "")
-    if (matchesAppAccountAndRegion(application, credentials.name, region, excludedApps.split(","))) {
-      return false
+    for (excludedApp in excludedApps.split(",")) {
+      if (excludedApp.trim() == application) {
+        return false
+      }
+    }
+
+    // This is a comma separated list of accounts to exclude
+    String excludedAccounts = dynamicConfigService.getConfig(String.class, "aws.features.launch-templates.excluded-accounts", "")
+    for (excludedAccount in excludedAccounts.split(",")) {
+      if (excludedAccount.trim() == credentials.name) {
+        return false
+      }
+    }
+
+    // Allows everything that is not excluded
+    if (dynamicConfigService.isEnabled("aws.features.launch-templates.all-applications", false)) {
+      return true
     }
 
     // Application allow list with the following format:
-    // app1:account:region1,region2,app2:account:region1
+    // app1:account:region1,app2:account:region1
     // This allows more control over what account and region pairs to enable for this deployment.
     String allowedApps = dynamicConfigService
       .getConfig(String.class, "aws.features.launch-templates.allowed-applications", "")
@@ -415,7 +429,7 @@ class AutoScalingWorker {
       return true
     }
 
-    // Final check is an allow list for account/region pairs with the following format:
+    // An allow list for account/region pairs with the following format:
     // account:region
     String allowedAccountsAndRegions = dynamicConfigService
       .getConfig(String.class, "aws.features.launch-templates.allowed-accounts-regions", "")
@@ -428,11 +442,19 @@ class AutoScalingWorker {
       }
     }
 
+    // This is a comma separated list of accounts to allow
+    String allowedAccounts = dynamicConfigService.getConfig(String.class, "aws.features.launch-templates.allowed-accounts", "")
+    for (allowedAccount in allowedAccounts.split(",")) {
+      if (allowedAccount.trim() == credentials.name) {
+        return true
+      }
+    }
+
     return false
   }
 
   /**
-   * Helper function to parse and match an array of app:account:region1,...,regex=app:account,region
+   * Helper function to parse and match an array of app:account:region1,...,app:account,region
    * to the specified application, account and region
    * Used to flag launch template feature and rollout
    */
@@ -445,14 +467,7 @@ class AutoScalingWorker {
     for (appAccountRegion in applicationAccountRegions) {
       if (appAccountRegion && appAccountRegion.contains(":")) {
         def (app, account, regions) = appAccountRegion.split(":")
-        // To avoid an ever long list of applications, a regex can be used to specify a group of apps. ex: regex=^cas
-        String regex = null
-        if (app.startsWith("regex=")) {
-          regex = ((String) app).substring(((String) app).indexOf("=") + 1)
-        }
-
-        boolean matchedApp = (regex && Pattern.matches(regex, application) || !regex && app == application)
-        if (matchedApp && account == accountName && region in (regions as String).split(",")) {
+        if (app == application && account == accountName && region in (regions as String).split(",")) {
           return true
         }
       }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorkerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorkerUnitSpec.groovy
@@ -453,9 +453,7 @@ class AutoScalingWorkerUnitSpec extends Specification {
     applicationAccountRegions           | application   | accountName | region      || matches
     "foo:test:us-east-1"                | "foo"         | "test"      | "us-east-1" || true
     "foo:test:us-east-1,us-west-2"      | "foo"         | "test"      | "eu-west-1" || false
-    "regex=^foo.*:prod:us-east-1"       | "foobar"      | "prod"      | "us-east-1" || true
-    "regex=^foo.*:prod:us-east-1"       | "foobar"      | "test"      | "us-east-1" || false
-    "regex=^cass.*:prod:us-east-1"      | "cass_l"      | "prod"      | "us-east-1" || true
+    "foo:prod:us-east-1"                | "foo"         | "test"      | "us-east-1" || false
   }
 
   static Subnet subnet(String subnetId) {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorkerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorkerUnitSpec.groovy
@@ -128,7 +128,10 @@ class AutoScalingWorkerUnitSpec extends Specification {
 
     then:
     1 * dynamicConfigService.isEnabled('aws.features.launch-templates', false) >> true
-    1 * dynamicConfigService.getConfig(String.class, "aws.features.launch-templates.excluded-applications", "") >> ""
+    1 * dynamicConfigService.isEnabled('aws.features.launch-templates.all-applications', false) >> false
+    1 * dynamicConfigService.getConfig(String.class, "aws.features.launch-templates.excluded-accounts", "") >> ""
+    0 * dynamicConfigService.getConfig(String.class, "aws.features.launch-templates.allowed-accounts", "") >> ""
+    1 * dynamicConfigService.getConfig(String.class,"aws.features.launch-templates.excluded-applications", "") >> ""
     1 * dynamicConfigService.getConfig(String.class,"aws.features.launch-templates.allowed-applications", "") >> { "myasg:foo:us-east-1" }
     1 * mockAutoScalingWorker.createAutoScalingGroup(expectedAsgName, null, { it.launchTemplateId == "id" }) >> {}
     (sequence == null ? 1 : 0) * clusterProvider.getCluster('myasg', 'test', 'myasg-stack-details') >> { null }
@@ -163,7 +166,9 @@ class AutoScalingWorkerUnitSpec extends Specification {
 
     then:
     1 * dynamicConfigService.isEnabled('aws.features.launch-templates', false) >> true
+    1 * dynamicConfigService.isEnabled("aws.features.launch-templates.all-applications", false) >> false
     1 * dynamicConfigService.getConfig(String.class, "aws.features.launch-templates.excluded-applications", "") >> ""
+    1 * dynamicConfigService.getConfig(String.class, "aws.features.launch-templates.excluded-accounts", "") >> ""
     1 * dynamicConfigService.getConfig(String.class,"aws.features.launch-templates.allowed-applications", "") >> { "myasg:foo:us-east-1" }
     1 * launchTemplateService.createLaunchTemplate(_,_,_,_) >>
       new LaunchTemplate(launchTemplateId: "id", latestVersionNumber: 0, launchTemplateName: "lt")


### PR DESCRIPTION
Updating `shouldSetLaunchTemplate` to help with account and region rollout
- `aws.features.launch-templates.allowed-accounts` to enable by account
- `aws.features.launch-templates.excluded-accounts` to exclude by accounts
- `aws.features.launch-templates.all-applications` to fully enable launch templates on everything but what lies in an exclusion list

Reverting regex support
- Application level exclusion/inclusion should be fairly narrow and transient as part of the rollout process
- For most cases excluding/allowing accounts and regions provide enough control for the rollout while keeping these properties simple 



