### PR TITLE
fix(aws/loadbalancing): mark draining instances as out of service

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/InstanceTargetGroupState.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/InstanceTargetGroupState.groovy
@@ -40,16 +40,17 @@ class InstanceTargetGroupState {
   private HealthState deriveHealthState() {
     //ELBv2 has concrete states: unused -> initial -> healthy    -> draining
     //                                            \-> unhealthy -/
-    if (state == 'healthy') {
-      return HealthState.Up
+    switch (state) {
+      case 'healthy':
+        return HealthState.Up
+      case 'initial':
+        return HealthState.Starting
+      case 'unused':
+        return HealthState.OutOfService
+      case 'draining':
+        return HealthState.Draining
+      default:
+        return HealthState.Down
     }
-
-    if (state == 'initial') {
-      return HealthState.Starting
-    }
-    if (state == 'unused' || state == 'draining') {
-      return HealthState.OutOfService
-    }
-    return HealthState.Down
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/InstanceTargetGroupState.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/InstanceTargetGroupState.groovy
@@ -40,18 +40,14 @@ class InstanceTargetGroupState {
   private HealthState deriveHealthState() {
     //ELBv2 has concrete states: unused -> initial -> healthy    -> draining
     //                                            \-> unhealthy -/
-
-    // a draining instance is still serving active connections, and will
-    //  transition to unused once those complete - we will consider it
-    //  UP until it completes draining
-    if (state == 'healthy' || state == 'draining') {
+    if (state == 'healthy') {
       return HealthState.Up
     }
 
     if (state == 'initial') {
       return HealthState.Starting
     }
-    if (state == 'unused') {
+    if (state == 'unused' || state == 'draining') {
       return HealthState.OutOfService
     }
     return HealthState.Down

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/HealthState.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/HealthState.java
@@ -23,7 +23,8 @@ public enum HealthState {
   Unknown,
   Starting,
   Succeeded,
-  Up;
+  Up,
+  Draining;
 
   public static HealthState fromString(final String name) {
     for (HealthState state : values()) {


### PR DESCRIPTION
Marking draining instances as "UP" would falsely finish a pipeline successfully.

More details about this bug is documented here: https://github.com/spinnaker/spinnaker/issues/5867
As well as a slack conversation here https://spinnakerteam.slack.com/archives/CB78MFQPP/p1588774672064600