### PR TITLE
feat(cf): update space and org services to use v3 endpoints

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
@@ -107,7 +107,8 @@ public class ServiceInstances {
   }
 
   public List<CloudFoundryService> findAllServicesByRegion(String region) {
-    return orgs.findSpaceByRegion(region)
+    return spaces
+        .findSpaceByRegion(region)
         .map(
             space -> {
               List<Resource<Service>> services =
@@ -131,7 +132,8 @@ public class ServiceInstances {
   CloudFoundryServiceInstance getOsbServiceInstanceByRegion(
       String region, String serviceInstanceName) {
     CloudFoundrySpace space =
-        orgs.findSpaceByRegion(region)
+        spaces
+            .findSpaceByRegion(region)
             .orElseThrow(() -> new CloudFoundryApiException("Cannot find region '" + region + "'"));
     return Optional.ofNullable(getOsbServiceInstance(space, serviceInstanceName))
         .orElseThrow(
@@ -166,7 +168,8 @@ public class ServiceInstances {
                 throw new CloudFoundryApiException(
                     "Cannot specify 'org > space' as any of the " + gerund + " regions");
               }
-              return orgs.findSpaceByRegion(r)
+              return spaces
+                  .findSpaceByRegion(r)
                   .orElseThrow(
                       () ->
                           new CloudFoundryApiException(
@@ -316,7 +319,8 @@ public class ServiceInstances {
   @Nullable
   public CloudFoundryServiceInstance getServiceInstance(String region, String serviceInstanceName) {
     CloudFoundrySpace space =
-        orgs.findSpaceByRegion(region)
+        spaces
+            .findSpaceByRegion(region)
             .orElseThrow(() -> new CloudFoundryApiException("Cannot find region '" + region + "'"));
     Supplier<CloudFoundryServiceInstance> si =
         () -> Optional.ofNullable(getOsbServiceInstance(space, serviceInstanceName)).orElse(null);

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/OrganizationService.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/OrganizationService.java
@@ -16,23 +16,17 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.api;
 
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Organization;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Page;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Resource;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Space;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Organization;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Pagination;
 import java.util.List;
 import retrofit.http.GET;
 import retrofit.http.Path;
 import retrofit.http.Query;
 
 public interface OrganizationService {
-  @GET("/v2/organizations")
-  Page<Organization> all(@Query("page") Integer page, @Query("q") List<String> query);
+  @GET("/v3/organizations")
+  Pagination<Organization> all(@Query("page") Integer page, @Query("names") List<String> orgNames);
 
-  @GET("/v2/organizations/{guid}")
-  Resource<Organization> findById(@Path("guid") String guid);
-
-  @GET("/v2/organizations/{guid}/spaces")
-  Page<Space> getSpaceByName(
-      @Path("guid") String guid, @Query("page") Integer page, @Query("q") List<String> query);
+  @GET("/v3/organizations/{guid}")
+  Organization findById(@Path("guid") String guid);
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/SpaceService.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/SpaceService.java
@@ -17,17 +17,22 @@
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.api;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.*;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Pagination;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Space;
 import java.util.List;
 import retrofit.http.GET;
 import retrofit.http.Path;
 import retrofit.http.Query;
 
 public interface SpaceService {
-  @GET("/v2/spaces")
-  Page<Space> all(@Query("page") Integer page, @Query("q") List<String> query);
+  @GET("/v3/spaces")
+  Pagination<Space> all(
+      @Query("page") Integer page,
+      @Query("names") List<String> names,
+      @Query("organization_guids") List<String> orgGuids);
 
-  @GET("/v2/spaces/{guid}")
-  Resource<Space> findById(@Path("guid") String guid);
+  @GET("/v3/spaces/{guid}")
+  Space findById(@Path("guid") String guid);
 
   @GET("/v2/spaces/{guid}/service_instances")
   Page<ServiceInstance> getServiceInstancesById(

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/Organization.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/Organization.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3;
+
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class Organization {
+  private String name;
+  private String guid;
+  private Map<String, Link> links;
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/Space.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/Space.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3;
+
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class Space {
+  private String guid;
+  private String name;
+  private Map<String, ToOneRelationship> relationships;
+  private Map<String, Link> links;
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractCloudFoundryAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractCloudFoundryAtomicOperationConverter.java
@@ -27,7 +27,7 @@ public abstract class AbstractCloudFoundryAtomicOperationConverter
     extends AbstractAtomicOperationsCredentialsConverter<CloudFoundryCredentials> {
 
   protected Optional<CloudFoundrySpace> findSpace(String region, CloudFoundryClient client) {
-    return client.getOrganizations().findSpaceByRegion(region);
+    return client.getSpaces().findSpaceByRegion(region);
   }
 
   protected CloudFoundryClient getClient(Map<?, ?> input) {

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryLoadBalancerCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryLoadBalancerCachingAgent.java
@@ -170,7 +170,7 @@ public class CloudFoundryLoadBalancerCachingAgent extends AbstractCloudFoundryCa
       return null;
     }
 
-    CloudFoundrySpace space = getClient().getOrganizations().findSpaceByRegion(region).orElse(null);
+    CloudFoundrySpace space = getClient().getSpaces().findSpaceByRegion(region).orElse(null);
     if (space == null) {
       return null;
     }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
@@ -149,8 +149,7 @@ public class CloudFoundryServerGroupCachingAgent extends AbstractCloudFoundryCac
       return null;
     }
 
-    CloudFoundrySpace space =
-        this.getClient().getOrganizations().findSpaceByRegion(region).orElse(null);
+    CloudFoundrySpace space = this.getClient().getSpaces().findSpaceByRegion(region).orElse(null);
     if (space == null) {
       return null;
     }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundrySpaceCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundrySpaceCachingAgent.java
@@ -64,7 +64,7 @@ public class CloudFoundrySpaceCachingAgent extends AbstractCloudFoundryCachingAg
     String accountName = getAccountName();
     log.info("Caching all spaces in Cloud Foundry account " + accountName);
 
-    List<CloudFoundrySpace> spaces = getCredentials().getSpacesLive();
+    List<CloudFoundrySpace> spaces = this.getClient().getSpaces().all();
 
     Map<String, Collection<CacheData>> results =
         ImmutableMap.of(

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/OrganizationsTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/OrganizationsTest.java
@@ -1,19 +1,15 @@
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.api.OrganizationService;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Organization;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Page;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Resource;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Space;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Organization;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Pagination;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryOrganization;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -24,59 +20,27 @@ class OrganizationsTest {
     OrganizationService organizationService = mock(OrganizationService.class);
     organizations = new Organizations(organizationService);
     when(organizationService.all(any(), any())).thenReturn(generateOrganizationPage());
-    when(organizationService.getSpaceByName(anyString(), any(), any()))
-        .thenReturn(generateSpacePage());
   }
 
   @Test
-  void findSpaceByRegionSucceedsWhenSpaceExistsInOrg() {
+  void findByNameSucceedsWhenOrgExists() {
     CloudFoundryOrganization expectedOrganization =
         CloudFoundryOrganization.builder().id("org-guid").name("org").build();
-    CloudFoundrySpace expectedSpace =
-        CloudFoundrySpace.builder()
-            .id("space-guid")
-            .name("space")
-            .organization(expectedOrganization)
-            .build();
 
-    Optional<CloudFoundrySpace> result = organizations.findSpaceByRegion("org > space");
+    Optional<CloudFoundryOrganization> result = organizations.findByName("org");
 
-    assertThat(result).isEqualTo(Optional.of(expectedSpace));
+    assertThat(result).isEqualTo(Optional.of(expectedOrganization));
   }
 
-  @Test
-  void findSpaceByRegionThrowsExceptionForOrgSpaceNameCaseMismatch() {
-    try {
-      organizations.findSpaceByRegion("org > sPaCe");
-      failBecauseExceptionWasNotThrown(CloudFoundryApiException.class);
-    } catch (Throwable t) {
-      assertThat(t).isInstanceOf(CloudFoundryApiException.class);
-    }
-  }
-
-  private Page<Organization> generateOrganizationPage() {
-    Organization organization = new Organization().setName("org");
-    Resource.Metadata metadata = new Resource.Metadata().setGuid("org-guid");
-    Resource<Organization> resource = new Resource<>();
-    resource.setEntity(organization);
-    resource.setMetadata(metadata);
-    Page<Organization> page = new Page<>();
-    page.setTotalResults(1);
-    page.setTotalPages(1);
-    page.setResources(Collections.singletonList(resource));
-    return page;
-  }
-
-  private Page<Space> generateSpacePage() {
-    Space space = new Space().setName("space");
-    Resource.Metadata metadata = new Resource.Metadata().setGuid("space-guid");
-    Resource<Space> resource = new Resource<>();
-    resource.setEntity(space);
-    resource.setMetadata(metadata);
-    Page<Space> page = new Page<>();
-    page.setTotalResults(1);
-    page.setTotalPages(1);
-    page.setResources(Collections.singletonList(resource));
-    return page;
+  private Pagination<Organization> generateOrganizationPage() {
+    Organization organization = new Organization();
+    organization.setGuid("org-guid");
+    organization.setName("org");
+    Pagination.Details details = new Pagination.Details();
+    details.setTotalPages(1);
+    Pagination<Organization> pagination = new Pagination<>();
+    pagination.setPagination(details);
+    pagination.setResources(List.of(organization));
+    return pagination;
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstancesTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstancesTest.java
@@ -459,7 +459,7 @@ class ServiceInstancesTest {
   void
       vetShareServiceArgumentsAndGetSharingRegionIdsShouldThrowExceptionWhenServiceSharingShareToSpaceIsTheSourceSpace() {
     when(orgs.findByName(any())).thenReturn(Optional.ofNullable(cloudFoundryOrganization));
-    when(orgs.findSpaceByRegion(any())).thenReturn(Optional.of(cloudFoundrySpace));
+    when(spaces.findSpaceByRegion(any())).thenReturn(Optional.of(cloudFoundrySpace));
     when(configService.getConfigFeatureFlags())
         .thenReturn(
             singleton(new ConfigFeatureFlag().setName(SERVICE_INSTANCE_SHARING).setEnabled(true)));
@@ -478,7 +478,7 @@ class ServiceInstancesTest {
   void
       getOsbCloudFoundryServiceInstanceShouldThrowExceptionWhenServiceSharingServiceInstanceDoesNotExist() {
     when(orgs.findByName(any())).thenReturn(Optional.ofNullable(cloudFoundryOrganization));
-    when(orgs.findSpaceByRegion(any())).thenReturn(Optional.of(cloudFoundrySpace));
+    when(spaces.findSpaceByRegion(any())).thenReturn(Optional.of(cloudFoundrySpace));
     when(serviceInstanceService.all(any(), any())).thenReturn(createEmptyOsbServiceInstancePage());
 
     assertThrows(
@@ -491,7 +491,7 @@ class ServiceInstancesTest {
   @Test
   void getOsbCloudFoundryServiceInstanceShouldThrowExceptionWhenServiceSharingSpaceDoesNotExist() {
     when(orgs.findByName(any())).thenReturn(Optional.ofNullable(cloudFoundryOrganization));
-    when(orgs.findSpaceByRegion(any())).thenReturn(Optional.empty());
+    when(spaces.findSpaceByRegion(any())).thenReturn(Optional.empty());
     when(serviceInstanceService.all(any(), any())).thenReturn(createEmptyOsbServiceInstancePage());
 
     assertThrows(
@@ -561,7 +561,7 @@ class ServiceInstancesTest {
   @Test
   void checkServiceShareableShouldThrowExceptionWhenManagedServiceDoesNotSupportSharing() {
     when(orgs.findByName(any())).thenReturn(Optional.ofNullable(cloudFoundryOrganization));
-    when(orgs.findSpaceByRegion(any())).thenReturn(Optional.of(cloudFoundrySpace));
+    when(spaces.findSpaceByRegion(any())).thenReturn(Optional.of(cloudFoundrySpace));
     when(configService.getConfigFeatureFlags())
         .thenReturn(
             singleton(new ConfigFeatureFlag().setName(SERVICE_INSTANCE_SHARING).setEnabled(true)));
@@ -598,7 +598,7 @@ class ServiceInstancesTest {
             .build();
 
     when(orgs.findByName(any())).thenReturn(Optional.ofNullable(cloudFoundryOrganization));
-    when(orgs.findSpaceByRegion(any()))
+    when(spaces.findSpaceByRegion(any()))
         .thenReturn(Optional.of(space1))
         .thenReturn(Optional.of(space2))
         .thenReturn(Optional.of(cloudFoundrySpace));
@@ -652,7 +652,7 @@ class ServiceInstancesTest {
             .build();
 
     when(orgs.findByName(any())).thenReturn(Optional.ofNullable(cloudFoundryOrganization));
-    when(orgs.findSpaceByRegion(any()))
+    when(spaces.findSpaceByRegion(any()))
         .thenReturn(Optional.of(space1))
         .thenReturn(Optional.of(space2))
         .thenReturn(Optional.of(cloudFoundrySpace));
@@ -721,7 +721,7 @@ class ServiceInstancesTest {
             .build();
 
     when(orgs.findByName(any())).thenReturn(Optional.ofNullable(cloudFoundryOrganization));
-    when(orgs.findSpaceByRegion(any()))
+    when(spaces.findSpaceByRegion(any()))
         .thenReturn(Optional.of(space1))
         .thenReturn(Optional.of(space2))
         .thenReturn(Optional.of(cloudFoundrySpace));
@@ -783,7 +783,7 @@ class ServiceInstancesTest {
   void
       vetUnshareServiceArgumentsAndGetSharingRegionIdsShouldThrowExceptionWhenServiceSharingRegionDoesNotExist() {
     when(orgs.findByName(any())).thenReturn(Optional.ofNullable(cloudFoundryOrganization));
-    when(orgs.findSpaceByRegion(any())).thenReturn(Optional.empty());
+    when(spaces.findSpaceByRegion(any())).thenReturn(Optional.empty());
 
     assertThrows(
         () ->
@@ -797,7 +797,7 @@ class ServiceInstancesTest {
   void
       vetUnshareServiceArgumentsAndGetSharingRegionIdsShouldThrowExceptionWhenServiceSharingShareToSpaceDoesNotExist() {
     when(orgs.findByName(any())).thenReturn(Optional.ofNullable(cloudFoundryOrganization));
-    when(orgs.findSpaceByRegion(any())).thenReturn(Optional.empty());
+    when(spaces.findSpaceByRegion(any())).thenReturn(Optional.empty());
     when(configService.getConfigFeatureFlags())
         .thenReturn(
             singleton(new ConfigFeatureFlag().setName(SERVICE_INSTANCE_SHARING).setEnabled(true)));
@@ -835,7 +835,7 @@ class ServiceInstancesTest {
             .build();
 
     when(orgs.findByName(any())).thenReturn(Optional.ofNullable(cloudFoundryOrganization));
-    when(orgs.findSpaceByRegion(any()))
+    when(spaces.findSpaceByRegion(any()))
         .thenReturn(Optional.of(space0))
         .thenReturn(Optional.of(space1))
         .thenReturn(Optional.of(space2));
@@ -880,7 +880,7 @@ class ServiceInstancesTest {
   @Test
   void getServiceInstanceShouldThrowAnExceptionWhenTheRegionCannotBeFound() {
     when(orgs.findByName(any())).thenReturn(Optional.ofNullable(cloudFoundryOrganization));
-    when(orgs.findSpaceByRegion(any())).thenReturn(Optional.empty());
+    when(spaces.findSpaceByRegion(any())).thenReturn(Optional.empty());
 
     assertThrows(
         () -> serviceInstances.getServiceInstance("org > space", "service-instance-name"),
@@ -891,7 +891,7 @@ class ServiceInstancesTest {
   @Test
   void getServiceInstanceShouldReturnCloudFoundryOsbServiceInstance() {
     when(orgs.findByName(any())).thenReturn(Optional.ofNullable(cloudFoundryOrganization));
-    when(orgs.findSpaceByRegion(any())).thenReturn(Optional.of(cloudFoundrySpace));
+    when(spaces.findSpaceByRegion(any())).thenReturn(Optional.of(cloudFoundrySpace));
 
     when(serviceInstanceService.all(any(), any())).thenReturn(createOsbServiceInstancePage());
 
@@ -912,7 +912,7 @@ class ServiceInstancesTest {
   @Test
   void getServiceInstanceShouldReturnCloudFoundryUserProvidedServiceInstance() {
     when(orgs.findByName(any())).thenReturn(Optional.ofNullable(cloudFoundryOrganization));
-    when(orgs.findSpaceByRegion(any())).thenReturn(Optional.of(cloudFoundrySpace));
+    when(spaces.findSpaceByRegion(any())).thenReturn(Optional.of(cloudFoundrySpace));
 
     when(serviceInstanceService.all(any(), any())).thenReturn(createEmptyOsbServiceInstancePage());
     when(serviceInstanceService.allUserProvided(any(), any()))

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/SpacesTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/SpacesTest.java
@@ -1,14 +1,20 @@
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.api.SpaceService;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.*;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Pagination;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Space;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryOrganization;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryServiceInstance;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
 import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class SpacesTest {
@@ -48,5 +54,50 @@ class SpacesTest {
         spaces.getServiceInstanceByNameAndSpace(serviceInstanceName1, cloudFoundrySpace);
 
     assertThat(actual).isNull();
+  }
+
+  @Test
+  void findSpaceByRegionSucceedsWhenSpaceExistsInOrg() {
+    CloudFoundryOrganization expectedOrganization =
+        CloudFoundryOrganization.builder().id("org-guid").name("org").build();
+
+    Space space = new Space();
+    space.setName("space");
+    space.setGuid("space-guid");
+
+    CloudFoundrySpace expectedSpace =
+        CloudFoundrySpace.builder()
+            .id("space-guid")
+            .name("space")
+            .organization(expectedOrganization)
+            .build();
+
+    when(spaceService.all(any(), any(), any())).thenReturn(generateSpacePage());
+    when(orgs.findByName(anyString())).thenReturn(Optional.of(expectedOrganization));
+    Optional<CloudFoundrySpace> result = spaces.findSpaceByRegion("org > space");
+
+    assertThat(result).isEqualTo(Optional.of(expectedSpace));
+  }
+
+  @Test
+  void findSpaceByRegionThrowsExceptionForOrgSpaceNameCaseMismatch() {
+    try {
+      spaces.findSpaceByRegion("org > sPaCe");
+      failBecauseExceptionWasNotThrown(CloudFoundryApiException.class);
+    } catch (Throwable t) {
+      assertThat(t).isInstanceOf(CloudFoundryApiException.class);
+    }
+  }
+
+  private Pagination<Space> generateSpacePage() {
+    Space space = new Space();
+    space.setGuid("space-guid");
+    space.setName("space");
+    Pagination.Details details = new Pagination.Details();
+    details.setTotalPages(1);
+    Pagination<Space> pagination = new Pagination<>();
+    pagination.setPagination(details);
+    pagination.setResources(List.of(space));
+    return pagination;
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractCloudFoundryAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractCloudFoundryAtomicOperationConverterTest.java
@@ -41,7 +41,7 @@ class AbstractCloudFoundryAtomicOperationConverterTest {
 
   @Test
   void expectFindSpaceSucceeds() {
-    when(cloudFoundryClient.getOrganizations().findSpaceByRegion(any()))
+    when(cloudFoundryClient.getSpaces().findSpaceByRegion(any()))
         .thenAnswer(
             (Answer<Optional<CloudFoundrySpace>>)
                 invocation ->

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -62,7 +62,7 @@ class AbstractCloudFoundryServerGroupAtomicOperationConverterTest {
 
   @Test
   void getServerGroupIdSuccess() {
-    when(cloudFoundryClient.getOrganizations().findSpaceByRegion(any()))
+    when(cloudFoundryClient.getSpaces().findSpaceByRegion(any()))
         .thenReturn(Optional.of(CloudFoundrySpace.builder().build()));
     assertThat(converter.getServerGroupId("server", "region > space", cloudFoundryClient))
         .isEqualTo("servergroup-id");
@@ -70,7 +70,7 @@ class AbstractCloudFoundryServerGroupAtomicOperationConverterTest {
 
   @Test
   void getServerGroupIdFindFails() {
-    when(cloudFoundryClient.getOrganizations().findSpaceByRegion(any()))
+    when(cloudFoundryClient.getSpaces().findSpaceByRegion(any()))
         .thenReturn(Optional.of(CloudFoundrySpace.builder().build()));
     assertThat(
             converter.getServerGroupId(
@@ -80,8 +80,7 @@ class AbstractCloudFoundryServerGroupAtomicOperationConverterTest {
 
   @Test
   void getServerGroupIdSpaceInvalid() {
-    when(cloudFoundryClient.getOrganizations().findSpaceByRegion(any()))
-        .thenReturn(Optional.empty());
+    when(cloudFoundryClient.getSpaces().findSpaceByRegion(any())).thenReturn(Optional.empty());
     assertThat(converter.getServerGroupId("server", "region > region", cloudFoundryClient))
         .isNull();
   }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractLoadBalancersAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractLoadBalancersAtomicOperationConverterTest.java
@@ -62,7 +62,7 @@ class AbstractLoadBalancersAtomicOperationConverterTest {
                           .build());
                 });
 
-    when(cloudFoundryClient.getOrganizations().findSpaceByRegion(any()))
+    when(cloudFoundryClient.getSpaces().findSpaceByRegion(any()))
         .thenReturn(Optional.of(CloudFoundrySpace.builder().build()));
 
     when(cloudFoundryClient.getRoutes().toRouteId(any()))

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/CreateCloudFoundryServiceKeyAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/CreateCloudFoundryServiceKeyAtomicOperationConverterTest.java
@@ -48,7 +48,7 @@ class CreateCloudFoundryServiceKeyAtomicOperationConverterTest {
           .build();
 
   {
-    when(cloudFoundryClient.getOrganizations().findSpaceByRegion(any()))
+    when(cloudFoundryClient.getSpaces().findSpaceByRegion(any()))
         .thenReturn(Optional.of(cloudFoundrySpace));
   }
 

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeleteCloudFoundryServiceKeyAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeleteCloudFoundryServiceKeyAtomicOperationConverterTest.java
@@ -53,7 +53,7 @@ class DeleteCloudFoundryServiceKeyAtomicOperationConverterTest {
   {
     when(cloudFoundryClient.getOrganizations().findByName(any()))
         .thenReturn(Optional.of(cloudFoundryOrganization));
-    when(cloudFoundryClient.getOrganizations().findSpaceByRegion(any()))
+    when(cloudFoundryClient.getSpaces().findSpaceByRegion(any()))
         .thenReturn(Optional.of(cloudFoundrySpace));
   }
 

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -62,7 +62,7 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
                             .build());
                   });
 
-      when(cloudFoundryClient.getOrganizations().findSpaceByRegion(any()))
+      when(cloudFoundryClient.getSpaces().findSpaceByRegion(any()))
           .thenReturn(
               Optional.of(
                   CloudFoundrySpace.builder()

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
@@ -56,7 +56,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
         .thenReturn(
             Optional.of(CloudFoundryOrganization.builder().id("space-guid").name("space").build()));
 
-    when(cloudFoundryClient.getOrganizations().findSpaceByRegion(any()))
+    when(cloudFoundryClient.getSpaces().findSpaceByRegion(any()))
         .thenAnswer(
             (Answer<Optional<CloudFoundrySpace>>)
                 invocation ->

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/ScaleCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/ScaleCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -56,7 +56,7 @@ class ScaleCloudFoundryServerGroupAtomicOperationConverterTest {
                           .build());
                 });
 
-    when(cloudFoundryClient.getOrganizations().findSpaceByRegion(any()))
+    when(cloudFoundryClient.getSpaces().findSpaceByRegion(any()))
         .thenReturn(Optional.of(CloudFoundrySpace.builder().build()));
   }
 

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundrySpaceCachingAgentTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundrySpaceCachingAgentTest.java
@@ -37,6 +37,7 @@ import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.cache.Keys;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.cache.ResourceCacheData;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.Spaces;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryOrganization;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.security.CloudFoundryCredentials;
@@ -54,6 +55,7 @@ class CloudFoundrySpaceCachingAgentTest {
   private CloudFoundrySpaceCachingAgent cloudFoundrySpaceCachingAgent =
       new CloudFoundrySpaceCachingAgent(credentials, registry);
   private ProviderCache mockProviderCache = mock(ProviderCache.class);
+  private Spaces spaces = mock(Spaces.class);
 
   @BeforeEach
   void before() {
@@ -79,7 +81,8 @@ class CloudFoundrySpaceCachingAgentTest {
             .build();
 
     when(mockProviderCache.getAll(any(), anyCollection())).thenReturn(emptySet());
-    when(credentials.getSpacesLive()).thenReturn(List.of(space1, space2).toJavaList());
+    when(cloudFoundryClient.getSpaces()).thenReturn(spaces);
+    when(spaces.all()).thenReturn(List.of(space1, space2).toJavaList());
 
     CacheData spaceCacheData1 =
         new ResourceCacheData(


### PR DESCRIPTION
Migrate Space and Org services to v3, from v2. Most of these changes are straight forward and required no refactoring. Some, however, required refactoring to keep up with the latest changes and conventions. For example, the v3 api uses Pagination objects instead of Page objects with metadata. Some objects structure also changed. Spaces now have access to their orgGuids through a relationship map. Originally a space object would have this orgGuid at the root. I've adjusted and added to various tests to make sure everything is working as expected. No new logic was implemented