### PR TITLE
chore(artifacts): add test to demonstrate current behavior when fetch…

### DIFF
--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactControllerSpec.java
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactControllerSpec.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Avast Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.controllers;
+
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.Main;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.context.WebApplicationContext;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = Main.class)
+@TestPropertySource(
+    properties = {
+      "redis.enabled = false",
+      "sql.enabled = false",
+      "spring.application.name = clouddriver"
+    })
+public class ArtifactControllerSpec {
+
+  private MockMvc mvc;
+
+  @Autowired private WebApplicationContext webApplicationContext;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Before
+  public void setup() throws Exception {
+    this.mvc = webAppContextSetup(webApplicationContext).build();
+  }
+
+  @Test
+  public void testFetchWithMisconfiguredArtifact() throws Exception {
+    Artifact misconfiguredArtifact = Artifact.builder().name("foo").build();
+    MvcResult result =
+        mvc.perform(
+                put("/artifacts/fetch")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(misconfiguredArtifact)))
+            .andReturn();
+
+    mvc.perform(asyncDispatch(result))
+        .andDo(print())
+        .andExpect(status().isInternalServerError())
+        .andExpect(content().string(is(emptyString())));
+  }
+}

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactControllerSpec.java
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactControllerSpec.java
@@ -28,19 +28,21 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppC
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.clouddriver.Main;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.context.WebApplicationContext;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
 @SpringBootTest(classes = Main.class)
 @TestPropertySource(
     properties = {
@@ -56,7 +58,7 @@ public class ArtifactControllerSpec {
 
   @Autowired private ObjectMapper objectMapper;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     this.mvc = webAppContextSetup(webApplicationContext).build();
   }


### PR DESCRIPTION
…ing a misconfigured artifact

A subsequent PR to change the response code to 400 is on its way.  Ideally that would also indicate to code that uses [RetrySupport](https://github.com/spinnaker/kork/blob/c58b660cfebd225a5c2a779b45ce1be3808ec11f/kork-exceptions/src/main/java/com/netflix/spinnaker/kork/core/RetrySupport.java#L37) that there's no point in retrying when artifacts are misconfigured, but I don't have that worked out just yet.