### PR TITLE
feat(artifacts): dynamic artifact credentials via kork-credentials

### DIFF
--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -4,7 +4,6 @@ sourceSets.main.java.srcDirs = ['src/main/java']
 dependencies {
   implementation project(":clouddriver-api")
   implementation project(":clouddriver-core")
-  implementation project(":clouddriver-security")
 
   compileOnly "org.projectlombok:lombok"
   annotationProcessor "org.projectlombok:lombok"
@@ -35,12 +34,9 @@ dependencies {
 
   testImplementation "com.github.tomakehurst:wiremock:latest.release"
   testImplementation "org.assertj:assertj-core"
-  testImplementation "org.mockito:mockito-core"
   testImplementation "org.junit-pioneer:junit-pioneer:0.3.0"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "ru.lanwen.wiremock:wiremock-junit5:1.2.0"
-  testImplementation "org.springframework:spring-test"
-  testImplementation "org.springframework.boot:spring-boot-test"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -4,9 +4,11 @@ sourceSets.main.java.srcDirs = ['src/main/java']
 dependencies {
   implementation project(":clouddriver-api")
   implementation project(":clouddriver-core")
+  implementation project(":clouddriver-security")
 
   compileOnly "org.projectlombok:lombok"
   annotationProcessor "org.projectlombok:lombok"
+  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "com.amazonaws:aws-java-sdk-s3"
   implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
@@ -15,6 +17,7 @@ dependencies {
   implementation 'com.google.auth:google-auth-library-oauth2-http'
   implementation "com.netflix.frigga:frigga"
   implementation "com.netflix.spinnaker.kork:kork-artifacts"
+  implementation "com.netflix.spinnaker.kork:kork-credentials"
   implementation "com.netflix.spinnaker.kork:kork-annotations"
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation "com.netflix.spinnaker.kork:kork-security"
@@ -32,9 +35,12 @@ dependencies {
 
   testImplementation "com.github.tomakehurst:wiremock:latest.release"
   testImplementation "org.assertj:assertj-core"
+  testImplementation "org.mockito:mockito-core"
   testImplementation "org.junit-pioneer:junit-pioneer:0.3.0"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "ru.lanwen.wiremock:wiremock-junit5:1.2.0"
+  testImplementation "org.springframework:spring-test"
+  testImplementation "org.springframework.boot:spring-boot-test"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactCredentialsRepository.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactCredentialsRepository.java
@@ -17,55 +17,16 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts;
 
-import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
-import java.util.Collection;
-import java.util.Collections;
+import com.netflix.spinnaker.credentials.CompositeCredentialsRepository;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import lombok.Getter;
-import org.springframework.stereotype.Component;
 
-@Component
-public class ArtifactCredentialsRepository {
-  @Getter private final List<ArtifactCredentials> allCredentials;
+public class ArtifactCredentialsRepository
+    extends CompositeCredentialsRepository<ArtifactCredentials> {
 
-  public ArtifactCredentialsRepository(List<List<? extends ArtifactCredentials>> allCredentials) {
-    this.allCredentials =
-        Collections.unmodifiableList(
-            allCredentials.stream()
-                .filter(Objects::nonNull)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList()));
-  }
-
-  private ArtifactCredentials getCredentials(String accountName) {
-    return getAllCredentials().stream()
-        .filter(e -> e.getName().equals(accountName))
-        .findFirst()
-        .orElseThrow(
-            () ->
-                new IllegalArgumentException(
-                    "No credentials with name '" + accountName + "' could be found."));
-  }
-
-  public ArtifactCredentials getCredentials(String accountName, String type) {
-    if (Strings.isNullOrEmpty(accountName)) {
-      throw new IllegalArgumentException(
-          "An artifact account must be supplied to download this artifact: " + accountName);
-    }
-
-    ArtifactCredentials credentials = getCredentials(accountName);
-    if (!credentials.handlesType(type)) {
-      throw new IllegalArgumentException(
-          "Artifact credentials '"
-              + accountName
-              + "' cannot handle artifacts of type '"
-              + type
-              + "'");
-    }
-
-    return credentials;
+  public ArtifactCredentialsRepository(
+      List<CredentialsRepository<? extends ArtifactCredentials>> repositories) {
+    super(repositories);
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactDownloader.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactDownloader.java
@@ -18,6 +18,10 @@
 package com.netflix.spinnaker.clouddriver.artifacts;
 
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.exceptions.MissingCredentialsException;
+import com.netflix.spinnaker.kork.exceptions.UnknownCredentialsTypeException;
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import lombok.RequiredArgsConstructor;
@@ -29,8 +33,14 @@ public class ArtifactDownloader {
   private final ArtifactCredentialsRepository artifactCredentialsRepository;
 
   public InputStream download(Artifact artifact) throws IOException {
-    return artifactCredentialsRepository
-        .getCredentials(artifact.getArtifactAccount(), artifact.getType())
-        .download(artifact);
+    try {
+      return artifactCredentialsRepository
+          .getCredentials(artifact.getArtifactAccount(), artifact.getType())
+          .download(artifact);
+    } catch (UnknownCredentialsTypeException e) {
+      throw new InvalidRequestException(e);
+    } catch (MissingCredentialsException e) {
+      throw new NotFoundException(e);
+    }
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactAccount.java
@@ -29,7 +29,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-final class BitbucketArtifactAccount implements ArtifactAccount, BasicAuth {
+public class BitbucketArtifactAccount implements ArtifactAccount, BasicAuth {
   private final String name;
   private final Optional<String> username;
   private final Optional<String> password;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentials.java
@@ -27,13 +27,19 @@ import lombok.extern.slf4j.Slf4j;
 
 @NonnullByDefault
 @Slf4j
-final class BitbucketArtifactCredentials
+public class BitbucketArtifactCredentials
     extends SimpleHttpArtifactCredentials<BitbucketArtifactAccount> implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-bitbucket";
   @Getter private final String name;
   @Getter private final ImmutableList<String> types = ImmutableList.of("bitbucket/file");
 
   BitbucketArtifactCredentials(BitbucketArtifactAccount account, OkHttpClient okHttpClient) {
     super(okHttpClient, account);
     this.name = account.getName();
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/ArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/ArtifactAccount.java
@@ -17,6 +17,8 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.config;
 
-public interface ArtifactAccount {
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+
+public interface ArtifactAccount extends CredentialsDefinition {
   String getName();
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/ArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/ArtifactCredentials.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.artifacts.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.netflix.spinnaker.credentials.Credentials;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.IOException;
@@ -27,7 +28,7 @@ import java.util.Optional;
 import org.apache.commons.lang3.NotImplementedException;
 
 @NonnullByDefault
-public interface ArtifactCredentials {
+public interface ArtifactCredentials extends Credentials {
   String getName();
 
   /**

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/custom/CustomArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/custom/CustomArtifactConfiguration.java
@@ -17,8 +17,9 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.custom;
 
-import java.util.Collections;
-import java.util.List;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository;
+import com.netflix.spinnaker.credentials.NoopCredentialsLifecycleHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -28,10 +29,13 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor
 @Slf4j
 class CustomArtifactConfiguration {
+
   @Bean
-  List<? extends CustomArtifactCredentials> customArtifactCredentials() {
-    CustomArtifactAccount account = new CustomArtifactAccount();
-    CustomArtifactCredentials credentials = new CustomArtifactCredentials(account);
-    return Collections.singletonList(credentials);
+  public CredentialsRepository<CustomArtifactCredentials> customArtifactCredentialsRepository() {
+    CredentialsRepository<CustomArtifactCredentials> repository =
+        new MapBackedCredentialsRepository<>(
+            CustomArtifactCredentials.CREDENTIALS_TYPE, new NoopCredentialsLifecycleHandler<>());
+    repository.save(new CustomArtifactCredentials(new CustomArtifactAccount()));
+    return repository;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/custom/CustomArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/custom/CustomArtifactCredentials.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 @NonnullByDefault
 @Slf4j
 final class CustomArtifactCredentials implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-custom";
   @Getter private final String name;
   @Getter private final ImmutableList<String> types = ImmutableList.of("custom/object");
 
@@ -38,5 +39,10 @@ final class CustomArtifactCredentials implements ArtifactCredentials {
   public InputStream download(Artifact artifact) {
     throw new UnsupportedOperationException(
         "Custom references are passed on to cloud platforms to handle or process");
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/docker/DockerArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/docker/DockerArtifactConfiguration.java
@@ -17,8 +17,9 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.docker;
 
-import java.util.Collections;
-import java.util.List;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository;
+import com.netflix.spinnaker.credentials.NoopCredentialsLifecycleHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -30,8 +31,13 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor
 @Slf4j
 class DockerArtifactConfiguration {
+
   @Bean
-  List<? extends DockerArtifactCredentials> dockerArtifactCredentials() {
-    return Collections.singletonList(new DockerArtifactCredentials(new DockerArtifactAccount()));
+  public CredentialsRepository<DockerArtifactCredentials> dockerArtifactCredentialsRepository() {
+    CredentialsRepository<DockerArtifactCredentials> repository =
+        new MapBackedCredentialsRepository<>(
+            DockerArtifactCredentials.CREDENTIALS_TYPE, new NoopCredentialsLifecycleHandler<>());
+    repository.save(new DockerArtifactCredentials(new DockerArtifactAccount()));
+    return repository;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/docker/DockerArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/docker/DockerArtifactCredentials.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 @NonnullByDefault
 @Value
 final class DockerArtifactCredentials implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-docker";
   public static final String TYPE = "docker/image";
 
   private final String name;
@@ -41,5 +42,10 @@ final class DockerArtifactCredentials implements ArtifactCredentials {
   public InputStream download(Artifact artifact) {
     throw new UnsupportedOperationException(
         "Docker references are passed on to cloud platforms who retrieve images directly");
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactConfiguration.java
@@ -17,8 +17,9 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.embedded;
 
-import java.util.Collections;
-import java.util.List;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository;
+import com.netflix.spinnaker.credentials.NoopCredentialsLifecycleHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -29,9 +30,12 @@ import org.springframework.context.annotation.Configuration;
 @Slf4j
 class EmbeddedArtifactConfiguration {
   @Bean
-  List<? extends EmbeddedArtifactCredentials> embeddedArtifactCredentials() {
-    EmbeddedArtifactAccount account = new EmbeddedArtifactAccount();
-    EmbeddedArtifactCredentials credentials = new EmbeddedArtifactCredentials(account);
-    return Collections.singletonList(credentials);
+  public CredentialsRepository<EmbeddedArtifactCredentials>
+      embeddedArtifactCredentialsRepository() {
+    CredentialsRepository<EmbeddedArtifactCredentials> repository =
+        new MapBackedCredentialsRepository<>(
+            EmbeddedArtifactCredentials.CREDENTIALS_TYPE, new NoopCredentialsLifecycleHandler<>());
+    repository.save(new EmbeddedArtifactCredentials(new EmbeddedArtifactAccount()));
+    return repository;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactCredentials.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.NotImplementedException;
 @NonnullByDefault
 @Slf4j
 final class EmbeddedArtifactCredentials implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-embedded";
   @Getter private final String name;
   @Getter private final ImmutableList<String> types = ImmutableList.of("embedded/base64");
 
@@ -59,5 +60,10 @@ final class EmbeddedArtifactCredentials implements ArtifactCredentials {
   @Override
   public boolean handlesType(String type) {
     return type.startsWith("embedded/");
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/front50/Front50ArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/front50/Front50ArtifactConfiguration.java
@@ -18,8 +18,9 @@ package com.netflix.spinnaker.clouddriver.artifacts.front50;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
-import java.util.Collections;
-import java.util.List;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository;
+import com.netflix.spinnaker.credentials.NoopCredentialsLifecycleHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -30,9 +31,12 @@ import org.springframework.context.annotation.Configuration;
 @Slf4j
 class Front50ArtifactConfiguration {
   @Bean
-  List<? extends Front50ArtifactCredentials> front50ArtifactCredentials(
+  public CredentialsRepository<Front50ArtifactCredentials> front50ArtifactCredentialsRepository(
       ObjectMapper objectMapper, Front50Service front50Service) {
-    Front50ArtifactCredentials c = new Front50ArtifactCredentials(objectMapper, front50Service);
-    return Collections.singletonList(c);
+    CredentialsRepository<Front50ArtifactCredentials> repository =
+        new MapBackedCredentialsRepository<>(
+            Front50ArtifactCredentials.CREDENTIALS_TYPE, new NoopCredentialsLifecycleHandler<>());
+    repository.save(new Front50ArtifactCredentials(objectMapper, front50Service));
+    return repository;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/front50/Front50ArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/front50/Front50ArtifactCredentials.java
@@ -40,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 @NonnullByDefault
 @Slf4j
 final class Front50ArtifactCredentials implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-front50";
   private static final String ACCOUNT_NAME = "front50ArtifactCredentials";
   private static final String URL_PREFIX = "spinnaker://";
 
@@ -104,6 +105,11 @@ final class Front50ArtifactCredentials implements ArtifactCredentials {
       throw new IllegalArgumentException("Malformed Front50 artifact reference: " + reference);
     }
     return new SplitResult(refParts[0], refParts[1]);
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 
   @Data

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactAccount.java
@@ -28,7 +28,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-final class GcsArtifactAccount implements ArtifactAccount {
+public class GcsArtifactAccount implements ArtifactAccount {
   private final String name;
   private final Optional<String> jsonPath;
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactConfiguration.java
@@ -17,11 +17,9 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.gcs;
 
+import com.netflix.spinnaker.credentials.CredentialsTypeProperties;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -38,10 +36,14 @@ class GcsArtifactConfiguration {
   private final GcsArtifactProviderProperties gcsArtifactProviderProperties;
 
   @Bean
-  List<? extends GcsArtifactCredentials> gcsArtifactCredentials(
-      String clouddriverUserAgentApplicationName) {
-    return gcsArtifactProviderProperties.getAccounts().stream()
-        .map(
+  public CredentialsTypeProperties<GcsArtifactCredentials, GcsArtifactAccount>
+      gcsCredentialsProperties(String clouddriverUserAgentApplicationName) {
+    return CredentialsTypeProperties.<GcsArtifactCredentials, GcsArtifactAccount>builder()
+        .type(GcsArtifactCredentials.CREDENTIALS_TYPE)
+        .credentialsClass(GcsArtifactCredentials.class)
+        .credentialsDefinitionClass(GcsArtifactAccount.class)
+        .defaultCredentialsSource(gcsArtifactProviderProperties::getAccounts)
+        .credentialsParser(
             a -> {
               try {
                 return new GcsArtifactCredentials(clouddriverUserAgentApplicationName, a);
@@ -50,7 +52,6 @@ class GcsArtifactConfiguration {
                 return null;
               }
             })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+        .build();
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactCredentials.java
@@ -42,7 +42,8 @@ import lombok.extern.slf4j.Slf4j;
 
 @NonnullByDefault
 @Slf4j
-final class GcsArtifactCredentials implements ArtifactCredentials {
+public class GcsArtifactCredentials implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-gcs";
   @Getter private final String name;
   @Getter private final ImmutableList<String> types = ImmutableList.of("gcs/object");
 
@@ -103,5 +104,10 @@ final class GcsArtifactCredentials implements ArtifactCredentials {
     Storage.Objects.Get get = storage.objects().get(bucketName, path).setGeneration(generation);
 
     return get.executeMediaAsInputStream();
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactAccount.java
@@ -26,7 +26,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-final class GitRepoArtifactAccount implements ArtifactAccount {
+public class GitRepoArtifactAccount implements ArtifactAccount {
   private final String name;
   private final String username;
   private final String password;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactCredentials.java
@@ -51,7 +51,8 @@ import org.eclipse.jgit.util.FS;
 
 @NonnullByDefault
 @Slf4j
-final class GitRepoArtifactCredentials implements ArtifactCredentials {
+public class GitRepoArtifactCredentials implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-git";
   @Getter private final ImmutableList<String> types = ImmutableList.of("git/repo");
 
   @Getter private final String name;
@@ -63,6 +64,11 @@ final class GitRepoArtifactCredentials implements ArtifactCredentials {
   private final String sshKnownHostsFilePath;
   private final boolean sshTrustUnknownHosts;
   private final AuthType authType;
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
+  }
 
   private enum AuthType {
     HTTP,

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactAccount.java
@@ -30,7 +30,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-final class GitHubArtifactAccount implements ArtifactAccount, BasicAuth, TokenAuth {
+public class GitHubArtifactAccount implements ArtifactAccount, BasicAuth, TokenAuth {
   private String name;
   /*
    One of the following are required for auth:

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactConfiguration.java
@@ -18,10 +18,8 @@
 package com.netflix.spinnaker.clouddriver.artifacts.github;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.credentials.CredentialsTypeProperties;
 import com.squareup.okhttp.OkHttpClient;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -36,12 +34,16 @@ import org.springframework.context.annotation.Configuration;
 @Slf4j
 class GitHubArtifactConfiguration {
   private final GitHubArtifactProviderProperties gitHubArtifactProviderProperties;
-  private final ObjectMapper objectMapper;
 
   @Bean
-  List<? extends GitHubArtifactCredentials> gitHubArtifactCredentials(OkHttpClient okHttpClient) {
-    return gitHubArtifactProviderProperties.getAccounts().stream()
-        .map(
+  public CredentialsTypeProperties<GitHubArtifactCredentials, GitHubArtifactAccount>
+      githubCredentialsProperties(OkHttpClient okHttpClient, ObjectMapper objectMapper) {
+    return CredentialsTypeProperties.<GitHubArtifactCredentials, GitHubArtifactAccount>builder()
+        .type(GitHubArtifactCredentials.CREDENTIALS_TYPE)
+        .credentialsClass(GitHubArtifactCredentials.class)
+        .credentialsDefinitionClass(GitHubArtifactAccount.class)
+        .defaultCredentialsSource(gitHubArtifactProviderProperties::getAccounts)
+        .credentialsParser(
             a -> {
               try {
                 return new GitHubArtifactCredentials(a, okHttpClient, objectMapper);
@@ -50,7 +52,6 @@ class GitHubArtifactConfiguration {
                 return null;
               }
             })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+        .build();
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactCredentials.java
@@ -38,8 +38,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @NonnullByDefault
 @Slf4j
-final class GitHubArtifactCredentials extends SimpleHttpArtifactCredentials<GitHubArtifactAccount>
+public class GitHubArtifactCredentials extends SimpleHttpArtifactCredentials<GitHubArtifactAccount>
     implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-github";
   @Getter private final String name;
   @Getter private final ImmutableList<String> types = ImmutableList.of("github/file");
 
@@ -81,6 +82,11 @@ final class GitHubArtifactCredentials extends SimpleHttpArtifactCredentials<GitH
               + artifact);
     }
     return parseUrl(metadata.getDownloadUrl());
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 
   @Data

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactAccount.java
@@ -28,7 +28,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-final class GitlabArtifactAccount implements ArtifactAccount, TokenAuth {
+public class GitlabArtifactAccount implements ArtifactAccount, TokenAuth {
   private final String name;
   private final Optional<String> token;
   private final Optional<String> tokenFile;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactConfiguration.java
@@ -16,10 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.gitlab;
 
+import com.netflix.spinnaker.credentials.CredentialsTypeProperties;
 import com.squareup.okhttp.OkHttpClient;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -36,9 +34,14 @@ class GitlabArtifactConfiguration {
   private final GitlabArtifactProviderProperties gitlabArtifactProviderProperties;
 
   @Bean
-  List<? extends GitlabArtifactCredentials> gitlabArtifactCredentials(OkHttpClient okHttpClient) {
-    return gitlabArtifactProviderProperties.getAccounts().stream()
-        .map(
+  public CredentialsTypeProperties<GitlabArtifactCredentials, GitlabArtifactAccount>
+      gitlabCredentialsProperties(OkHttpClient okHttpClient) {
+    return CredentialsTypeProperties.<GitlabArtifactCredentials, GitlabArtifactAccount>builder()
+        .type(GitlabArtifactCredentials.CREDENTIALS_TYPE)
+        .credentialsClass(GitlabArtifactCredentials.class)
+        .credentialsDefinitionClass(GitlabArtifactAccount.class)
+        .defaultCredentialsSource(gitlabArtifactProviderProperties::getAccounts)
+        .credentialsParser(
             a -> {
               try {
                 return new GitlabArtifactCredentials(a, okHttpClient);
@@ -47,7 +50,6 @@ class GitlabArtifactConfiguration {
                 return null;
               }
             })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+        .build();
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactCredentials.java
@@ -31,8 +31,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @NonnullByDefault
 @Slf4j
-final class GitlabArtifactCredentials extends SimpleHttpArtifactCredentials<GitlabArtifactAccount>
+public class GitlabArtifactCredentials extends SimpleHttpArtifactCredentials<GitlabArtifactAccount>
     implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-gitlab";
   @Getter private final String name;
   @Getter private final ImmutableList<String> types = ImmutableList.of("gitlab/file");
 
@@ -62,5 +63,10 @@ final class GitlabArtifactCredentials extends SimpleHttpArtifactCredentials<Gitl
       version = "master";
     }
     return parseUrl(artifact.getReference()).newBuilder().addQueryParameter("ref", version).build();
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactAccount.java
@@ -29,7 +29,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-final class HelmArtifactAccount implements ArtifactAccount, BasicAuth {
+public class HelmArtifactAccount implements ArtifactAccount, BasicAuth {
   private final String name;
   /*
    One of the following are required for auth:

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactConfiguration.java
@@ -17,10 +17,8 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.helm;
 
+import com.netflix.spinnaker.credentials.CredentialsTypeProperties;
 import com.squareup.okhttp.OkHttpClient;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -37,10 +35,14 @@ class HelmArtifactConfiguration {
   private final HelmArtifactProviderProperties helmArtifactProviderProperties;
 
   @Bean
-  List<? extends HelmArtifactCredentials> helmArtifactCredentials(OkHttpClient okHttpClient) {
-
-    return helmArtifactProviderProperties.getAccounts().stream()
-        .map(
+  public CredentialsTypeProperties<HelmArtifactCredentials, HelmArtifactAccount>
+      helmCredentialsProperties(OkHttpClient okHttpClient) {
+    return CredentialsTypeProperties.<HelmArtifactCredentials, HelmArtifactAccount>builder()
+        .type(HelmArtifactCredentials.CREDENTIALS_TYPE)
+        .credentialsClass(HelmArtifactCredentials.class)
+        .credentialsDefinitionClass(HelmArtifactAccount.class)
+        .defaultCredentialsSource(helmArtifactProviderProperties::getAccounts)
+        .credentialsParser(
             a -> {
               try {
                 return new HelmArtifactCredentials(a, okHttpClient);
@@ -49,7 +51,6 @@ class HelmArtifactConfiguration {
                 return null;
               }
             })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+        .build();
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactCredentials.java
@@ -35,8 +35,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @NonnullByDefault
 @Slf4j
-final class HelmArtifactCredentials extends BaseHttpArtifactCredentials<HelmArtifactAccount>
+public class HelmArtifactCredentials extends BaseHttpArtifactCredentials<HelmArtifactAccount>
     implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-helm";
   @Getter private final String name;
   @Getter private final ImmutableList<String> types = ImmutableList.of("helm/chart", "helm/index");
 
@@ -47,7 +48,7 @@ final class HelmArtifactCredentials extends BaseHttpArtifactCredentials<HelmArti
     return types.contains(type);
   }
 
-  HelmArtifactCredentials(HelmArtifactAccount account, OkHttpClient okHttpClient) {
+  public HelmArtifactCredentials(HelmArtifactAccount account, OkHttpClient okHttpClient) {
     super(okHttpClient, account);
     this.name = account.getName();
     this.indexParser = new IndexParser(account.getRepository());
@@ -106,5 +107,10 @@ final class HelmArtifactCredentials extends BaseHttpArtifactCredentials<HelmArti
       throw new FailedDownloadException(
           "Failed to download index.yaml file in '" + indexParser.getRepository() + "' repository");
     }
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactAccount.java
@@ -30,7 +30,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-final class HttpArtifactAccount implements ArtifactAccount, BasicAuth {
+public class HttpArtifactAccount implements ArtifactAccount, BasicAuth {
   private final String name;
   /*
    One of the following are required for auth:

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactConfiguration.java
@@ -17,10 +17,9 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.http;
 
+import com.netflix.spinnaker.credentials.CredentialsTypeProperties;
 import com.squareup.okhttp.OkHttpClient;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -35,33 +34,34 @@ import org.springframework.context.annotation.Configuration;
 @Slf4j
 class HttpArtifactConfiguration {
   private final HttpArtifactProviderProperties httpArtifactProviderProperties;
+  private final HttpArtifactAccount noAuthAccount =
+      HttpArtifactAccount.builder().name("no-auth-http-account").build();
 
   @Bean
-  List<? extends HttpArtifactCredentials> httpArtifactCredentials(OkHttpClient okHttpClient) {
-    List<HttpArtifactCredentials> result =
-        httpArtifactProviderProperties.getAccounts().stream()
-            .map(
-                a -> {
-                  try {
-                    return new HttpArtifactCredentials(a, okHttpClient);
-                  } catch (Exception e) {
-                    log.warn("Failure instantiating Http artifact account {}: ", a, e);
-                    return null;
-                  }
-                })
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList());
+  public CredentialsTypeProperties<HttpArtifactCredentials, HttpArtifactAccount>
+      httpCredentialsProperties(OkHttpClient okHttpClient) {
+    return CredentialsTypeProperties.<HttpArtifactCredentials, HttpArtifactAccount>builder()
+        .type(HttpArtifactCredentials.CREDENTIALS_TYPE)
+        .credentialsClass(HttpArtifactCredentials.class)
+        .credentialsDefinitionClass(HttpArtifactAccount.class)
+        .defaultCredentialsSource(this::getHttpAccounts)
+        .credentialsParser(
+            a -> {
+              try {
+                return new HttpArtifactCredentials(a, okHttpClient);
+              } catch (Exception e) {
+                log.warn("Failure instantiating Http artifact account {}: ", a, e);
+                return null;
+              }
+            })
+        .build();
+  }
 
-    if (httpArtifactProviderProperties.getAccounts().stream()
-        .noneMatch(HttpArtifactAccount::usesAuth)) {
-      HttpArtifactAccount noAuthAccount =
-          HttpArtifactAccount.builder().name("no-auth-http-account").build();
-      HttpArtifactCredentials noAuthCredentials =
-          new HttpArtifactCredentials(noAuthAccount, okHttpClient);
-
-      result.add(noAuthCredentials);
+  private List<HttpArtifactAccount> getHttpAccounts() {
+    List<HttpArtifactAccount> accounts = httpArtifactProviderProperties.getAccounts();
+    if (accounts.stream().noneMatch(HttpArtifactAccount::usesAuth)) {
+      accounts.add(noAuthAccount);
     }
-
-    return result;
+    return accounts;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactCredentials.java
@@ -27,13 +27,19 @@ import lombok.extern.slf4j.Slf4j;
 
 @NonnullByDefault
 @Slf4j
-final class HttpArtifactCredentials extends SimpleHttpArtifactCredentials<HttpArtifactAccount>
+public class HttpArtifactCredentials extends SimpleHttpArtifactCredentials<HttpArtifactAccount>
     implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-http";
   @Getter private final String name;
   @Getter private final ImmutableList<String> types = ImmutableList.of("http/file");
 
   HttpArtifactCredentials(HttpArtifactAccount account, OkHttpClient okHttpClient) {
     super(okHttpClient, account);
     this.name = account.getName();
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactAccount.java
@@ -30,7 +30,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-final class IvyArtifactAccount implements ArtifactAccount {
+public class IvyArtifactAccount implements ArtifactAccount {
   private final String name;
   @Nullable private final IvySettings settings;
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactConfiguration.java
@@ -16,9 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.ivy;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import com.netflix.spinnaker.credentials.CredentialsTypeProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -35,9 +33,14 @@ class IvyArtifactConfiguration {
   private final IvyArtifactProviderProperties ivyArtifactProviderProperties;
 
   @Bean
-  List<? extends IvyArtifactCredentials> ivyArtifactCredentials() {
-    return ivyArtifactProviderProperties.getAccounts().stream()
-        .map(
+  public CredentialsTypeProperties<IvyArtifactCredentials, IvyArtifactAccount>
+      ivyCredentialsProperties() {
+    return CredentialsTypeProperties.<IvyArtifactCredentials, IvyArtifactAccount>builder()
+        .type(IvyArtifactCredentials.CREDENTIALS_TYPE)
+        .credentialsClass(IvyArtifactCredentials.class)
+        .credentialsDefinitionClass(IvyArtifactAccount.class)
+        .defaultCredentialsSource(ivyArtifactProviderProperties::getAccounts)
+        .credentialsParser(
             a -> {
               try {
                 return new IvyArtifactCredentials(a);
@@ -46,7 +49,6 @@ class IvyArtifactConfiguration {
                 return null;
               }
             })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+        .build();
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactCredentials.java
@@ -41,7 +41,8 @@ import org.slf4j.LoggerFactory;
 
 @NonnullByDefault
 @Slf4j
-final class IvyArtifactCredentials implements ArtifactCredentials {
+public class IvyArtifactCredentials implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-ivy";
   @Getter private final ImmutableList<String> types = ImmutableList.of("ivy/file");
   private final IvyArtifactAccount account;
   private final Supplier<Path> cacheBuilder;
@@ -147,5 +148,10 @@ final class IvyArtifactCredentials implements ArtifactCredentials {
   @Override
   public String getName() {
     return account.getName();
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsArtifactAccount.java
@@ -28,7 +28,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-final class JenkinsArtifactAccount implements ArtifactAccount, BasicAuth {
+public class JenkinsArtifactAccount implements ArtifactAccount, BasicAuth {
   private final String name;
   private final Optional<String> username;
   private final Optional<String> password;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsArtifactConfiguration.java
@@ -16,9 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.jenkins;
 
+import com.netflix.spinnaker.credentials.CredentialsTypeProperties;
 import com.squareup.okhttp.OkHttpClient;
-import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,21 +35,29 @@ class JenkinsArtifactConfiguration {
   private final JenkinsProperties jenkinsProperties;
 
   @Bean
-  List<? extends JenkinsArtifactCredentials> jenkinsArtifactCredentials(OkHttpClient okHttpClient) {
-    return jenkinsProperties.getMasters().stream()
-        .map(
-            m -> {
+  public CredentialsTypeProperties<JenkinsArtifactCredentials, JenkinsArtifactAccount>
+      jenkinsCredentialsProperties(OkHttpClient okHttpClient) {
+    return CredentialsTypeProperties.<JenkinsArtifactCredentials, JenkinsArtifactAccount>builder()
+        .type(JenkinsArtifactCredentials.CREDENTIALS_TYPE)
+        .credentialsClass(JenkinsArtifactCredentials.class)
+        .credentialsDefinitionClass(JenkinsArtifactAccount.class)
+        .defaultCredentialsSource(
+            () ->
+                jenkinsProperties.getMasters().stream()
+                    .map(
+                        m ->
+                            new JenkinsArtifactAccount(
+                                m.getName(), m.getUsername(), m.getPassword(), m.getAddress()))
+                    .collect(Collectors.toList()))
+        .credentialsParser(
+            a -> {
               try {
-                return new JenkinsArtifactCredentials(
-                    new JenkinsArtifactAccount(
-                        m.getName(), m.getUsername(), m.getPassword(), m.getAddress()),
-                    okHttpClient);
+                return new JenkinsArtifactCredentials(a, okHttpClient);
               } catch (Exception e) {
-                log.warn("Failure instantiating jenkins artifact account {}: ", m, e);
+                log.warn("Failure instantiating jenkins artifact account {}: ", a, e);
                 return null;
               }
             })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+        .build();
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsArtifactCredentials.java
@@ -28,8 +28,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @NonnullByDefault
 @Slf4j
-final class JenkinsArtifactCredentials extends SimpleHttpArtifactCredentials<JenkinsArtifactAccount>
-    implements ArtifactCredentials {
+public class JenkinsArtifactCredentials
+    extends SimpleHttpArtifactCredentials<JenkinsArtifactAccount> implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-jenkins";
   private static final String TYPE = "jenkins/file";
 
   @Getter private final String name;
@@ -70,5 +71,10 @@ final class JenkinsArtifactCredentials extends SimpleHttpArtifactCredentials<Jen
               + ". Read more here https://www.spinnaker.io/reference/artifacts/types/");
     }
     return url;
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/kubernetes/KubernetesArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/kubernetes/KubernetesArtifactConfiguration.java
@@ -17,8 +17,9 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.kubernetes;
 
-import java.util.Collections;
-import java.util.List;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository;
+import com.netflix.spinnaker.credentials.NoopCredentialsLifecycleHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -31,8 +32,13 @@ import org.springframework.context.annotation.Configuration;
 @Slf4j
 class KubernetesArtifactConfiguration {
   @Bean
-  List<? extends KubernetesArtifactCredentials> kubernetesArtifactAccounts() {
-    return Collections.singletonList(
-        new KubernetesArtifactCredentials(new KubernetesArtifactAccount()));
+  public CredentialsRepository<KubernetesArtifactCredentials>
+      kubernetesArtifactCredentialsRepository() {
+    CredentialsRepository<KubernetesArtifactCredentials> repository =
+        new MapBackedCredentialsRepository<>(
+            KubernetesArtifactCredentials.CREDENTIALS_TYPE,
+            new NoopCredentialsLifecycleHandler<>());
+    repository.save(new KubernetesArtifactCredentials(new KubernetesArtifactAccount()));
+    return repository;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/kubernetes/KubernetesArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/kubernetes/KubernetesArtifactCredentials.java
@@ -32,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Value
 @NonnullByDefault
 final class KubernetesArtifactCredentials implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-kubernetes";
   private final String name;
   private final ImmutableList<String> types;
 
@@ -47,5 +48,10 @@ final class KubernetesArtifactCredentials implements ArtifactCredentials {
   public InputStream download(Artifact artifact) {
     throw new UnsupportedOperationException(
         "Kubernetes artifacts are retrieved by kubernetes directly");
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactAccount.java
@@ -26,7 +26,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-final class MavenArtifactAccount implements ArtifactAccount {
+public class MavenArtifactAccount implements ArtifactAccount {
   private final String name;
   private final String repositoryUrl;
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
@@ -49,6 +49,7 @@ import org.eclipse.aether.version.VersionScheme;
 
 @NonnullByDefault
 public final class MavenArtifactCredentials implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-maven";
   private static final String RELEASE = "RELEASE";
   private static final String SNAPSHOT = "SNAPSHOT";
   private static final String LATEST = "LATEST";
@@ -83,6 +84,11 @@ public final class MavenArtifactCredentials implements ArtifactCredentials {
   @Override
   public String getName() {
     return account.getName();
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 
   @Override

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactAccount.java
@@ -19,7 +19,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-final class OracleArtifactAccount implements ArtifactAccount {
+public class OracleArtifactAccount implements ArtifactAccount {
   private final String name;
   private final String namespace;
   private final String region;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactConfiguration.java
@@ -9,9 +9,7 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.oracle;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import com.netflix.spinnaker.credentials.CredentialsTypeProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -28,10 +26,14 @@ class OracleArtifactConfiguration {
   private final OracleArtifactProviderProperties oracleArtifactProviderProperties;
 
   @Bean
-  List<? extends OracleArtifactCredentials> oracleArtifactCredentials(
-      String clouddriverUserAgentApplicationName) {
-    return oracleArtifactProviderProperties.getAccounts().stream()
-        .map(
+  public CredentialsTypeProperties<OracleArtifactCredentials, OracleArtifactAccount>
+      oracleCredentialsProperties(String clouddriverUserAgentApplicationName) {
+    return CredentialsTypeProperties.<OracleArtifactCredentials, OracleArtifactAccount>builder()
+        .type(OracleArtifactCredentials.CREDENTIALS_TYPE)
+        .credentialsClass(OracleArtifactCredentials.class)
+        .credentialsDefinitionClass(OracleArtifactAccount.class)
+        .defaultCredentialsSource(oracleArtifactProviderProperties::getAccounts)
+        .credentialsParser(
             a -> {
               try {
                 return new OracleArtifactCredentials(clouddriverUserAgentApplicationName, a);
@@ -40,7 +42,6 @@ class OracleArtifactConfiguration {
                 return null;
               }
             })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+        .build();
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactCredentials.java
@@ -24,7 +24,8 @@ import lombok.extern.slf4j.Slf4j;
 
 @NonnullByDefault
 @Slf4j
-final class OracleArtifactCredentials implements ArtifactCredentials {
+public class OracleArtifactCredentials implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-oracle";
   private static final String ARTIFACT_REFERENCE_PREFIX = "oci://";
   private static final String ARTIFACT_VERSION_QUERY_PARAM = "versionId";
   private static final String ARTIFACT_URI =
@@ -91,5 +92,10 @@ final class OracleArtifactCredentials implements ArtifactCredentials {
       }
       throw e;
     }
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactAccount.java
@@ -26,7 +26,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-final class S3ArtifactAccount implements ArtifactAccount {
+public class S3ArtifactAccount implements ArtifactAccount {
   private final String name;
   private final String apiEndpoint;
   private final String apiRegion;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactConfiguration.java
@@ -16,9 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.s3;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import com.netflix.spinnaker.credentials.CredentialsTypeProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -35,18 +33,22 @@ class S3ArtifactConfiguration {
   private final S3ArtifactProviderProperties s3ArtifactProviderProperties;
 
   @Bean
-  List<? extends S3ArtifactCredentials> s3ArtifactCredentials() {
-    return s3ArtifactProviderProperties.getAccounts().stream()
-        .map(
+  public CredentialsTypeProperties<S3ArtifactCredentials, S3ArtifactAccount>
+      s3CredentialsProperties() {
+    return CredentialsTypeProperties.<S3ArtifactCredentials, S3ArtifactAccount>builder()
+        .type(S3ArtifactCredentials.CREDENTIALS_TYPE)
+        .credentialsClass(S3ArtifactCredentials.class)
+        .credentialsDefinitionClass(S3ArtifactAccount.class)
+        .defaultCredentialsSource(s3ArtifactProviderProperties::getAccounts)
+        .credentialsParser(
             a -> {
               try {
                 return new S3ArtifactCredentials(a);
-              } catch (IllegalArgumentException e) {
+              } catch (Exception e) {
                 log.warn("Failure instantiating s3 artifact account {}: ", a, e);
                 return null;
               }
             })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+        .build();
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactCredentials.java
@@ -32,7 +32,8 @@ import lombok.Getter;
 
 @NonnullByDefault
 @Slf4j
-final class S3ArtifactCredentials implements ArtifactCredentials {
+public class S3ArtifactCredentials implements ArtifactCredentials {
+  public static final String CREDENTIALS_TYPE = "artifacts-s3";
   @Getter private final String name;
   @Getter private final ImmutableList<String> types = ImmutableList.of("s3/object");
 
@@ -88,5 +89,10 @@ final class S3ArtifactCredentials implements ArtifactCredentials {
     String path = reference.substring(slash + 1);
     S3Object s3obj = getS3Client().getObject(bucketName, path);
     return s3obj.getObjectContent();
+  }
+
+  @Override
+  public String getType() {
+    return CREDENTIALS_TYPE;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/config/ArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/config/ArtifactConfiguration.java
@@ -16,8 +16,16 @@
 
 package com.netflix.spinnaker.config;
 
+import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
+import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
+import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
+import com.netflix.spinnaker.credentials.CredentialsTypeBaseConfiguration;
+import com.netflix.spinnaker.credentials.CredentialsTypeProperties;
 import com.squareup.okhttp.OkHttpClient;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -33,5 +41,18 @@ public class ArtifactConfiguration {
   @Bean
   OkHttpClient okHttpClient() {
     return new OkHttpClient();
+  }
+
+  @Bean
+  public ArtifactCredentialsRepository artifactCredentialsRepository(
+      ApplicationContext applicationContext,
+      List<CredentialsTypeProperties<? extends ArtifactCredentials, ? extends ArtifactAccount>>
+          credentialsTypes) {
+    return new ArtifactCredentialsRepository(
+        credentialsTypes.stream()
+            .map(c -> new CredentialsTypeBaseConfiguration<>(applicationContext, c))
+            .peek(CredentialsTypeBaseConfiguration::afterPropertiesSet)
+            .map(CredentialsTypeBaseConfiguration::getCredentialsRepository)
+            .collect(Collectors.toList()));
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/artifacts/CloudFoundryArtifactCredentials.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/artifacts/CloudFoundryArtifactCredentials.java
@@ -28,6 +28,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class CloudFoundryArtifactCredentials implements ArtifactCredentials {
+  public static final String ARTIFACTS_TYPE = "artifacts/cloudfoundry";
   public static final String TYPE = "cloudfoundry/app";
 
   private final String name = "cloudfoundry";
@@ -44,5 +45,10 @@ public class CloudFoundryArtifactCredentials implements ArtifactCredentials {
   public InputStream download(@Nonnull Artifact artifact) {
     String packageId = client.getApplications().findCurrentPackageIdByAppId(artifact.getUuid());
     return client.getApplications().downloadPackageBits(packageId);
+  }
+
+  @Override
+  public String getType() {
+    return ARTIFACTS_TYPE;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
@@ -101,13 +101,13 @@ public class DeployCloudFoundryServerGroupAtomicOperationConverter
       return new CloudFoundryArtifactCredentials(credentials.getClient());
     }
 
-    return credentialsRepository.getAllCredentials().stream()
-        .filter(creds -> creds.getName().equals(artifactAccount))
-        .findAny()
-        .orElseThrow(
-            () ->
-                new IllegalArgumentException(
-                    "Unable to find artifact credentials '" + artifactAccount + "'"));
+    ArtifactCredentials credentials =
+        credentialsRepository.getFirstCredentialsWithName(artifactAccount);
+    if (credentials == null) {
+      throw new IllegalArgumentException(
+          "Unable to find artifact credentials '" + artifactAccount + "'");
+    }
+    return credentials;
   }
 
   // visible for testing

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/artifacts/ArtifactCredentialsFromString.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/artifacts/ArtifactCredentialsFromString.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 @NonnullByDefault
 public class ArtifactCredentialsFromString implements ArtifactCredentials {
+  public static final String ARTIFACT_TYPE = "artifacts/string";
 
   private final String name;
   private final ImmutableList<String> types;
@@ -45,6 +46,11 @@ public class ArtifactCredentialsFromString implements ArtifactCredentials {
 
   public String getName() {
     return name;
+  }
+
+  @Override
+  public String getType() {
+    return ARTIFACT_TYPE;
   }
 
   public ImmutableList<String> getTypes() {


### PR DESCRIPTION
This implements dynamic credentials for artifacts. Each type of credentials gets its own `CredentialsRepository` that can be adapted (dynamically reloaded, reading non Spring resources, etc.). `ArtifactCredentialsRepository` is now a simple `CompositeCredentialsRepository`.

Credentials types are defined via `CredentialsTypeProperties` and processed via a `CredentialsTypeBaseConfiguration` that creates all the required beans.

As a side note, credential types are `artifacts-<type>` because they can be dynamically reloaded via `credentials.poller.types.artifacts-<type>.reloadFrequencyMs` - using a dash works better than dot or slash even though slash seems more natural.