### PR TITLE
fix(core): Default equals()/hashCode() implementation for `AbstractAccountCredentials`

### DIFF
--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/AbstractAccountCredentials.java
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/AbstractAccountCredentials.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -58,5 +59,18 @@ public abstract class AbstractAccountCredentials<T> implements AccountCredential
       perms.add(Authorization.WRITE, role);
     }
     return perms.build();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    AccountCredentials that = (AccountCredentials) o;
+    return Objects.equals(getName(), that.getName()) && Objects.equals(getType(), that.getType());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), getType());
   }
 }


### PR DESCRIPTION
Addresses a problem with the `DefaultAccountCredentialsProvider` wherein duplicate `AccountCredentials`
were being returned.
