### PR TITLE
feat(aws): added capacityType to instance information cached

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/InstanceCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/InstanceCachingAgent.groovy
@@ -204,6 +204,10 @@ class InstanceCachingAgent implements CachingAgent, AccountAware, DriftMetric {
       } else {
         relationships[SERVER_GROUPS.ns].clear()
       }
+      def capacityType = getCapacityType(data.instance)
+      if (capacityType) {
+        attributes.put("capacityType", capacityType)
+      }
     }
   }
 
@@ -220,6 +224,18 @@ class InstanceCachingAgent implements CachingAgent, AccountAware, DriftMetric {
       awsInstanceHealth.description = stateReason.message
     }
     awsInstanceHealth
+  }
+
+  private String getCapacityType(Instance instance) {
+    if (instance.instanceLifecycle == null) {
+      return "on-demand"
+    }
+
+    if (instance.instanceLifecycle.toString().equalsIgnoreCase("spot")) {
+      return "spot"
+    }
+
+    return null
   }
 
   private static class InstanceData {


### PR DESCRIPTION
## Summary
added `capacityType` to instance information cached.

As [EC2/ Spot features](https://github.com/spinnaker/spinnaker/issues/5989) are added, it will be helpful to show capacity type (i.e. on-demand / spot) in instance information.

## Issue
https://github.com/spinnaker/spinnaker/issues/5989

## Tests
API response of `/instances/{account}/{region}/{instanceId}` includes `"capacityType": "spot"`  or `"capacityType": "on-demand"`

## Deck PR
https://github.com/spinnaker/deck/pull/8688