### PR TITLE
fix(titus): Add additional image attributes to Titus Server Group

### DIFF
--- a/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver-titus/clouddriver-titus.gradle
@@ -19,6 +19,7 @@ dependencies {
   implementation project(":clouddriver-eureka")
   implementation project(":clouddriver-saga")
   implementation project(":clouddriver-security")
+  implementation project(":clouddriver-docker")
 
   annotationProcessor "org.projectlombok:lombok"
   compileOnly "org.projectlombok:lombok"

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/TitusUtils.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/TitusUtils.java
@@ -51,4 +51,14 @@ public class TitusUtils {
               accountCredentials.getName()));
     }
   }
+
+  /** Get registry details for a particular Titus account. */
+  @Nonnull
+  public static String getRegistry(
+      @Nonnull AccountCredentialsProvider accountCredentialsProvider, @Nonnull String credentials) {
+    AccountCredentials accountCredentials = accountCredentialsProvider.getCredentials(credentials);
+    // Assert that AccountCredentials of NetflixTitusCredentials type
+    TitusUtils.assertTitusAccountCredentialsType(accountCredentials);
+    return (((NetflixTitusCredentials) accountCredentials).getRegistry());
+  }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/TitusUtils.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/TitusUtils.java
@@ -57,7 +57,6 @@ public class TitusUtils {
   public static String getRegistry(
       @Nonnull AccountCredentialsProvider accountCredentialsProvider, @Nonnull String credentials) {
     AccountCredentials accountCredentials = accountCredentialsProvider.getCredentials(credentials);
-    // Assert that AccountCredentials of NetflixTitusCredentials type
     TitusUtils.assertTitusAccountCredentialsType(accountCredentials);
     return (((NetflixTitusCredentials) accountCredentials).getRegistry());
   }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusClusterProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusClusterProvider.groovy
@@ -223,8 +223,12 @@ class TitusClusterProvider implements ClusterProvider<TitusCluster>, ServerGroup
       String key = DockerRegistryCacheKeys.getTaggedImageKey(registry, job.applicationName, job.version)
       Set<CacheData> images = DockerRegistryProviderUtils
         .getAllMatchingKeyPattern(cacheView, DockerRegistryCacheKeys.Namespace.TAGGED_IMAGE.getNs(), key)
-      List<Map<String, String>> allAttributes = images.collect {it.attributes }
-      if(allAttributes.size() >1) {
+      List<Map<String, String>> allAttributes = images.collect { it.attributes }
+      if (allAttributes.size() == 0 ) {
+        log.debug("Tagged image attributes not found for key: ${key}")
+        return Optional.empty()
+      }
+      if (allAttributes.size() > 1) {
         throw new TitusException("More than 1 tagged image found, Expected 1, but got ${allAttributes.size()}")
       }
       else return Optional.of(allAttributes.first())


### PR DESCRIPTION
`cats_v1_taggedImage` table now has additional bits of information around image build metadata , like `jenkins host` , `build number` etc being populated from the image registry as part of one of the caching agents. 

This change fetches these additional bits of information and attaches to `buildInfo.jenkins` in the server group response object, This should make the Titus Server group response on par with Aws Server Group response w.r.t to `buildInfo`.