### PR TITLE
fix(aws): Revert launch template setting security group ids

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -230,8 +230,7 @@ public class LaunchTemplateService {
                     .withName(settings.getIamRole()))
             .withMonitoring(
                 new LaunchTemplatesMonitoringRequest()
-                    .withEnabled(settings.getInstanceMonitoring()))
-            .withSecurityGroupIds(settings.getSecurityGroups());
+                    .withEnabled(settings.getInstanceMonitoring()));
 
     setUserData(
         request,


### PR DESCRIPTION
Launch templates cannot specify security groups in both the template data and the network interfaces.