### PR TITLE
feat(ecs): Make ECS agents implement AccountAware

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
@@ -25,6 +25,7 @@ import com.amazonaws.services.ecs.AmazonECS;
 import com.amazonaws.services.ecs.model.ListClustersRequest;
 import com.amazonaws.services.ecs.model.ListClustersResult;
 import com.google.common.base.CaseFormat;
+import com.netflix.spinnaker.cats.agent.AccountAware;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.agent.CachingAgent;
@@ -45,7 +46,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-abstract class AbstractEcsCachingAgent<T> implements CachingAgent {
+abstract class AbstractEcsCachingAgent<T> implements CachingAgent, AccountAware {
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   final AmazonClientProvider amazonClientProvider;
@@ -227,5 +228,14 @@ abstract class AbstractEcsCachingAgent<T> implements CachingAgent {
   protected Map<String, Collection<String>> addExtraEvictions(
       Map<String, Collection<String>> evictions) {
     return evictions;
+  }
+  /**
+   * Returns the account name with which this agent is associated.
+   *
+   * @return The name of the account this agent handles.
+   */
+  @Override
+  public String getAccountName() {
+    return accountName;
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgent.java
@@ -19,11 +19,11 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ALARMS;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
 import com.amazonaws.services.cloudwatch.model.DescribeAlarmsRequest;
 import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult;
 import com.amazonaws.services.cloudwatch.model.MetricAlarm;
+import com.netflix.spinnaker.cats.agent.AccountAware;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.agent.CachingAgent;
@@ -46,27 +46,22 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class EcsCloudMetricAlarmCachingAgent implements CachingAgent {
+public class EcsCloudMetricAlarmCachingAgent implements CachingAgent, AccountAware {
   static final Collection<AgentDataType> types =
       Collections.unmodifiableCollection(Arrays.asList(AUTHORITATIVE.forType(ALARMS.toString())));
 
   private final Logger log = LoggerFactory.getLogger(getClass());
   private AmazonClientProvider amazonClientProvider;
-  private AWSCredentialsProvider awsCredentialsProvider;
   private NetflixAmazonCredentials account;
   private String accountName;
   private String region;
 
   public EcsCloudMetricAlarmCachingAgent(
-      NetflixAmazonCredentials account,
-      String region,
-      AmazonClientProvider amazonClientProvider,
-      AWSCredentialsProvider awsCredentialsProvider) {
+      NetflixAmazonCredentials account, String region, AmazonClientProvider amazonClientProvider) {
     this.region = region;
     this.account = account;
     this.accountName = account.getName();
     this.amazonClientProvider = amazonClientProvider;
-    this.awsCredentialsProvider = awsCredentialsProvider;
   }
 
   public static Map<String, Object> convertMetricAlarmToAttributes(
@@ -169,5 +164,10 @@ public class EcsCloudMetricAlarmCachingAgent implements CachingAgent {
   @Override
   public String getProviderName() {
     return EcsProvider.NAME;
+  }
+
+  @Override
+  public String getAccountName() {
+    return accountName;
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCachingAgent.java
@@ -19,12 +19,12 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.IAM_ROLE;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
 import com.amazonaws.services.identitymanagement.model.ListRolesRequest;
 import com.amazonaws.services.identitymanagement.model.ListRolesResult;
 import com.amazonaws.services.identitymanagement.model.Role;
+import com.netflix.spinnaker.cats.agent.AccountAware;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.agent.CachingAgent;
@@ -50,13 +50,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class IamRoleCachingAgent implements CachingAgent {
+public class IamRoleCachingAgent implements CachingAgent, AccountAware {
 
   static final Collection<AgentDataType> types =
       Collections.unmodifiableCollection(Arrays.asList(AUTHORITATIVE.forType(IAM_ROLE.toString())));
   private final Logger log = LoggerFactory.getLogger(getClass());
   private AmazonClientProvider amazonClientProvider;
-  private AWSCredentialsProvider awsCredentialsProvider;
   private NetflixAmazonCredentials account;
   private String accountName;
   private IamPolicyReader iamPolicyReader;
@@ -64,12 +63,10 @@ public class IamRoleCachingAgent implements CachingAgent {
   public IamRoleCachingAgent(
       NetflixAmazonCredentials account,
       AmazonClientProvider amazonClientProvider,
-      AWSCredentialsProvider awsCredentialsProvider,
       IamPolicyReader iamPolicyReader) {
     this.account = account;
     this.accountName = account.getName();
     this.amazonClientProvider = amazonClientProvider;
-    this.awsCredentialsProvider = awsCredentialsProvider;
     this.iamPolicyReader = iamPolicyReader;
   }
 
@@ -216,5 +213,10 @@ public class IamRoleCachingAgent implements CachingAgent {
   @Override
   public Collection<AgentDataType> getProvidedDataTypes() {
     return types;
+  }
+
+  @Override
+  public String getAccountName() {
+    return accountName;
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ScalableTargetsCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ScalableTargetsCachingAgent.java
@@ -19,13 +19,13 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SCALABLE_TARGETS;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.applicationautoscaling.AWSApplicationAutoScaling;
 import com.amazonaws.services.applicationautoscaling.model.DescribeScalableTargetsRequest;
 import com.amazonaws.services.applicationautoscaling.model.DescribeScalableTargetsResult;
 import com.amazonaws.services.applicationautoscaling.model.ScalableTarget;
 import com.amazonaws.services.applicationautoscaling.model.ServiceNamespace;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.cats.agent.AccountAware;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.agent.CachingAgent;
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ScalableTargetsCachingAgent implements CachingAgent {
+public class ScalableTargetsCachingAgent implements CachingAgent, AccountAware {
   static final Collection<AgentDataType> types =
       Collections.unmodifiableCollection(
           Arrays.asList(AUTHORITATIVE.forType(SCALABLE_TARGETS.toString())));
@@ -56,7 +56,6 @@ public class ScalableTargetsCachingAgent implements CachingAgent {
   private final Logger log = LoggerFactory.getLogger(getClass());
   private final ObjectMapper objectMapper;
   private AmazonClientProvider amazonClientProvider;
-  private AWSCredentialsProvider awsCredentialsProvider;
   private NetflixAmazonCredentials account;
   private String accountName;
   private String region;
@@ -65,13 +64,11 @@ public class ScalableTargetsCachingAgent implements CachingAgent {
       NetflixAmazonCredentials account,
       String region,
       AmazonClientProvider amazonClientProvider,
-      AWSCredentialsProvider awsCredentialsProvider,
       ObjectMapper objectMapper) {
     this.region = region;
     this.account = account;
     this.accountName = account.getName();
     this.amazonClientProvider = amazonClientProvider;
-    this.awsCredentialsProvider = awsCredentialsProvider;
     this.objectMapper = objectMapper;
   }
 
@@ -168,5 +165,10 @@ public class ScalableTargetsCachingAgent implements CachingAgent {
   @Override
   public String getProviderName() {
     return EcsProvider.NAME;
+  }
+
+  @Override
+  public String getAccountName() {
+    return accountName;
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/SecretCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/SecretCachingAgent.java
@@ -18,12 +18,11 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SECRETS;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.model.ListSecretsRequest;
 import com.amazonaws.services.secretsmanager.model.ListSecretsResult;
 import com.amazonaws.services.secretsmanager.model.SecretListEntry;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.cats.agent.AccountAware;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.agent.CachingAgent;
@@ -40,30 +39,22 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SecretCachingAgent implements CachingAgent {
+public class SecretCachingAgent implements CachingAgent, AccountAware {
   static final Collection<AgentDataType> types =
       Collections.unmodifiableCollection(Arrays.asList(AUTHORITATIVE.forType(SECRETS.toString())));
 
   private final Logger log = LoggerFactory.getLogger(getClass());
-  private final ObjectMapper objectMapper;
   private AmazonClientProvider amazonClientProvider;
-  private AWSCredentialsProvider awsCredentialsProvider;
   private NetflixAmazonCredentials account;
   private String accountName;
   private String region;
 
   public SecretCachingAgent(
-      NetflixAmazonCredentials account,
-      String region,
-      AmazonClientProvider amazonClientProvider,
-      AWSCredentialsProvider awsCredentialsProvider,
-      ObjectMapper objectMapper) {
+      NetflixAmazonCredentials account, String region, AmazonClientProvider amazonClientProvider) {
     this.region = region;
     this.account = account;
     this.accountName = account.getName();
     this.amazonClientProvider = amazonClientProvider;
-    this.awsCredentialsProvider = awsCredentialsProvider;
-    this.objectMapper = objectMapper;
   }
 
   public static Map<String, Object> convertSecretToAttributes(
@@ -163,5 +154,10 @@ public class SecretCachingAgent implements CachingAgent {
   @Override
   public String getProviderName() {
     return EcsProvider.NAME;
+  }
+
+  @Override
+  public String getAccountName() {
+    return accountName;
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceDiscoveryCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceDiscoveryCachingAgent.java
@@ -18,12 +18,11 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICE_DISCOVERY_REGISTRIES;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.servicediscovery.AWSServiceDiscovery;
 import com.amazonaws.services.servicediscovery.model.ListServicesRequest;
 import com.amazonaws.services.servicediscovery.model.ListServicesResult;
 import com.amazonaws.services.servicediscovery.model.ServiceSummary;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.cats.agent.AccountAware;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.agent.CachingAgent;
@@ -40,31 +39,23 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ServiceDiscoveryCachingAgent implements CachingAgent {
+public class ServiceDiscoveryCachingAgent implements CachingAgent, AccountAware {
   static final Collection<AgentDataType> types =
       Collections.unmodifiableCollection(
           Arrays.asList(AUTHORITATIVE.forType(SERVICE_DISCOVERY_REGISTRIES.toString())));
 
   private final Logger log = LoggerFactory.getLogger(getClass());
-  private final ObjectMapper objectMapper;
   private AmazonClientProvider amazonClientProvider;
-  private AWSCredentialsProvider awsCredentialsProvider;
   private NetflixAmazonCredentials account;
   private String accountName;
   private String region;
 
   public ServiceDiscoveryCachingAgent(
-      NetflixAmazonCredentials account,
-      String region,
-      AmazonClientProvider amazonClientProvider,
-      AWSCredentialsProvider awsCredentialsProvider,
-      ObjectMapper objectMapper) {
+      NetflixAmazonCredentials account, String region, AmazonClientProvider amazonClientProvider) {
     this.region = region;
     this.account = account;
     this.accountName = account.getName();
     this.amazonClientProvider = amazonClientProvider;
-    this.awsCredentialsProvider = awsCredentialsProvider;
-    this.objectMapper = objectMapper;
   }
 
   public static Map<String, Object> convertServiceToAttributes(
@@ -165,5 +156,10 @@ public class ServiceDiscoveryCachingAgent implements CachingAgent {
   @Override
   public String getProviderName() {
     return EcsProvider.NAME;
+  }
+
+  @Override
+  public String getAccountName() {
+    return accountName;
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/config/EcsProviderConfig.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/config/EcsProviderConfig.java
@@ -90,7 +90,6 @@ public class EcsProviderConfig {
           new IamRoleCachingAgent(
               credentials,
               amazonClientProvider,
-              awsCredentialsProvider,
               iamPolicyReader)); // IAM is region-agnostic, so one caching agent per account is
       // enough
 
@@ -137,28 +136,15 @@ public class EcsProviderConfig {
                   objectMapper));
           newAgents.add(
               new EcsCloudMetricAlarmCachingAgent(
-                  credentials, region.getName(), amazonClientProvider, awsCredentialsProvider));
+                  credentials, region.getName(), amazonClientProvider));
           newAgents.add(
               new ScalableTargetsCachingAgent(
-                  credentials,
-                  region.getName(),
-                  amazonClientProvider,
-                  awsCredentialsProvider,
-                  objectMapper));
+                  credentials, region.getName(), amazonClientProvider, objectMapper));
           newAgents.add(
-              new SecretCachingAgent(
-                  credentials,
-                  region.getName(),
-                  amazonClientProvider,
-                  awsCredentialsProvider,
-                  objectMapper));
+              new SecretCachingAgent(credentials, region.getName(), amazonClientProvider));
           newAgents.add(
               new ServiceDiscoveryCachingAgent(
-                  credentials,
-                  region.getName(),
-                  amazonClientProvider,
-                  awsCredentialsProvider,
-                  objectMapper));
+                  credentials, region.getName(), amazonClientProvider));
           newAgents.add(
               new TargetHealthCachingAgent(
                   credentials,

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgentSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgentSpec.groovy
@@ -21,7 +21,6 @@ import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
-import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsMetricAlarm
 import spock.lang.Shared
@@ -39,7 +38,7 @@ class EcsCloudMetricAlarmCachingAgentSpec extends Specification {
   AWSCredentialsProvider credentialsProvider
 
   @Subject
-  EcsCloudMetricAlarmCachingAgent agent = new EcsCloudMetricAlarmCachingAgent(CommonCachingAgent.netflixAmazonCredentials, REGION, clientProvider, credentialsProvider)
+  EcsCloudMetricAlarmCachingAgent agent = new EcsCloudMetricAlarmCachingAgent(CommonCachingAgent.netflixAmazonCredentials, REGION, clientProvider)
 
   def setup() {
     cloudWatch = Mock(AmazonCloudWatch)

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ScalableTargetCachingAgentSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ScalableTargetCachingAgentSpec.groovy
@@ -39,7 +39,7 @@ class ScalableTargetCachingAgentSpec extends Specification {
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
   @Subject
-  ScalableTargetsCachingAgent agent = new ScalableTargetsCachingAgent(CommonCachingAgent.netflixAmazonCredentials, 'us-west-1', clientProvider, credentialsProvider, objectMapper)
+  ScalableTargetsCachingAgent agent = new ScalableTargetsCachingAgent(CommonCachingAgent.netflixAmazonCredentials, 'us-west-1', clientProvider, objectMapper)
 
   def 'should get a list of cloud watch alarms'() {
     given:

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/SecretCachingAgentSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/SecretCachingAgentSpec.groovy
@@ -15,13 +15,10 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent
 
-import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.services.applicationautoscaling.model.ServiceNamespace
+
 import com.amazonaws.services.secretsmanager.AWSSecretsManager
 import com.amazonaws.services.secretsmanager.model.ListSecretsResult
 import com.amazonaws.services.secretsmanager.model.SecretListEntry
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.Secret
@@ -34,12 +31,9 @@ class SecretCachingAgentSpec extends Specification {
   def secretsManager = Mock(AWSSecretsManager)
   def clientProvider = Mock(AmazonClientProvider)
   def providerCache = Mock(ProviderCache)
-  def credentialsProvider = Mock(AWSCredentialsProvider)
-  def objectMapper = new ObjectMapper()
-    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
   @Subject
-  SecretCachingAgent agent = new SecretCachingAgent(CommonCachingAgent.netflixAmazonCredentials, 'us-west-1', clientProvider, credentialsProvider, objectMapper)
+  SecretCachingAgent agent = new SecretCachingAgent(CommonCachingAgent.netflixAmazonCredentials, 'us-west-1', clientProvider)
 
   def 'should get a list of secrets'() {
     given:

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceDiscoveryCachingAgentSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceDiscoveryCachingAgentSpec.groovy
@@ -39,7 +39,7 @@ class ServiceDiscoveryCachingAgentSpec extends Specification {
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
   @Subject
-  ServiceDiscoveryCachingAgent agent = new ServiceDiscoveryCachingAgent(CommonCachingAgent.netflixAmazonCredentials, 'us-west-1', clientProvider, credentialsProvider, objectMapper)
+  ServiceDiscoveryCachingAgent agent = new ServiceDiscoveryCachingAgent(CommonCachingAgent.netflixAmazonCredentials, 'us-west-1', clientProvider)
 
   def 'should get a list of service discovery registries'() {
     given:

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCacheTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCacheTest.java
@@ -48,8 +48,7 @@ public class IamRoleCacheTest extends CommonCachingAgent {
 
   @Subject
   private final IamRoleCachingAgent agent =
-      new IamRoleCachingAgent(
-          netflixAmazonCredentials, clientProvider, credentialsProvider, iamPolicyReader);
+      new IamRoleCachingAgent(netflixAmazonCredentials, clientProvider, iamPolicyReader);
 
   @Test
   public void shouldRetrieveFromWrittenCache() {

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCachingAgentTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCachingAgentTest.java
@@ -43,8 +43,7 @@ public class IamRoleCachingAgentTest extends CommonCachingAgent {
 
   @Subject
   private final IamRoleCachingAgent agent =
-      new IamRoleCachingAgent(
-          netflixAmazonCredentials, clientProvider, credentialsProvider, iamPolicyReader);
+      new IamRoleCachingAgent(netflixAmazonCredentials, clientProvider, iamPolicyReader);
 
   @Test
   public void shouldGetListOfServices() {


### PR DESCRIPTION
In preparation for ECS provider to implement `BaseProvider` and `CredentialsRepository` as introduced in [RFC](https://github.com/spinnaker/governance/blob/master/rfc/account-management.md) , ECS agents must implement `AccountAware` to remove agents when credentials are removed from repository. 

@allisaurus 
