### PR TITLE
feat(ecs): add API support for Describe Clusters

### DIFF
--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/EcsControllersSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/EcsControllersSpec.java
@@ -18,18 +18,27 @@ package com.netflix.spinnaker.clouddriver.ecs.test;
 import static io.restassured.RestAssured.get;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.amazonaws.services.ecs.AmazonECS;
+import com.amazonaws.services.ecs.model.Cluster;
+import com.amazonaws.services.ecs.model.DescribeClustersRequest;
+import com.amazonaws.services.ecs.model.DescribeClustersResult;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.cats.provider.ProviderRegistry;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.EcsSpec;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +46,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class EcsControllersSpec extends EcsSpec {
 
   @Autowired private ProviderRegistry providerRegistry;
+
+  private AmazonECS mockECS = mock(AmazonECS.class);
 
   @DisplayName(".\n===\n" + "Given cached ECS cluster, retrieve it from /ecs/ecsClusters" + "\n===")
   @Test
@@ -69,6 +80,61 @@ public class EcsControllersSpec extends EcsSpec {
     assertTrue(responseStr.contains(testClusterName));
     assertTrue(responseStr.contains(ECS_ACCOUNT_NAME));
     assertTrue(responseStr.contains(TEST_REGION));
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given cached ECS clusters (names), retrieve detailed description "
+          + "of the cluster from /ecs/ecsDescribeClusters/{account}/{region}"
+          + "\n===")
+  @Test
+  public void getEcsDescribeClustersTest() throws JsonProcessingException {
+    // given
+    ProviderCache ecsCache = providerRegistry.getProviderCache(EcsProvider.NAME);
+    String testClusterName = "example-app-test-Cluster-NSnYsTXmCfV2";
+    String testNamespace = Keys.Namespace.ECS_CLUSTERS.ns;
+
+    String clusterKey = Keys.getClusterKey(ECS_ACCOUNT_NAME, TEST_REGION, testClusterName);
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("account", ECS_ACCOUNT_NAME);
+    attributes.put("region", TEST_REGION);
+    attributes.put("clusterArn", "arn:aws:ecs:::cluster/" + testClusterName);
+    attributes.put("clusterName", testClusterName);
+
+    DefaultCacheResult testResult = buildCacheResult(attributes, testNamespace, clusterKey);
+    ecsCache.addCacheResult("TestAgent", Collections.singletonList(testNamespace), testResult);
+
+    when(mockAwsProvider.getAmazonEcs(
+            any(NetflixAmazonCredentials.class), anyString(), anyBoolean()))
+        .thenReturn(mockECS);
+    Cluster clusterDecription =
+        new Cluster()
+            .withClusterArn("arn:aws:ecs:::cluster/" + testClusterName)
+            .withStatus("ACTIVE")
+            .withCapacityProviders("FARGATE", "FARGATE-SPOT")
+            .withClusterName(testClusterName);
+    when(mockECS.describeClusters(any(DescribeClustersRequest.class)))
+        .thenReturn(new DescribeClustersResult().withClusters(clusterDecription));
+
+    // when
+    String testUrl = getTestUrl("/ecs/ecsDescribeClusters/" + ECS_ACCOUNT_NAME + "/" + TEST_REGION);
+
+    Response response =
+        get(testUrl).then().statusCode(200).contentType(ContentType.JSON).extract().response();
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    Collection<Cluster> clusters =
+        Arrays.asList(objectMapper.readValue(response.asString(), Cluster[].class));
+    // then
+    assertNotNull(clusters);
+    Cluster clusterDescription =
+        (clusters.stream().filter(cluster -> cluster.getClusterName().equals(testClusterName)))
+            .findAny()
+            .get();
+    assertTrue(clusterDescription.getClusterArn().contains(testClusterName));
+    assertTrue(clusterDescription.getCapacityProviders().size() == 2);
+    assertTrue(clusterDescription.getStatus().equals("ACTIVE"));
   }
 
   @DisplayName(".\n===\n" + "Given cached ECS secret, retrieve it from /ecs/secrets" + "\n===")

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsClusterController.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsClusterController.java
@@ -16,10 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.controllers;
 
+import com.amazonaws.services.ecs.model.Cluster;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsCluster;
 import com.netflix.spinnaker.clouddriver.ecs.provider.view.EcsClusterProvider;
 import java.util.Collection;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,5 +38,11 @@ public class EcsClusterController {
   @RequestMapping(value = {"/ecs/ecsClusters"})
   public Collection<EcsCluster> getAllEcsClusters() {
     return ecsClusterProvider.getAllEcsClusters();
+  }
+
+  @RequestMapping(value = {"/ecs/ecsDescribeClusters/{account}/{region}"})
+  public Collection<Cluster> getAllEcsClustersDescription(
+      @PathVariable String account, @PathVariable String region) {
+    return ecsClusterProvider.getAllEcsClustersDescription(account, region);
   }
 }


### PR DESCRIPTION
Add support for getting capacity providers using Describe Cluster API.

Backend changes to support: [spinnaker/spinnaker#5400](https://github.com/spinnaker/spinnaker/issues/5400)