### PR TITLE
fix(kubernetes): k8s event timestamp should be null safe

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesManifestContainerBuilder.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesManifestContainerBuilder.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.moniker.Moniker;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -45,7 +46,11 @@ final class KubernetesManifestContainerBuilder {
     KubernetesResourceProperties properties = credentials.getResourcePropertyRegistry().get(kind);
 
     Function<KubernetesManifest, String> lastEventTimestamp =
-        (m) -> (String) m.getOrDefault("lastTimestamp", m.getOrDefault("firstTimestamp", "n/a"));
+        (m) ->
+            Optional.ofNullable(
+                    (String)
+                        m.getOrDefault("lastTimestamp", m.getOrDefault("firstTimestamp", "n/a")))
+                .orElse("n/a");
 
     events =
         events.stream()


### PR DESCRIPTION
In some cases k8s api returns `lastTimestamp` with null value causing the `ManifestBuilder` to throw nullPointerException.
Made `lastEventTimestamp` optional and set default value for usecases when the key exists in the map but is null

Issue: https://github.com/spinnaker/spinnaker/issues/6181