### PR TITLE
fix(cats-core): Consult authorative type before update

### DIFF
--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/provider/DefaultProviderCache.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/provider/DefaultProviderCache.java
@@ -145,7 +145,9 @@ public class DefaultProviderCache implements ProviderCache {
         previousSet = new HashSet<>();
       }
       if (cacheResult.getCacheResults().containsKey(type)) {
-        cacheDataType(type, sourceAgentType, cacheResult.getCacheResults().get(type));
+        if (authoritativeTypes.contains(type)) {
+          cacheDataType(type, sourceAgentType, cacheResult.getCacheResults().get(type));
+        }
         for (CacheData data : cacheResult.getCacheResults().get(type)) {
           previousSet.remove(data.getId());
         }


### PR DESCRIPTION
During my [attempt]( https://github.com/spinnaker/clouddriver/pull/5033) to fix problem when on-demand cache update is requested for `ClusterCachingAgent`, I managed to discover that a problem from the underlying update method which should affect all non-SQL provider cache.

I investigate further and found that the call to [cacheDataType](https://github.com/spinnaker/clouddriver/blob/ab7eee1aa2ea2cb30bd8e30f1277a411885caf0e/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/provider/DefaultProviderCache.java#L148), which is the method that updates the cache, is not guarded with authoritative check. This means even if we set `authoritativeTypes`, types that is not authoritative will still replace the cache.

So I added a new commit to add the authoritative check and issue that I faced is resolved, but I'm afraid this might potentially break other agents that might miss assigning authoritative value but still works as intended because there wasn't any check. Here are the places that calls `putCacheResult` and how they pass authoritative value (i.e. determine if agent will misbehave if the change went through):

- In [CachingAgent](https://github.com/spinnaker/clouddriver/blob/ab7eee1aa2ea2cb30bd8e30f1277a411885caf0e/clouddriver-api/src/main/java/com/netflix/spinnaker/cats/agent/CachingAgent.java#L138-L141), the method is called by using the previously computed authoritative value based on agent's `providedTypes`. That means that any agents that doesn't define `providedTypes` with the correct value will be affected.

- In [CatsOnDemandCacheUpdater](clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsOnDemandCacheUpdater.java), the method is called based on `OnDemandResult` returned by `handle`. That means any agents that doesn't set the correct `authoritativeTypes` value on `handle` return value will be affected.