### PR TITLE
fix(aws): Always index private images for an account

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
@@ -141,11 +141,8 @@ public class ProviderHelpers {
         newlyAddedAgents.add(
             new LaunchConfigCachingAgent(
                 amazonClientProvider, credentials, region.getName(), objectMapper, registry));
-        boolean publicImages = false;
-        if (!publicRegions.contains(region.getName())) {
-          publicImages = true;
-          publicRegions.add(region.getName());
-        }
+
+        // always index private images per account/region
         newlyAddedAgents.add(
             new ImageCachingAgent(
                 amazonClientProvider,
@@ -153,8 +150,23 @@ public class ProviderHelpers {
                 region.getName(),
                 objectMapper,
                 registry,
-                publicImages,
+                false,
                 dynamicConfigService));
+
+        if (!publicRegions.contains(region.getName())) {
+          // only index public images once per region (regardless of account)
+          publicRegions.add(region.getName());
+          newlyAddedAgents.add(
+              new ImageCachingAgent(
+                  amazonClientProvider,
+                  credentials,
+                  region.getName(),
+                  objectMapper,
+                  registry,
+                  true,
+                  dynamicConfigService));
+        }
+
         newlyAddedAgents.add(
             new InstanceCachingAgent(
                 amazonClientProvider, credentials, region.getName(), objectMapper, registry));


### PR DESCRIPTION
Corrects a regression from spinnaker/clouddriver#5004 where we did not consistently
index private images across all accounts.
