### PR TITLE
feat(titus): Validate that `jobId` provided to `UpsertTitusScalingPolicy` operation

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizer.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizer.java
@@ -136,14 +136,16 @@ public class DescriptionAuthorizer<T> {
     if (requiresApplicationRestriction && account != null && applications.isEmpty()) {
       registry
           .counter(
-              missingApplicationId.withTag(
-                  "descriptionClass", description.getClass().getSimpleName()))
+              missingApplicationId
+                  .withTag("descriptionClass", description.getClass().getSimpleName())
+                  .withTag("hasValidationErrors", errors.hasErrors()))
           .increment();
 
       log.warn(
-          "No application(s) specified for operation with account restriction (type: {}, account: {})",
+          "No application(s) specified for operation with account restriction (type: {}, account: {}, hasValidationErrors: {})",
           description.getClass().getSimpleName(),
-          account);
+          account,
+          errors.hasErrors());
     }
 
     registry

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/converters/UpsertTitusScalingPolicyAtomicOperationConverter.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/converters/UpsertTitusScalingPolicyAtomicOperationConverter.groovy
@@ -57,7 +57,7 @@ class UpsertTitusScalingPolicyAtomicOperationConverter extends AbstractAtomicOpe
       converted.application = titusJob.appName
     } catch (Exception e) {
       converted.application = null
-      log.error("Unable to determine application for titus job (jobId: {})", converted.jobId, e)
+      log.warn("Unable to determine application for titus job (jobId: {})", converted.jobId, e)
     }
 
     converted

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/AbstractTitusDescriptionValidatorSupport.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/AbstractTitusDescriptionValidatorSupport.groovy
@@ -34,7 +34,7 @@ abstract class AbstractTitusDescriptionValidatorSupport<T extends AbstractTitusC
   }
 
   @Override
-  void validate(List priorDescriptions, T description, ValidationErrors errors) {
+  void validate(List<T> priorDescriptions, T description, ValidationErrors errors) {
     if (!description.credentials) {
       errors.rejectValue "credentials", "${descriptionName}.credentials.empty"
     } else {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/UpsertTitusScalingPolicyDescriptionValidator.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/UpsertTitusScalingPolicyDescriptionValidator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.titus.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import com.netflix.spinnaker.clouddriver.titus.TitusOperation;
+import com.netflix.spinnaker.clouddriver.titus.deploy.description.UpsertTitusScalingPolicyDescription;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@TitusOperation(AtomicOperations.UPSERT_SCALING_POLICY)
+class UpsertTitusScalingPolicyDescriptionValidator
+    extends AbstractTitusDescriptionValidatorSupport<UpsertTitusScalingPolicyDescription> {
+
+  @Autowired
+  UpsertTitusScalingPolicyDescriptionValidator(
+      AccountCredentialsProvider accountCredentialsProvider) {
+    super(accountCredentialsProvider, "upsertTitusScalingPolicyDescription");
+  }
+
+  @Override
+  public void validate(
+      List<UpsertTitusScalingPolicyDescription> priorDescriptions,
+      UpsertTitusScalingPolicyDescription description,
+      ValidationErrors errors) {
+    super.validate(priorDescriptions, description, errors);
+
+    if (description.getJobId() == null) {
+      errors.rejectValue(
+          "jobId",
+          "upsertTitusScalingPolicyDescription.jobId.empty",
+          "A Titus job identifier (jobId) must be specified");
+    }
+  }
+}


### PR DESCRIPTION
Also added an additional `hasValidationErrors` tag to the `authorization.missingApplication`
metric.

This tag will allow us to silence some alerting. The presence of a validation error will
prevent execution (and this metric is meant to indicate operations that are executing but
lack application details).
