### PR TITLE
fix(aws lb): Parse LBs with dashes in them

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
@@ -67,7 +67,7 @@ class AmazonLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadBalan
 
   private static boolean applicationMatcher(String key, String applicationName) {
     // aws:loadBalancers:account:region:loadbalancer-name:vpc:type
-    return key ==~ 'aws:[^:]*:[^:]*:[^:]*:' + applicationName + '(-[^:]*):'
+    return key ==~ 'aws:[^:]*:[^:]*:[^:]*:' + applicationName + '(-[^:]*)?:.*'
   }
 
   @Override


### PR DESCRIPTION
Follow up to https://github.com/spinnaker/clouddriver/pull/5041
Some load balancers wouldn't get parsed because the regex required `:` at the end and didn't have the `-stack-detail` as optional
