### PR TITLE
fix(cache/aws): Add authoritative type for on demand update

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
@@ -249,7 +249,10 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
 
     log.info("onDemand cache refresh (data: ${data}, evictions: ${evictions}, cacheResult: ${cacheResultAsJson})")
     return new OnDemandAgent.OnDemandResult(
-      sourceAgentType: getOnDemandAgentType(), cacheResult: cacheResult, evictions: evictions
+      sourceAgentType: getOnDemandAgentType(),
+      cacheResult: cacheResult,
+      evictions: evictions,
+      authoritativeTypes: types.findAll { it.authority == AgentDataType.Authority.AUTHORITATIVE }.collect { it.typeName }
     )
   }
 


### PR DESCRIPTION
This PR make sure that only authoritative data types from `ClusterCachingAgent` will gets applied during on demand cache update. 

Fixes https://github.com/spinnaker/spinnaker/issues/6122
