### PR TITLE
fix(titus): Remove use of account credentials provider in Titus validators

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/AbstractTitusDescriptionValidatorSupport.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/AbstractTitusDescriptionValidatorSupport.groovy
@@ -25,11 +25,9 @@ import com.netflix.spinnaker.clouddriver.titus.deploy.description.AbstractTitusC
 
 abstract class AbstractTitusDescriptionValidatorSupport<T extends AbstractTitusCredentialsDescription> extends DescriptionValidator<T> {
 
-  private final AccountCredentialsProvider accountCredentialsProvider
   private final String descriptionName
 
-  AbstractTitusDescriptionValidatorSupport(AccountCredentialsProvider accountCredentialsProvider, String descriptionName) {
-    this.accountCredentialsProvider = accountCredentialsProvider
+  AbstractTitusDescriptionValidatorSupport(String descriptionName) {
     this.descriptionName = descriptionName
   }
 
@@ -38,17 +36,11 @@ abstract class AbstractTitusDescriptionValidatorSupport<T extends AbstractTitusC
     if (!description.credentials) {
       errors.rejectValue "credentials", "${descriptionName}.credentials.empty"
     } else {
-      def credentials = getAccountCredentials(description?.credentials?.name)
-      if (!(credentials instanceof NetflixTitusCredentials)) {
+      if (!(description?.credentials instanceof NetflixTitusCredentials)) {
         errors.rejectValue("credentials", "${descriptionName}.credentials.invalid")
       }
     }
   }
-
-  AccountCredentials getAccountCredentials(String accountName) {
-    accountCredentialsProvider.getCredentials(accountName)
-  }
-
 
   static <T> void validateRegion(T description, String regionName, String errorKey, ValidationErrors errors) {
     validateRegions(description, regionName ? [regionName] : [], errorKey, errors, "region")

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DestroyTitusJobDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DestroyTitusJobDescriptionValidator.groovy
@@ -29,8 +29,8 @@ import org.springframework.stereotype.Component
 @TitusOperation(AtomicOperations.DESTROY_JOB)
 class DestroyTitusJobDescriptionValidator extends AbstractTitusDescriptionValidatorSupport<DestroyTitusJobDescription> {
 
-  DestroyTitusJobDescriptionValidator(AccountCredentialsProvider accountCredentialsProvider) {
-    super(accountCredentialsProvider, "destroyTitusJobDescription")
+  DestroyTitusJobDescriptionValidator() {
+    super("destroyTitusJobDescription")
   }
 
   @Override
@@ -40,9 +40,7 @@ class DestroyTitusJobDescriptionValidator extends AbstractTitusDescriptionValida
     if (!description.region) {
       errors.rejectValue "region", "destroyTitusJobDescription.region.empty"
     }
-
-    def credentials = getAccountCredentials(description?.credentials?.name)
-    if (credentials && !((NetflixTitusCredentials) credentials).regions.name.contains(description.region)) {
+    if (description?.credentials && !((NetflixTitusCredentials) description?.credentials).regions.name.contains(description.region)) {
       errors.rejectValue "region", "destroyTitusJobDescription.region.not.configured", description.region, "Region not configured"
     }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DestroyTitusServerGroupDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DestroyTitusServerGroupDescriptionValidator.groovy
@@ -30,8 +30,8 @@ import org.springframework.stereotype.Component
 class DestroyTitusServerGroupDescriptionValidator extends AbstractTitusDescriptionValidatorSupport<DestroyTitusServerGroupDescription> {
 
   @Autowired
-  DestroyTitusServerGroupDescriptionValidator(AccountCredentialsProvider accountCredentialsProvider) {
-    super(accountCredentialsProvider, "destroyTitusServerGroupDescription")
+  DestroyTitusServerGroupDescriptionValidator() {
+    super("destroyTitusServerGroupDescription")
   }
 
   @Override
@@ -43,8 +43,7 @@ class DestroyTitusServerGroupDescriptionValidator extends AbstractTitusDescripti
       errors.rejectValue "region", "destroyTitusServerGroupDescription.region.empty"
     }
 
-    def credentials = getAccountCredentials(description?.credentials?.name)
-    if (credentials && !((NetflixTitusCredentials) credentials).regions.name.contains(description.region)) {
+    if (description?.credentials && !((NetflixTitusCredentials) description?.credentials).regions.name.contains(description.region)) {
       errors.rejectValue "region", "destroyTitusServerGroupDescription.region.not.configured", description.region, "Region not configured"
     }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DisableTitusInstancesInDiscoveryDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DisableTitusInstancesInDiscoveryDescriptionValidator.groovy
@@ -30,8 +30,8 @@ class DisableTitusInstancesInDiscoveryDescriptionValidator
   extends AbstractTitusDescriptionValidatorSupport<EnableDisableInstanceDiscoveryDescription> {
 
   @Autowired
-  DisableTitusInstancesInDiscoveryDescriptionValidator(AccountCredentialsProvider accountCredentialsProvider) {
-    super(accountCredentialsProvider, "disableInstacesInDiscoveryDescription")
+  DisableTitusInstancesInDiscoveryDescriptionValidator() {
+    super("disableInstacesInDiscoveryDescription")
   }
 
   @Override

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DisableTitusServerGroupDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DisableTitusServerGroupDescriptionValidator.groovy
@@ -30,8 +30,8 @@ import org.springframework.stereotype.Component
 class DisableTitusServerGroupDescriptionValidator extends AbstractTitusDescriptionValidatorSupport<EnableDisableServerGroupDescription> {
 
   @Autowired
-  DisableTitusServerGroupDescriptionValidator(AccountCredentialsProvider accountCredentialsProvider) {
-    super(accountCredentialsProvider, "disableTitusServerGroupDescription")
+  DisableTitusServerGroupDescriptionValidator() {
+    super("disableTitusServerGroupDescription")
   }
 
   @Override
@@ -43,8 +43,7 @@ class DisableTitusServerGroupDescriptionValidator extends AbstractTitusDescripti
       errors.rejectValue "region", "disableTitusServerGroupDescription.region.empty"
     }
 
-    def credentials = getAccountCredentials(description?.credentials?.name)
-    if (credentials && !((NetflixTitusCredentials) credentials).regions.name.contains(description.region)) {
+    if (description?.credentials && !((NetflixTitusCredentials) description?.credentials).regions.name.contains(description.region)) {
       errors.rejectValue "region", "disableTitusServerGroupDescription.region.not.configured", description.region, "Region not configured"
     }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/EnableTitusInstancesInDiscoveryDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/EnableTitusInstancesInDiscoveryDescriptionValidator.groovy
@@ -29,8 +29,8 @@ import org.springframework.stereotype.Component
 class EnableTitusInstancesInDiscoveryDescriptionValidator extends AbstractTitusDescriptionValidatorSupport<EnableDisableInstanceDiscoveryDescription> {
 
   @Autowired
-  EnableTitusInstancesInDiscoveryDescriptionValidator(AccountCredentialsProvider accountCredentialsProvider) {
-    super(accountCredentialsProvider, "enableInstacesInDiscoveryDescription")
+  EnableTitusInstancesInDiscoveryDescriptionValidator() {
+    super("enableInstacesInDiscoveryDescription")
   }
 
   void validate(List priorDescriptions, EnableDisableInstanceDiscoveryDescription description, ValidationErrors errors) {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/ResizeTitusServerGroupDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/ResizeTitusServerGroupDescriptionValidator.groovy
@@ -30,8 +30,8 @@ import org.springframework.stereotype.Component
 class ResizeTitusServerGroupDescriptionValidator extends AbstractTitusDescriptionValidatorSupport<ResizeTitusServerGroupDescription> {
 
   @Autowired
-  ResizeTitusServerGroupDescriptionValidator(AccountCredentialsProvider accountCredentialsProvider) {
-    super(accountCredentialsProvider, "resizeTitusServerGroupDescription")
+  ResizeTitusServerGroupDescriptionValidator() {
+    super("resizeTitusServerGroupDescription")
   }
 
   @Override
@@ -43,8 +43,7 @@ class ResizeTitusServerGroupDescriptionValidator extends AbstractTitusDescriptio
       errors.rejectValue "region", "resizeTitusServerGroupDescription.region.empty"
     }
 
-    def credentials = getAccountCredentials(description?.credentials?.name)
-    if (credentials && !((NetflixTitusCredentials) credentials).regions.name.contains(description.region)) {
+    if (description?.credentials && !((NetflixTitusCredentials) description?.credentials).regions.name.contains(description.region)) {
       errors.rejectValue "region", "resizeTitusServerGroupDescription.region.not.configured", description.region, "Region not configured"
     }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/TerminateTitusInstancesDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/TerminateTitusInstancesDescriptionValidator.groovy
@@ -30,8 +30,8 @@ import org.springframework.stereotype.Component
 class TerminateTitusInstancesDescriptionValidator extends AbstractTitusDescriptionValidatorSupport<TerminateTitusInstancesDescription> {
 
   @Autowired
-  TerminateTitusInstancesDescriptionValidator(AccountCredentialsProvider accountCredentialsProvider) {
-    super(accountCredentialsProvider, "terminateTitusInstancesDescription")
+  TerminateTitusInstancesDescriptionValidator() {
+    super("terminateTitusInstancesDescription")
   }
 
   @Override
@@ -43,8 +43,7 @@ class TerminateTitusInstancesDescriptionValidator extends AbstractTitusDescripti
       errors.rejectValue "region", "terminateTitusInstancesDescription.region.empty"
     }
 
-    def credentials = getAccountCredentials(description?.credentials?.name)
-    if (credentials && !((NetflixTitusCredentials) credentials).regions.name.contains(description.region)) {
+    if (description?.credentials && !((NetflixTitusCredentials) description?.credentials).regions.name.contains(description.region)) {
       errors.rejectValue "region", "terminateTitusInstancesDescription.region.not.configured", description.region, "Region not configured"
     }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/TitusDeployDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/TitusDeployDescriptionValidator.groovy
@@ -30,8 +30,8 @@ import org.springframework.stereotype.Component
 class TitusDeployDescriptionValidator extends AbstractTitusDescriptionValidatorSupport<TitusDeployDescription> {
 
   @Autowired
-  TitusDeployDescriptionValidator(AccountCredentialsProvider accountCredentialsProvider) {
-    super(accountCredentialsProvider, "titusDeployDescription")
+  TitusDeployDescriptionValidator() {
+    super("titusDeployDescription")
   }
 
   @Override
@@ -43,8 +43,7 @@ class TitusDeployDescriptionValidator extends AbstractTitusDescriptionValidatorS
       errors.rejectValue "region", "titusDeployDescription.region.empty"
     }
 
-    def credentials = getAccountCredentials(description?.credentials?.name)
-    if (credentials && !((NetflixTitusCredentials) credentials).regions.name.contains(description.region)) {
+    if (description?.credentials && !((NetflixTitusCredentials) description?.credentials).regions.name.contains(description.region)) {
       errors.rejectValue "region", "titusDeployDescription.region.not.configured", "Region '${description.region}' not configured"
     }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/UpsertTitusScalingPolicyDescriptionValidator.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/UpsertTitusScalingPolicyDescriptionValidator.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.clouddriver.titus.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import com.netflix.spinnaker.clouddriver.titus.TitusOperation;
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.UpsertTitusScalingPolicyDescription;
 import java.util.List;
@@ -31,9 +30,8 @@ class UpsertTitusScalingPolicyDescriptionValidator
     extends AbstractTitusDescriptionValidatorSupport<UpsertTitusScalingPolicyDescription> {
 
   @Autowired
-  UpsertTitusScalingPolicyDescriptionValidator(
-      AccountCredentialsProvider accountCredentialsProvider) {
-    super(accountCredentialsProvider, "upsertTitusScalingPolicyDescription");
+  UpsertTitusScalingPolicyDescriptionValidator() {
+    super("upsertTitusScalingPolicyDescription");
   }
 
   @Override


### PR DESCRIPTION
In my atomic operation preprocessor spelunking I noticed we have some unnecessary code that provides a credentials object in a validator - not needed because we already have the credentials object on the atomic operation description.