### PR TITLE
fix(amazon): Fix application name matching in load balancer cache keys

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
@@ -66,7 +66,8 @@ class AmazonLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadBalan
   }
 
   private static boolean applicationMatcher(String key, String applicationName) {
-    return key ==~ 'aws:.*:' + applicationName + '-.*' || key ==~ 'aws:.*:' + applicationName || key ==~ 'aws:.*:' + applicationName + ':.*'
+    // aws:loadBalancers:account:region:loadbalancer-name:vpc:type
+    return key ==~ 'aws:[^:]*:[^:]*:[^:]*:' + applicationName + '(-[^:]*):'
   }
 
   @Override


### PR DESCRIPTION
This stops the previous behavior where it would match any segment, e.g.: account, region, vpc, type

Previously if you queried  `api.myspinnaker.com/applications/{someaccount/someregion/somevpc}/loadBalancers`, you would get all load balancers in that account/region/vpc.  We match the load balancer key and look for the application name.  The `.*:` portion was too loose and would match the wrong segments from `aws:loadBalancers:account:region:loadbalancer-name:vpc:type`


This tightens up the regex to look only in the application portion of the key.