### PR TITLE
feat(ecs): add more integration tests for Amazon ECS createServerGroupOperation

### DIFF
--- a/clouddriver-ecs/src/integration/resources/testoperations/createServerGroup-inputs-ec2-LegacyTargetGroup-autoScalingGroup.json
+++ b/clouddriver-ecs/src/integration/resources/testoperations/createServerGroup-inputs-ec2-LegacyTargetGroup-autoScalingGroup.json
@@ -1,0 +1,33 @@
+{
+  "account": "ecs-account",
+  "application": "ecs",
+  "availabilityZones": {
+    "us-west-2": [
+      "us-west-2a",
+      "us-west-2c"
+    ]
+  },
+  "capacity": {
+    "desired": 1,
+    "max": 1,
+    "min": 1
+  },
+  "cloudProvider": "ecs",
+  "computeUnits": 256,
+  "containerPort": 80,
+  "credentials": "ecs-account",
+  "dockerImageAddress": "nginx",
+  "ecsClusterName": "integInputsEc2LegacyTargetGroupWithAutoScaling-cluster",
+  "launchType": "EC2",
+  "networkMode": "bridge",
+  "placementStrategySequence": [],
+  "reservedMemory": 512,
+  "stack": "integInputsEc2LegacyTargetGroupWithAutoScalingGroup",
+  "targetGroup": "integInputsEc2LegacyTargetGroupWithAutoScalingGroup-targetGroup",
+  "source" : {
+    "account" :  "ecs-account",
+    "region" :  "us-west-2",
+    "asgName" :  "ecs",
+    "useSourceCapacity" : true
+  }
+}


### PR DESCRIPTION
This PR contains integration test for Create Server Group Operation for the task definition input with auto scaling source / policies.
