### PR TITLE
fix(aws): Better support for serializing `instanceType`

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
@@ -133,6 +133,11 @@ class AmazonServerGroup implements ServerGroup, Serializable {
   }
 
   @Override
+  String getInstanceType() {
+    return launchConfig?.instanceType ?: ((Map<String, String>)launchTemplate?.launchTemplateData)?.instanceType
+  }
+
+  @Override
   ServerGroup.InstanceCounts getInstanceCounts() {
     Collection<Instance> instances = getInstances()
     new ServerGroup.InstanceCounts(

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroup.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroup.java
@@ -123,6 +123,10 @@ public interface ServerGroup {
   @Empty
   Map<String, Object> getLaunchConfig();
 
+  default String getInstanceType() {
+    return null;
+  }
+
   /**
    * A collection of attributes describing the tags of this server group
    *

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
@@ -134,17 +134,6 @@ class ServerGroupController {
     sg.application = moniker.app
     sg.stack = moniker.stack
     sg.freeFormDetail = moniker.detail
-
-    //The following fields exist in the non-expanded result and so even though there is some
-    //minor data duplication here it seems reasonable to also set these fields in the expanded result.
-    if (serverGroup.launchConfig) {
-      if (serverGroup.launchConfig.instanceType) {
-        sg.instanceType = serverGroup.launchConfig.instanceType
-      }
-    }
-    if (serverGroup.launchTemplate && serverGroup.launchTemplate.launchTemplateData) {
-      instanceType = serverGroup.launchTemplate.launchTemplateData.instanceType
-    }
     sg.account = cluster.accountName
 
     return sg
@@ -301,16 +290,8 @@ class ServerGroupController {
       securityGroups = serverGroup.getSecurityGroups()
       loadBalancers = serverGroup.getLoadBalancers()
       serverGroupManagers = serverGroup.getServerGroupManagers()
+      instanceType = serverGroup.getInstanceType()
       moniker = serverGroup.getMoniker()
-      if (serverGroup.launchConfig) {
-        if (serverGroup.launchConfig.instanceType) {
-          instanceType = serverGroup.launchConfig.instanceType
-        }
-      }
-
-      if (serverGroup.launchTemplate && serverGroup.launchTemplate.launchTemplateData) {
-        instanceType = serverGroup.launchTemplate.launchTemplateData.instanceType
-      }
 
       if (serverGroup.tags) {
         tags = serverGroup.tags


### PR DESCRIPTION
Moves the instance type determination (launch config vs template) to the `AmazonServerGroup`
and out of the `ServerGroupController`.
