### PR TITLE
fix(agents): Add additional cleanup agents when agentScheduler is null

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
@@ -256,7 +256,7 @@ public class ProviderHelpers {
         }
       }
     }
-    if (awsCleanupProvider.getAgentScheduler() != null) {
+    if (awsCleanupProvider.getAgentScheduler() == null) {
       if (awsConfigurationProperties.getCleanup().getAlarms().getEnabled()) {
         newlyAddedAgents.add(
             new CleanupAlarmsAgent(

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandlerSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandlerSpec.groovy
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.cats.agent.AgentProvider
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.edda.EddaApiFactory
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider
@@ -63,6 +64,8 @@ class AmazonCredentialsLifecycleHandlerSpec extends Specification {
     Mock(ExecutorService)
   )
   def deployDefaults = new  AwsConfiguration.DeployDefaults()
+
+  def awsConfigurationProperties = new AwsConfigurationProperties()
 
   def setup() {
     awsCleanupProvider = new AwsCleanupProvider()
@@ -111,7 +114,7 @@ class AmazonCredentialsLifecycleHandlerSpec extends Specification {
       getAmazonEC2(_, _) >> amazonEC2
     }
     def handler = new AmazonCredentialsLifecycleHandler(awsCleanupProvider, awsInfrastructureProvider, awsProvider,
-      amazonCloudProvider, amazonClientProvider, null, null, objectMapper, null, eddaApiFactory, null, registry, reservationReportPool, agentProviders, null, null, dynamicConfigService, deployDefaults,
+      amazonCloudProvider, amazonClientProvider, null, awsConfigurationProperties, objectMapper, null, eddaApiFactory, null, registry, reservationReportPool, agentProviders, null, null, dynamicConfigService, deployDefaults,
       credentialsRepository)
     def credThree = TestCredential.named('three')
 
@@ -132,7 +135,7 @@ class AmazonCredentialsLifecycleHandlerSpec extends Specification {
 
   def 'subsequent call should not add reservation caching agents'() {
     def handler = new AmazonCredentialsLifecycleHandler(awsCleanupProvider, awsInfrastructureProvider, awsProvider,
-      amazonCloudProvider, null, null, null, objectMapper, null, eddaApiFactory, null, registry, reservationReportPool, agentProviders, null, null, dynamicConfigService, deployDefaults,
+      amazonCloudProvider, null, null, awsConfigurationProperties, objectMapper, null, eddaApiFactory, null, registry, reservationReportPool, agentProviders, null, null, dynamicConfigService, deployDefaults,
       credentialsRepository)
     def credThree = TestCredential.named('three')
     handler.reservationReportCachingAgentScheduled = true
@@ -157,7 +160,7 @@ class AmazonCredentialsLifecycleHandlerSpec extends Specification {
       getAmazonEC2(_, _) >> amazonEC2
     }
     def handler = new AmazonCredentialsLifecycleHandler(awsCleanupProvider, awsInfrastructureProvider, awsProvider,
-      amazonCloudProvider, amazonClientProvider, null, null, objectMapper, null, eddaApiFactory, null, registry, reservationReportPool, agentProviders, null, null, dynamicConfigService, deployDefaults,
+      amazonCloudProvider, amazonClientProvider, null, awsConfigurationProperties, objectMapper, null, eddaApiFactory, null, registry, reservationReportPool, agentProviders, null, null, dynamicConfigService, deployDefaults,
       credentialsRepository)
     def credThree = TestCredential.named('three')
     handler.credentialsAdded(credThree)


### PR DESCRIPTION
https://github.com/spinnaker/clouddriver/pull/5021 got this conditional backwards when adding additional cleanup agents.

Original conditional: https://github.com/spinnaker/clouddriver/pull/5021/files#diff-7a2ba10435894f582c87b3d6868072fea5ce68217d051fd739e7305e3998e3dbL246

Which was changed to: https://github.com/spinnaker/clouddriver/pull/5021/files#diff-e2d08201e4229c88257693e056afb5516a3fe2004c08b40cea98a1fb300a2c9bR256

This restores to the correct conditional.