### PR TITLE
 fix(aws): Ignore not found errors when deleting an asg

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DestroyAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DestroyAsgAtomicOperation.groovy
@@ -131,9 +131,12 @@ class DestroyAsgAtomicOperation implements AtomicOperation<Void> {
             new DeleteLaunchTemplateRequest(launchTemplateId: launchTemplateId))
         }
       } catch (AmazonAutoScalingException e) {
-        String msg = e.message.toLowerCase()
         // Ignore not found exception
-        if (!msg.contains("not found") && !msg.contains("does not exist")) {
+        if (lcName && !e.message.toLowerCase().contains("launch configuration name not found") {
+          throw e
+        }
+
+        if (launchTemplateId && !e.message.contains("InvalidLaunchTemplateId.NotFound")) {
           throw e
         }
       }


### PR DESCRIPTION
- Breaks error-throwing logic into two conditionals (one for launch configs and one for launch templates)
- Reverts conditional check for launch configs