### PR TITLE
feat(ecs): Improve task definition cache

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/AbstractCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/AbstractCacheClient.java
@@ -24,8 +24,11 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 abstract class AbstractCacheClient<T> {
+  private final Logger log = LoggerFactory.getLogger(getClass());
 
   private final String keyNamespace;
   protected final Cache cacheView;
@@ -89,6 +92,7 @@ abstract class AbstractCacheClient<T> {
    * @return
    */
   private Collection<CacheData> fetchFromCache(String account, String region) {
+    log.debug("fetching all for account '{}' and region '{}'", account, region);
     String accountFilter = account != null ? account + Keys.SEPARATOR : "*" + Keys.SEPARATOR;
     String regionFilter = region != null ? region + Keys.SEPARATOR : "*" + Keys.SEPARATOR;
     Set<String> keys = new HashSet<>();


### PR DESCRIPTION
* cache only task definitions associated with ECS services

Addresses https://github.com/spinnaker/spinnaker/issues/6063

This change reduces the number of unnecessary cache entries held by Spinnaker and, as a result, the number of `ecs:*TaskDefinition` API calls needed to populate the cache. 

### Testing

Testing in an account with ~1000 task definitions (not necessarily associated w/ services) shows a reduction in the # of calls made to ECS during regular caching agent execution.

* 0 `DescribeTaskDefinition` calls were made during registrations of task defs NOT associated w/ a service (vs. ~1000 w/ previous version)
* 0 `ListTaskDefinition` calls made during a 30 window where no deployments were happening (vs. ~300 w/ previous version).
* Pipeline deployments succeed in slightly shorter (maybe negligible) amount of time (NOTE: test account only held ~10 services)

