### PR TITLE
fix(sql): Permanently skip postgres field migration when not using postgres

### DIFF
--- a/clouddriver-sql/src/main/resources/db/changelog/20201110-field-type-postgres.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog/20201110-field-type-postgres.yml
@@ -1,7 +1,7 @@
 databaseChangeLog:
   - changeSet:
       preConditions:
-        onFail: CONTINUE
+        onFail: MARK_RAN
         dbms:
           type: postgresql
       id: change-field-types-postgresql


### PR DESCRIPTION
Fix of the migration added in https://github.com/spinnaker/clouddriver/pull/5097