### PR TITLE
feat(kubernetes): Send SIGKILL to kubectl

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/ForceDestroyWatchdog.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/ForceDestroyWatchdog.java
@@ -50,7 +50,7 @@ public class ForceDestroyWatchdog extends ExecuteWatchdog {
     try {
       Thread.sleep(GRACE_PERIOD_MS);
     } catch (InterruptedException e) {
-      // nothing to do
+      Thread.currentThread().interrupt();
     }
 
     if (process.isAlive()) {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/ForceDestroyWatchdog.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/ForceDestroyWatchdog.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jobs.local;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.exec.ExecuteWatchdog;
+import org.apache.commons.exec.Watchdog;
+
+/**
+ * Extension of {@link org.apache.commons.exec.ExecuteWatchdog} that sends SIGKILL signal to the
+ * watched process if not finished by SIGTERM.
+ */
+@Slf4j
+public class ForceDestroyWatchdog extends ExecuteWatchdog {
+
+  private final long timeout;
+  private Process process;
+
+  public ForceDestroyWatchdog(final long timeout) {
+    super(timeout);
+    this.timeout = timeout;
+  }
+
+  @Override
+  public synchronized void start(Process processToMonitor) {
+    super.start(processToMonitor);
+    this.process = processToMonitor;
+  }
+
+  @Override
+  public synchronized void timeoutOccured(final Watchdog w) {
+    super.timeoutOccured(w);
+    if (process.isAlive()) {
+      log.warn(
+          "Timeout: Waited {} ms for process to finish and process is still alive after sending SIGTERM signal. Sending SIGKILL.",
+          timeout);
+      process.destroyForcibly();
+    }
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/ForceDestroyWatchdog.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/ForceDestroyWatchdog.java
@@ -27,6 +27,8 @@ import org.apache.commons.exec.Watchdog;
 @Slf4j
 public class ForceDestroyWatchdog extends ExecuteWatchdog {
 
+  private static final long GRACE_PERIOD_MS = 250;
+
   private final long timeout;
   private Process process;
 
@@ -44,10 +46,17 @@ public class ForceDestroyWatchdog extends ExecuteWatchdog {
   @Override
   public synchronized void timeoutOccured(final Watchdog w) {
     super.timeoutOccured(w);
+
+    try {
+      Thread.sleep(GRACE_PERIOD_MS);
+    } catch (InterruptedException e) {
+      // nothing to do
+    }
+
     if (process.isAlive()) {
       log.warn(
           "Timeout: Waited {} ms for process to finish and process is still alive after sending SIGTERM signal. Sending SIGKILL.",
-          timeout);
+          timeout + GRACE_PERIOD_MS);
       process.destroyForcibly();
     }
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.java
@@ -131,7 +131,7 @@ public class JobExecutorLocal implements JobExecutor {
   private Executor buildExecutor(ExecuteStreamHandler streamHandler) {
     Executor executor = new DefaultExecutor();
     executor.setStreamHandler(streamHandler);
-    executor.setWatchdog(new ExecuteWatchdog(timeoutMinutes * 60 * 1000));
+    executor.setWatchdog(new ForceDestroyWatchdog(timeoutMinutes * 60 * 1000));
     // Setting this to null causes the executor to skip verifying exit codes; we'll handle checking
     // the exit status instead of having the executor throw an exception for non-zero exit codes.
     executor.setExitValues(null);


### PR DESCRIPTION
Spawning `kubectl` jobs has a timeout controlled by `jobs.local.timeout-minutes` (default: 10 minutes), which is used for aborting the job.

The default implementation of apache commons exec uses `Process.destroy` for sending a SIGTERM signal to `kubectl`. Usually this works fine, but there may be some situations in which `kubectl` doesn't respond to that signal and may remain running for an unknown period of time.

This PR introduces a way for sending a SIGKILL signal (`kill -9`) to `kubectl` if it ignores the SIGTERM signal, by using `Process.destroyForcibly`.