### PR TITLE
fix(serverGroup): Set instanceType in view model for asgs with launch…

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
@@ -142,6 +142,9 @@ class ServerGroupController {
         sg.instanceType = serverGroup.launchConfig.instanceType
       }
     }
+    if (serverGroup.launchTemplate && serverGroup.launchTemplate.launchTemplateData) {
+      instanceType = serverGroup.launchTemplate.launchTemplateData.instanceType
+    }
     sg.account = cluster.accountName
 
     return sg
@@ -304,6 +307,11 @@ class ServerGroupController {
           instanceType = serverGroup.launchConfig.instanceType
         }
       }
+
+      if (serverGroup.launchTemplate && serverGroup.launchTemplate.launchTemplateData) {
+        instanceType = serverGroup.launchTemplate.launchTemplateData.instanceType
+      }
+
       if (serverGroup.tags) {
         tags = serverGroup.tags
       }


### PR DESCRIPTION
The `ServerGroupViewModel` only set the instance type if the ASG was backed by a launch config. This affected filtering by `instanceType`, since the type was undefined for any asg backed by a launch template.

Note: The `instanceType` was set in AWS at the launch template level, just not on Spinnaker's view model. 