### PR TITLE
fix(aws): Set launch template security group ids and rollup to asg data

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.model
 
+import com.amazonaws.services.ec2.model.RequestLaunchTemplateData
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonIgnore
@@ -114,18 +115,17 @@ class AmazonServerGroup implements ServerGroup, Serializable {
     }
 
     if (launchTemplate) {
-      def ltData = launchTemplate.get("launchTemplateData")
-      def groupIds = (Set<String>) ltData["securityGroupIds"]
+      def launchTemplateData = (RequestLaunchTemplateData) launchTemplate.get("launchTemplateData")
+      def securityGroupIds = (Set<String>) launchTemplateData?.securityGroupIds ?: []
 
-      if (groupIds?.size()) {
-        securityGroups = (Set<String>) groupIds
+      if (securityGroupIds?.size()) {
+        securityGroups = (Set<String>) securityGroupIds
       }
 
-      if (!groupIds?.size()) {
-        def networkInterface = ltData["networkInterfaces"].find({ it["deviceIndex"] == 0 })
-        if (networkInterface != null) {
-          securityGroups = (Set<String>) networkInterface["groups"]
-        }
+      if (!securityGroupIds?.size()) {
+        def networkInterface = launchTemplateData?.networkInterfaces?.find({ it["deviceIndex"] == 0 })
+        def groups = networkInterface?.groups ?: []
+        securityGroups = (Set<String>) groups
       }
     }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
@@ -113,8 +113,20 @@ class AmazonServerGroup implements ServerGroup, Serializable {
       securityGroups = (Set<String>) launchConfig.securityGroups
     }
 
-    if (launchTemplate && launchTemplate.containsKey("securityGroups")) {
-      securityGroups = (Set<String>) launchConfig.securityGroups
+    if (launchTemplate) {
+      def ltData = launchTemplate.get("launchTemplateData")
+      def groupIds = (Set<String>) ltData["securityGroupIds"]
+
+      if (groupIds?.size()) {
+        securityGroups = (Set<String>) groupIds
+      }
+
+      if (!groupIds?.size()) {
+        def networkInterface = ltData["networkInterfaces"].find({ it["deviceIndex"] == 0 })
+        if (networkInterface != null) {
+          securityGroups = (Set<String>) networkInterface["groups"]
+        }
+      }
     }
 
     return securityGroups

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -234,7 +234,8 @@ public class LaunchTemplateService {
                     .withName(settings.getIamRole()))
             .withMonitoring(
                 new LaunchTemplatesMonitoringRequest()
-                    .withEnabled(settings.getInstanceMonitoring()));
+                    .withEnabled(settings.getInstanceMonitoring()))
+            .withSecurityGroupIds(settings.getSecurityGroups());
 
     setUserData(
         request,


### PR DESCRIPTION
- Security groups were only being set on launch templates within the network interfaces. This PR sets `securityGroupIds` attribute when a launch template is being created.
- ASGs with launch templates were not rolling up `securityGroups` to the `ServerGroup` model. This PR also fixes a bug that sets the ASG security groups based on `securityGroupIds`, with a fallback to the `networkInterfaces` for safety. 
