### PR TITLE
fix(dynamicAccounts): Included java files in source set

### DIFF
--- a/clouddriver-configserver/clouddriver-configserver.gradle
+++ b/clouddriver-configserver/clouddriver-configserver.gradle
@@ -2,6 +2,12 @@ apply plugin: 'java-library'
 
 tasks.compileGroovy.enabled=false
 
+sourceSets {
+  main {
+    java.srcDirs = ['src/main/java']
+  }
+}
+
 dependencies {
   compileOnly "org.projectlombok:lombok"
   annotationProcessor "org.projectlombok:lombok"

--- a/clouddriver-configserver/src/main/java/com/netflix/spinnaker/clouddriver/cache/CloudConfigRefreshConfig.java
+++ b/clouddriver-configserver/src/main/java/com/netflix/spinnaker/clouddriver/cache/CloudConfigRefreshConfig.java
@@ -40,6 +40,8 @@ import org.springframework.context.annotation.*;
 @EnableConfigurationProperties(CloudConfigRefreshProperties.class)
 public class CloudConfigRefreshConfig {
 
+  private DoesntExist doesntExist;
+
   @Configuration
   @Conditional(RemoteConfigSourceConfigured.class)
   @EnableConfigServer

--- a/clouddriver-configserver/src/main/java/com/netflix/spinnaker/clouddriver/cache/CloudConfigRefreshConfig.java
+++ b/clouddriver-configserver/src/main/java/com/netflix/spinnaker/clouddriver/cache/CloudConfigRefreshConfig.java
@@ -40,8 +40,6 @@ import org.springframework.context.annotation.*;
 @EnableConfigurationProperties(CloudConfigRefreshProperties.class)
 public class CloudConfigRefreshConfig {
 
-  private DoesntExist doesntExist;
-
   @Configuration
   @Conditional(RemoteConfigSourceConfigured.class)
   @EnableConfigServer


### PR DESCRIPTION
The module `clouddriver-configserver` is misconfigured. It doesn't detect the source files in `src/main/java`. As a result, the jar file `clouddriver-configserver.jar` produced in builds lacks any java classes.

This can be easily verified if whithout this fix, you introduce a compilation error in `CloudConfigRefreshConfig` and run `./gradlew build -x test`, as it builds successfully.

Closes https://github.com/spinnaker/spinnaker/issues/6128
