### PR TITLE
feat(aws): Add filtering of AutoScalingGroups to include/exclude based on Tags

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCachingAgentFilterConfiguration.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCachingAgentFilterConfiguration.java
@@ -1,0 +1,57 @@
+package com.netflix.spinnaker.clouddriver.aws.provider.agent;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("aws.caching.filter")
+public class AmazonCachingAgentFilterConfiguration {
+
+  List<TagFilterOption> includeTags;
+  List<TagFilterOption> excludeTags;
+
+  public static class TagFilterOption {
+    String name;
+    String value;
+
+    public TagFilterOption() {}
+
+    public TagFilterOption(String name, String value) {
+      this.name = name;
+      this.value = value;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+  }
+
+  public List<TagFilterOption> getIncludeTags() {
+    return includeTags;
+  }
+
+  public void setIncludeTags(List<TagFilterOption> includeTags) {
+    this.includeTags = includeTags;
+  }
+
+  public List<TagFilterOption> getExcludeTags() {
+    return excludeTags;
+  }
+
+  public void setExcludeTags(List<TagFilterOption> excludeTags) {
+    this.excludeTags = excludeTags;
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider;
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider;
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider;
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonApplicationLoadBalancerCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCachingAgentFilterConfiguration;
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCertificateCachingAgent;
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCloudFormationCachingAgent;
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonElasticIpCachingAgent;
@@ -122,6 +123,7 @@ public class ProviderHelpers {
       ObjectMapper objectMapper,
       Registry registry,
       EddaTimeoutConfig eddaTimeoutConfig,
+      AmazonCachingAgentFilterConfiguration amazonCachingAgentFilterConfiguration,
       AwsProvider awsProvider,
       AmazonCloudProvider amazonCloudProvider,
       DynamicConfigService dynamicConfigService,
@@ -143,7 +145,8 @@ public class ProviderHelpers {
                 region.getName(),
                 objectMapper,
                 registry,
-                eddaTimeoutConfig));
+                eddaTimeoutConfig,
+                amazonCachingAgentFilterConfiguration));
         newlyAddedAgents.add(
             new LaunchConfigCachingAgent(
                 amazonClientProvider, credentials, region.getName(), objectMapper, registry));

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandler.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.aws.edda.EddaApiFactory;
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider;
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider;
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCachingAgentFilterConfiguration;
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.ImageCachingAgent;
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservationReportCachingAgent;
 import com.netflix.spinnaker.clouddriver.aws.provider.config.ProviderHelpers;
@@ -73,6 +74,7 @@ public class AmazonCredentialsLifecycleHandler
   private final Optional<ExecutorService> reservationReportPool;
   private final Optional<Collection<AgentProvider>> agentProviders;
   private final EddaTimeoutConfig eddaTimeoutConfig;
+  private final AmazonCachingAgentFilterConfiguration amazonCachingAgentFilterConfiguration;
   private final DynamicConfigService dynamicConfigService;
   private final DeployDefaults deployDefaults;
   private final CredentialsRepository<NetflixAmazonCredentials>
@@ -175,6 +177,7 @@ public class AmazonCredentialsLifecycleHandler
             objectMapper,
             registry,
             eddaTimeoutConfig,
+            amazonCachingAgentFilterConfiguration,
             awsProvider,
             amazonCloudProvider,
             dynamicConfigService,

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgentSpec.groovy
@@ -17,8 +17,12 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
+import com.amazonaws.services.autoscaling.AmazonAutoScaling
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup
+import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
+import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsResult
 import com.amazonaws.services.autoscaling.model.SuspendedProcess
+import com.amazonaws.services.autoscaling.model.TagDescription
 import com.amazonaws.services.ec2.AmazonEC2
 import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer
 import com.netflix.spectator.api.Spectator
@@ -60,6 +64,9 @@ class ClusterCachingAgentSpec extends Specification {
   @Shared
   EddaTimeoutConfig edda = Mock(EddaTimeoutConfig)
 
+  @Shared
+  AmazonCachingAgentFilterConfiguration filterConfiguration = new AmazonCachingAgentFilterConfiguration()
+
   def getAgent() {
     def creds = Stub(NetflixAmazonCredentials) {
       getName() >> accountName
@@ -69,7 +76,7 @@ class ClusterCachingAgentSpec extends Specification {
     def client = Stub(AmazonClientProvider) {
       getAmazonEC2(creds, region, _) >> ec2
     }
-    new ClusterCachingAgent(cloud, client, creds, region, AmazonObjectMapperConfigurer.createConfigured(), Spectator.globalRegistry(), edda)
+    new ClusterCachingAgent(cloud, client, creds, region, AmazonObjectMapperConfigurer.createConfigured(), Spectator.globalRegistry(), edda, filterConfiguration)
   }
 
   @Unroll
@@ -135,6 +142,62 @@ class ClusterCachingAgentSpec extends Specification {
 
     then:
     result.authoritativeTypes as Set == ["clusters", "serverGroups", "applications"] as Set
+  }
+
+  void "asg should filter excluded tags"() {
+    given:
+    def agent = getAgent()
+    def client = Stub(AmazonClientProvider) {
+      getAutoScaling(_, _, _) >> Stub(AmazonAutoScaling) {
+        describeAutoScalingGroups(_) >> new DescribeAutoScalingGroupsResult() {
+          List<AutoScalingGroup> getAutoScalingGroups() {
+            return filterableASGs
+          }
+        }
+      }
+    }
+
+    def clients = new ClusterCachingAgent.AmazonClients(client, agent.account, agent.region, false)
+    filterConfiguration.includeTags = includeTags
+    filterConfiguration.excludeTags = excludeTags
+
+    when:
+    def result = agent.loadAutoScalingGroups(clients)
+
+    then:
+    result.asgs*.autoScalingGroupName == expected
+
+    where:
+    includeTags                   | excludeTags                   | expected
+    null                          | null                          | filterableASGs*.autoScalingGroupName
+    [taggify("hello")]            | null                          | ["test-hello-tag-value", "test-hello-tag-value-different", "test-hello-tag-no-value"]
+    [taggify("hello", "goodbye")] | null                          | ["test-hello-tag-value"]
+    [taggify("hello", "goo")]     | null                          | []
+    [taggify("hello", ".*bye")]   | null                          | ["test-hello-tag-value"]
+    [taggify(".*a.*")]            | null                          | ["test-no-hello-tag"]
+    null                          | [taggify("hello")]            | ["test-no-hello-tag"]
+    null                          | [taggify("hello", "goodbye")] | ["test-hello-tag-value-different", "test-hello-tag-no-value", "test-no-hello-tag"]
+    [taggify("hello", "goodbye")] | [taggify("hello")]            | []
+    [taggify(".*", "ciao")]       | [taggify("hello", ".*")]      | []
+  }
+
+  private static final List<AutoScalingGroup> filterableASGs = [
+    new AutoScalingGroup()
+      .withAutoScalingGroupName("test-hello-tag-value")
+      .withTags(new TagDescription().withKey("hello").withValue("goodbye")),
+    new AutoScalingGroup()
+      .withAutoScalingGroupName("test-hello-tag-value-different")
+      .withTags(new TagDescription().withKey("hello").withValue("ciao")),
+    new AutoScalingGroup()
+      .withAutoScalingGroupName("test-hello-tag-no-value")
+      .withTags(new TagDescription().withKey("hello")),
+    new AutoScalingGroup()
+      .withAutoScalingGroupName("test-no-hello-tag")
+      .withTags(new TagDescription().withKey("Name")),
+  ]
+
+  private static def taggify(String name = null, String value = null) {
+    return new AmazonCachingAgentFilterConfiguration.TagFilterOption(name, value)
   }
 
   private SuspendedProcess sP(String processName) {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandlerSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandlerSpec.groovy
@@ -76,7 +76,7 @@ class AmazonCredentialsLifecycleHandlerSpec extends Specification {
     def imageCachingAgentTwo = new ImageCachingAgent(null, credTwo, "us-east-1", objectMapper, null, false, null)
     awsProvider.addAgents([imageCachingAgentOne, imageCachingAgentTwo])
     def handler = new AmazonCredentialsLifecycleHandler(awsCleanupProvider, awsInfrastructureProvider, awsProvider,
-      null, null, null, null, objectMapper, null, null, null, null, null, null, null, null, null,
+      null, null, null, null, objectMapper, null, null, null, null, null, null, null, null, null, null,
       credentialsRepository)
 
     when:
@@ -94,7 +94,7 @@ class AmazonCredentialsLifecycleHandlerSpec extends Specification {
     def imageCachingAgentTwo = new ImageCachingAgent(null, credTwo, "us-east-1", objectMapper, null, false, null)
     awsProvider.addAgents([imageCachingAgentOne, imageCachingAgentTwo])
     def handler = new AmazonCredentialsLifecycleHandler(awsCleanupProvider, awsInfrastructureProvider, awsProvider,
-      null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+      null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
       credentialsRepository)
     handler.publicRegions.add("us-west-2")
 
@@ -111,7 +111,7 @@ class AmazonCredentialsLifecycleHandlerSpec extends Specification {
       getAmazonEC2(_, _) >> amazonEC2
     }
     def handler = new AmazonCredentialsLifecycleHandler(awsCleanupProvider, awsInfrastructureProvider, awsProvider,
-      amazonCloudProvider, amazonClientProvider, null, null, objectMapper, null, eddaApiFactory, null, registry, reservationReportPool, agentProviders, null, dynamicConfigService, deployDefaults,
+      amazonCloudProvider, amazonClientProvider, null, null, objectMapper, null, eddaApiFactory, null, registry, reservationReportPool, agentProviders, null, null, dynamicConfigService, deployDefaults,
       credentialsRepository)
     def credThree = TestCredential.named('three')
 
@@ -132,7 +132,7 @@ class AmazonCredentialsLifecycleHandlerSpec extends Specification {
 
   def 'subsequent call should not add reservation caching agents'() {
     def handler = new AmazonCredentialsLifecycleHandler(awsCleanupProvider, awsInfrastructureProvider, awsProvider,
-      amazonCloudProvider, null, null, null, objectMapper, null, eddaApiFactory, null, registry, reservationReportPool, agentProviders, null, dynamicConfigService, deployDefaults,
+      amazonCloudProvider, null, null, null, objectMapper, null, eddaApiFactory, null, registry, reservationReportPool, agentProviders, null, null, dynamicConfigService, deployDefaults,
       credentialsRepository)
     def credThree = TestCredential.named('three')
     handler.reservationReportCachingAgentScheduled = true
@@ -157,7 +157,7 @@ class AmazonCredentialsLifecycleHandlerSpec extends Specification {
       getAmazonEC2(_, _) >> amazonEC2
     }
     def handler = new AmazonCredentialsLifecycleHandler(awsCleanupProvider, awsInfrastructureProvider, awsProvider,
-      amazonCloudProvider, amazonClientProvider, null, null, objectMapper, null, eddaApiFactory, null, registry, reservationReportPool, agentProviders, null, dynamicConfigService, deployDefaults,
+      amazonCloudProvider, amazonClientProvider, null, null, objectMapper, null, eddaApiFactory, null, registry, reservationReportPool, agentProviders, null, null, dynamicConfigService, deployDefaults,
       credentialsRepository)
     def credThree = TestCredential.named('three')
     handler.credentialsAdded(credThree)


### PR DESCRIPTION
This provides a filtering mechanism to include/exclude AutoScalingGroups based on configured name/value pairs. The intent of naming the filter configuration `AmazonCachingAgentFilterConfiguration` is to allow it to be reused for different agent filtering (load balancers etc).

This is needed to allow for a subset of AWS resources to be managed by Spinnaker (for our environment, exclude is enough, but added include for other use cases).