### PR TITLE
feat(artifacts): throw a non-retryable exception when an artifact is …

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactCredentialsRepository.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactCredentialsRepository.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.artifacts;
 
 import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
+import com.netflix.spinnaker.clouddriver.artifacts.exceptions.ArtifactCredentialsException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -46,19 +47,19 @@ public class ArtifactCredentialsRepository {
         .findFirst()
         .orElseThrow(
             () ->
-                new IllegalArgumentException(
+                new ArtifactCredentialsException(
                     "No credentials with name '" + accountName + "' could be found."));
   }
 
   public ArtifactCredentials getCredentials(String accountName, String type) {
     if (Strings.isNullOrEmpty(accountName)) {
-      throw new IllegalArgumentException(
+      throw new ArtifactCredentialsException(
           "An artifact account must be supplied to download this artifact: " + accountName);
     }
 
     ArtifactCredentials credentials = getCredentials(accountName);
     if (!credentials.handlesType(type)) {
-      throw new IllegalArgumentException(
+      throw new ArtifactCredentialsException(
           "Artifact credentials '"
               + accountName
               + "' cannot handle artifacts of type '"

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/exceptions/ArtifactCredentialsException.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/exceptions/ArtifactCredentialsException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Avast Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.exceptions;
+
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+
+/** A non-retryable exception for e.g. when artifact is mis-configured */
+public class ArtifactCredentialsException extends SpinnakerException {
+
+  public ArtifactCredentialsException(String message) {
+    super(message);
+    init();
+  }
+
+  public ArtifactCredentialsException(String message, Throwable cause) {
+    super(message, cause);
+    init();
+  }
+
+  private void init() {
+    setRetryable(false);
+  }
+}


### PR DESCRIPTION
…misconfigured

Introduce non-retryable exception ArtifactCredentialsException and use it in
ArtifactCredentialsRepository, so there's enough information in the response to the fetch
endpoint for callers to not retry.
