### PR TITLE
feat(ecs): add more integration test for Amazon ECS createServerGroup

### DIFF
--- a/clouddriver-ecs/src/integration/resources/testartifacts/createServerGroup-artifact-EC2-TGMappings-multipleLBsAndContainers-artifactFile.json
+++ b/clouddriver-ecs/src/integration/resources/testartifacts/createServerGroup-artifact-EC2-TGMappings-multipleLBsAndContainers-artifactFile.json
@@ -1,0 +1,67 @@
+{
+  "family": "PLACEHOLDER",
+  "containerDefinitions": [
+    {
+      "name": "application1",
+      "image": "PLACEHOLDER",
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "spinnaker-ecs-demo",
+          "awslogs-region": "us-west-2",
+          "awslogs-stream-prefix": "spinnaker"
+        }
+      },
+      "portMappings": [
+        {
+          "protocol": "tcp",
+          "containerPort": 80
+        }
+      ],
+      "environment": [
+        {
+          "name": "PORT",
+          "value": "80"
+        }
+      ],
+      "cpu": 256,
+      "memoryReservation": 512,
+      "essential": true
+    },
+    {
+      "name": "application2",
+      "image": "PLACEHOLDER",
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "spinnaker-ecs-demo",
+          "awslogs-region": "us-west-2",
+          "awslogs-stream-prefix": "spinnaker"
+        }
+      },
+      "portMappings": [
+        {
+          "protocol": "tcp",
+          "containerPort": 84
+        }
+      ],
+      "environment": [
+        {
+          "name": "PORT",
+          "value": "84"
+        }
+      ],
+      "cpu": 256,
+      "memoryReservation": 512,
+      "essential": true
+    }
+  ],
+  "cpu": "256",
+  "memory": "512",
+  "requiresCompatibilities": [
+    "EC2"
+  ],
+  "executionRoleArn": "arn:aws:iam:::executionRole/testExecutionRole:1",
+  "networkMode": "bridge",
+  "taskRoleArn" : "arn:aws:iam:::role/testTaskRole:1"
+}

--- a/clouddriver-ecs/src/integration/resources/testoperations/createServerGroup-artifact-EC2-TGMappings-multipleLBsAndContainers.json
+++ b/clouddriver-ecs/src/integration/resources/testoperations/createServerGroup-artifact-EC2-TGMappings-multipleLBsAndContainers.json
@@ -1,0 +1,53 @@
+{
+  "account": "ecs-account",
+  "application": "ecs",
+  "availabilityZones": {
+    "us-west-2": [
+      "us-west-2a",
+      "us-west-2c"
+    ]
+  },
+  "capacity": {
+    "desired": 1,
+    "max": 1,
+    "min": 1
+  },
+  "cloudProvider": "ecs",
+  "computeUnits": 256,
+  "credentials": "ecs-account",
+  "dockerImageAddress": "nginx",
+  "ecsClusterName": "integArtifactEC2TgMappingskWithMultipleLBsAndContainers-cluster",
+  "launchType": "EC2",
+  "networkMode": "bridge",
+  "placementStrategySequence": [],
+  "reservedMemory": 512,
+  "stack": "integArtifactsEC2TgMappingsStackWithMultipleLBsAndContainers",
+  "freeFormDetails" : "detailTest",
+  "targetGroupMappings": [
+    {
+      "containerName": "application1",
+      "containerPort": 80,
+      "targetGroup": "integArtifactEC2TgMappings-targetGroupForPort80"
+    },
+    {
+      "containerName": "application2",
+      "containerPort": 84,
+      "targetGroup": "integArtifactEC2TgMappings-targetGroupForPort84"
+    }
+  ],
+  "useTaskDefinitionArtifact" : true,
+  "taskDefinitionArtifactAccount"  :  "my-github",
+  "resolvedTaskDefinitionArtifact": {
+    "account": "ecs-account",
+    "type": "ecs",
+    "customKind" :  true,
+    "name" : "applications",
+    "location" : "us-west-2",
+    "reference" : "refernce",
+    "metadata" : null,
+    "artifactAccount" : "my-github",
+    "provenance" : "prov",
+    "uuid" : "uid-123"
+  },
+  "containerToImageMap": {}
+}


### PR DESCRIPTION
This PR contains integration test for Create Server Group Operation for the task definition artifact, EC2 launch type, and target group mappings with multiple load balancers and multiple containers.