### PR TITLE
feat(amazon): Add Edda proxy for LaunchTemplateVersions

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AmazonClientInvocationHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AmazonClientInvocationHandler.java
@@ -45,6 +45,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -203,6 +206,32 @@ public class AmazonClientInvocationHandler implements InvocationHandler {
             describe(request, "launchTemplateNames", "launchTemplates", LaunchTemplate.class));
   }
 
+  private static final Function<AmazonWebServiceRequest, Collection<String>> LAUNCH_TEMPLATE_VERSION_EXTRACTOR = (r) -> {
+    if (r == null) {
+      return Collections.emptyList();
+    }
+    DescribeLaunchTemplateVersionsRequest req = (DescribeLaunchTemplateVersionsRequest) r;
+    if (req.getLaunchTemplateId() == null) {
+      return Collections.emptyList();
+    }
+    if (req.getVersions() == null || req.getVersions().isEmpty()) {
+      String defaultId = req.getLaunchTemplateId() + ":$Default";
+      return Collections.singletonList(defaultId);
+    }
+    return req.getVersions().stream().map(v -> req.getLaunchTemplateId() + ":" + v).collect(Collectors.toCollection(ArrayList::new));
+  };
+
+
+  public DescribeLaunchTemplateVersionsResult describeLaunchTemplateVersions() {
+    return describeLaunchTemplateVersions(null);
+  }
+
+  public DescribeLaunchTemplateVersionsResult describeLaunchTemplateVersions(DescribeLaunchTemplateVersionsRequest request) {
+    return new DescribeLaunchTemplateVersionsResult().withLaunchTemplateVersions(
+      describe(request, LAUNCH_TEMPLATE_VERSION_EXTRACTOR, "launchTemplateVersions", LaunchTemplateVersion.class)
+    );
+  }
+
   public DescribeImagesResult describeImages() {
     return describeImages(null);
   }
@@ -345,15 +374,23 @@ public class AmazonClientInvocationHandler implements InvocationHandler {
   ////////////////////////////////////
 
   private <T> List<T> describe(
+    AmazonWebServiceRequest request,
+    String idKey,
+    final String object,
+    final Class<T> singleType) {
+    return describe(request, r -> getRequestIds(r, idKey), object, singleType);
+  }
+
+  private <T> List<T> describe(
       AmazonWebServiceRequest request,
-      String idKey,
+      Function<AmazonWebServiceRequest, Collection<String>> idExtractor,
       final String object,
       final Class<T> singleType) {
     lastModified.set(null);
     final Map<String, String> metricTags = new HashMap<>(this.metricTags);
     metricTags.put("collection", object);
     try {
-      final Collection<String> ids = getRequestIds(request, idKey);
+      final Collection<String> ids = idExtractor.apply(request);
       metricTags.put("collectionMode", ids.isEmpty() ? "full" : "byId");
       final JavaType singleMeta =
           objectMapper

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AmazonClientInvocationHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AmazonClientInvocationHandler.java
@@ -47,7 +47,6 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -206,30 +205,38 @@ public class AmazonClientInvocationHandler implements InvocationHandler {
             describe(request, "launchTemplateNames", "launchTemplates", LaunchTemplate.class));
   }
 
-  private static final Function<AmazonWebServiceRequest, Collection<String>> LAUNCH_TEMPLATE_VERSION_EXTRACTOR = (r) -> {
-    if (r == null) {
-      return Collections.emptyList();
-    }
-    DescribeLaunchTemplateVersionsRequest req = (DescribeLaunchTemplateVersionsRequest) r;
-    if (req.getLaunchTemplateId() == null) {
-      return Collections.emptyList();
-    }
-    if (req.getVersions() == null || req.getVersions().isEmpty()) {
-      String defaultId = req.getLaunchTemplateId() + ":$Default";
-      return Collections.singletonList(defaultId);
-    }
-    return req.getVersions().stream().map(v -> req.getLaunchTemplateId() + ":" + v).collect(Collectors.toCollection(ArrayList::new));
-  };
-
+  private static final Function<AmazonWebServiceRequest, Collection<String>>
+      LAUNCH_TEMPLATE_VERSION_EXTRACTOR =
+          (r) -> {
+            if (r == null) {
+              return Collections.emptyList();
+            }
+            DescribeLaunchTemplateVersionsRequest req = (DescribeLaunchTemplateVersionsRequest) r;
+            if (req.getLaunchTemplateId() == null) {
+              return Collections.emptyList();
+            }
+            if (req.getVersions() == null || req.getVersions().isEmpty()) {
+              String defaultId = req.getLaunchTemplateId() + ":$Default";
+              return Collections.singletonList(defaultId);
+            }
+            return req.getVersions().stream()
+                .map(v -> req.getLaunchTemplateId() + ":" + v)
+                .collect(Collectors.toCollection(ArrayList::new));
+          };
 
   public DescribeLaunchTemplateVersionsResult describeLaunchTemplateVersions() {
     return describeLaunchTemplateVersions(null);
   }
 
-  public DescribeLaunchTemplateVersionsResult describeLaunchTemplateVersions(DescribeLaunchTemplateVersionsRequest request) {
-    return new DescribeLaunchTemplateVersionsResult().withLaunchTemplateVersions(
-      describe(request, LAUNCH_TEMPLATE_VERSION_EXTRACTOR, "launchTemplateVersions", LaunchTemplateVersion.class)
-    );
+  public DescribeLaunchTemplateVersionsResult describeLaunchTemplateVersions(
+      DescribeLaunchTemplateVersionsRequest request) {
+    return new DescribeLaunchTemplateVersionsResult()
+        .withLaunchTemplateVersions(
+            describe(
+                request,
+                LAUNCH_TEMPLATE_VERSION_EXTRACTOR,
+                "launchTemplateVersions",
+                LaunchTemplateVersion.class));
   }
 
   public DescribeImagesResult describeImages() {
@@ -374,10 +381,10 @@ public class AmazonClientInvocationHandler implements InvocationHandler {
   ////////////////////////////////////
 
   private <T> List<T> describe(
-    AmazonWebServiceRequest request,
-    String idKey,
-    final String object,
-    final Class<T> singleType) {
+      AmazonWebServiceRequest request,
+      String idKey,
+      final String object,
+      final Class<T> singleType) {
     return describe(request, r -> getRequestIds(r, idKey), object, singleType);
   }
 


### PR DESCRIPTION
- Add a proxy to fetch launch tempalte version collectors
- extend support for constructing an `idKey` of the format `launchTemplateId:version`