### PR TITLE
fix(ecs): Ensure null is returned when account does not exist

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsAccountMapper.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsAccountMapper.java
@@ -60,7 +60,11 @@ public class EcsAccountMapper {
   }
 
   public NetflixECSCredentials fromAwsAccountNameToEcs(String awsAccountName) {
-    return credentialsRepository.getOne(ecsCredentialsMap.get(awsAccountName));
+    String ecsAccountName = ecsCredentialsMap.get(awsAccountName);
+    if (ecsAccountName == null) {
+      return null;
+    }
+    return credentialsRepository.getOne(ecsAccountName);
   }
 
   public NetflixAmazonCredentials fromEcsAccountNameToAws(String ecsAccountName) {

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsAccountMapperSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsAccountMapperSpec.groovy
@@ -82,4 +82,15 @@ class EcsAccountMapperSpec extends Specification {
     !ecsAccountMapper.ecsCredentialsMap.containsKey(ecsAccountName)
     !ecsAccountMapper.awsCredentialsMap.containsKey(awsAccount)
   }
+
+  def 'should return null if provided name is invalid'() {
+    given:
+    def ecsAccountMapper = new EcsAccountMapper(credentialsRepository, compositeCredentialsRepository)
+
+    when:
+    def result = ecsAccountMapper.fromAwsAccountNameToEcs("invalid")
+
+    then:
+    result == null
+  }
 }


### PR DESCRIPTION
This addresses an issue where call to` /securityGroups` fails when a ECS account was removed but security group information is still in cache. 