### PR TITLE
fix(saga): In reality, the argument to `parseSagaResult` can be `null`

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/sagas/AbstractSagaAtomicOperation.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/sagas/AbstractSagaAtomicOperation.java
@@ -64,7 +64,7 @@ public abstract class AbstractSagaAtomicOperation<T, SR, R>
    * Provides the opportunity to convert a {@link SagaAction.Result} into the expected result type
    * of the AtomicOperation.
    */
-  protected abstract R parseSagaResult(@Nonnull SR result);
+  protected abstract R parseSagaResult(SR result);
 
   @Override
   public R operate(List priorOutputs) {

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/provider/agent/EurekaCachingAgent.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/provider/agent/EurekaCachingAgent.groovy
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.clouddriver.eureka.model.EurekaApplication
 import com.netflix.spinnaker.clouddriver.eureka.model.EurekaApplications
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.util.logging.Slf4j
 
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH
@@ -93,7 +94,9 @@ class EurekaCachingAgent implements CachingAgent, HealthProvidingCachingAgent, C
   @Override
   CacheResult loadData(ProviderCache providerCache) {
     log.info("Describing items in ${agentType}")
-    EurekaApplications disco = retry.retry({ eurekaApi.loadEurekaApplications() }, 3, 100, false)
+    EurekaApplications disco = AuthenticatedRequest.allowAnonymous({
+      retry.retry({ eurekaApi.loadEurekaApplications() }, 3, 100, false)
+    })
 
     Map<String, Set<String>> instanceHealthRelationships = [:].withDefault { new HashSet<String>() }
     Map<String, List<CacheData>> eurekaInstances = [:].withDefault { [] }


### PR DESCRIPTION
Uncovered this while implementing a saga in Kotlin which is a little more sticky about
arguments and return types that are marked `@Nonnull`.
