### PR TITLE
feat(cloudfoundry): bind services before building droplet

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
@@ -224,7 +224,6 @@ public class HttpCloudFoundryClient implements CloudFoundryClient {
         new ServiceInstances(
             createService(ServiceInstanceService.class),
             createService(ConfigService.class),
-            organizations,
             spaces);
     this.routes =
         new Routes(

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
@@ -23,6 +23,7 @@ import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Las
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.LastOperation.Type.*;
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ServiceInstance.Type.MANAGED_SERVICE_INSTANCE;
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ServiceInstance.Type.USER_PROVIDED_SERVICE_INSTANCE;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
@@ -50,34 +51,21 @@ import org.springframework.util.StringUtils;
 public class ServiceInstances {
   private final ServiceInstanceService api;
   private final ConfigService configApi;
-  private final Organizations orgs;
   private final Spaces spaces;
 
-  public Void createServiceBindingsByName(
-      CloudFoundryServerGroup cloudFoundryServerGroup,
-      @Nullable List<String> serviceInstanceNames) {
-    if (serviceInstanceNames != null && !serviceInstanceNames.isEmpty()) {
-      List<String> serviceInstanceQuery =
-          getServiceQueryParams(serviceInstanceNames, cloudFoundryServerGroup.getSpace());
-      List<Resource<? extends AbstractServiceInstance>> serviceInstances = new ArrayList<>();
-      serviceInstances.addAll(
-          collectPageResources("service instances", pg -> api.all(pg, serviceInstanceQuery)));
-      serviceInstances.addAll(
-          collectPageResources(
-              "service instances", pg -> api.allUserProvided(pg, serviceInstanceQuery)));
+  public void createServiceBinding(CreateServiceBinding createServiceBinding) {
+    try {
+      safelyCall(() -> api.createServiceBinding(createServiceBinding)).get();
+    } catch (CloudFoundryApiException e) {
+      if (e.getErrorCode() == null) throw e;
 
-      if (serviceInstances.size() != serviceInstanceNames.size()) {
-        throw new CloudFoundryApiException(
-            "Number of service instances does not match the number of service names");
-      }
-
-      for (Resource<? extends AbstractServiceInstance> serviceInstance : serviceInstances) {
-        api.createServiceBinding(
-            new CreateServiceBinding(
-                serviceInstance.getMetadata().getGuid(), cloudFoundryServerGroup.getId()));
+      switch (e.getErrorCode()) {
+        case SERVICE_INSTANCE_ALREADY_BOUND:
+          return;
+        default:
+          throw e;
       }
     }
-    return null;
   }
 
   private Resource<Service> findServiceByServiceName(String serviceName) {
@@ -126,6 +114,19 @@ public class ServiceInstances {
                   .collect(toList());
             })
         .orElse(Collections.emptyList());
+  }
+
+  public List<Resource<? extends AbstractServiceInstance>> findAllServicesBySpaceAndNames(
+      CloudFoundrySpace space, List<String> serviceInstanceNames) {
+    if (serviceInstanceNames == null || serviceInstanceNames.isEmpty()) return emptyList();
+    List<String> serviceInstanceQuery = getServiceQueryParams(serviceInstanceNames, space);
+    List<Resource<? extends AbstractServiceInstance>> serviceInstances = new ArrayList<>();
+    serviceInstances.addAll(
+        collectPageResources("service instances", pg -> api.all(pg, serviceInstanceQuery)));
+    serviceInstances.addAll(
+        collectPageResources(
+            "service instances", pg -> api.allUserProvided(pg, serviceInstanceQuery)));
+    return serviceInstances;
   }
 
   // Visible for testing

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ServiceInstanceService.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ServiceInstanceService.java
@@ -31,7 +31,7 @@ public interface ServiceInstanceService {
       @Query("page") Integer page, @Query("q") List<String> queryParam);
 
   @POST("/v2/service_bindings?accepts_incomplete=true")
-  Response createServiceBinding(@Body CreateServiceBinding body);
+  Resource<ServiceBinding> createServiceBinding(@Body CreateServiceBinding body);
 
   @GET("/v2/services")
   Page<Service> findService(@Query("page") Integer page, @Query("q") List<String> queryParams);

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/ErrorDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/ErrorDescription.java
@@ -96,7 +96,8 @@ public class ErrorDescription {
     ROUTE_PATH_TAKEN("CF-RoutePathTaken"),
     ROUTE_PORT_TAKEN("CF-RoutePortTaken"),
     RESOURCE_NOT_FOUND("CF-ResourceNotFound"),
-    SERVICE_ALREADY_EXISTS("60002");
+    SERVICE_ALREADY_EXISTS("60002"),
+    SERVICE_INSTANCE_ALREADY_BOUND("CF-ServiceBindingAppServiceTaken");
 
     private final String code;
 

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/CreateServiceBinding.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/CreateServiceBinding.java
@@ -16,12 +16,16 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
 
+import java.util.Map;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@AllArgsConstructor
 @Getter
 public class CreateServiceBinding {
   private final String serviceInstanceGuid;
   private final String appGuid;
+  private Map<String, Object> parameters;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -93,14 +93,14 @@ public class DeployCloudFoundryServerGroupAtomicOperation
       }
     }
 
+    createServiceBindings(serverGroup, description);
+
     buildDroplet(packageId, serverGroup.getId(), description);
     scaleApplication(serverGroup.getId(), description);
     if (description.getApplicationAttributes().getHealthCheckType() != null
         || description.getApplicationAttributes().getCommand() != null) {
       updateProcess(serverGroup.getId(), description);
     }
-
-    createServiceBindings(serverGroup, description);
 
     if (!mapRoutes(
         description,

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryCloudProvider;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.artifacts.CloudFoundryArtifactCredentials;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryApiException;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.CreateServiceBinding;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessStats;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.CloudFoundryServerGroupNameResolver;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeployCloudFoundryServerGroupDescription;
@@ -99,10 +100,7 @@ public class DeployCloudFoundryServerGroupAtomicOperation
       updateProcess(serverGroup.getId(), description);
     }
 
-    client
-        .getServiceInstances()
-        .createServiceBindingsByName(
-            serverGroup, description.getApplicationAttributes().getServices());
+    createServiceBindings(serverGroup, description);
 
     if (!mapRoutes(
         description,
@@ -141,6 +139,53 @@ public class DeployCloudFoundryServerGroupAtomicOperation
     getTask().updateStatus(PHASE, "Deployed '" + description.getApplication() + "'");
 
     return deploymentResult();
+  }
+
+  private void createServiceBindings(
+      CloudFoundryServerGroup serverGroup, DeployCloudFoundryServerGroupDescription description) {
+    List<String> serviceNames = description.getApplicationAttributes().getServices();
+    if (serviceNames == null || serviceNames.isEmpty()) return;
+    getTask()
+        .updateStatus(
+            PHASE,
+            "Creating Cloud Foundry service bindings between application '"
+                + description.getServerGroupName()
+                + "' and services: "
+                + description.getApplicationAttributes().getServices());
+
+    List<CreateServiceBinding> bindings =
+        description
+            .getClient()
+            .getServiceInstances()
+            .findAllServicesBySpaceAndNames(
+                serverGroup.getSpace(), description.getApplicationAttributes().getServices())
+            .stream()
+            .map(
+                s ->
+                    new CreateServiceBinding(
+                        s.getMetadata().getGuid(), serverGroup.getId(), Collections.emptyMap()))
+            .collect(toList());
+
+    if (bindings.size() != description.getApplicationAttributes().getServices().size()) {
+      getTask()
+          .updateStatus(
+              PHASE,
+              "Failed to create Cloud Foundry service bindings between application '"
+                  + description.getServerGroupName()
+                  + "' and services: "
+                  + description.getApplicationAttributes().getServices());
+      throw new CloudFoundryApiException(
+          "Number of service instances does not match the number of service names");
+    }
+
+    bindings.forEach(b -> description.getClient().getServiceInstances().createServiceBinding(b));
+    getTask()
+        .updateStatus(
+            PHASE,
+            "Created Cloud Foundry service bindings between application '"
+                + description.getServerGroupName()
+                + "' and services: "
+                + description.getApplicationAttributes().getServices());
   }
 
   private DeploymentResult deploymentResult() {

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
@@ -24,10 +24,10 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.artifacts.ArtifactCredentialsFromString;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.Applications;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryApiException;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.MockCloudFoundryClient;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.*;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.AbstractServiceInstance;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Resource;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ServiceInstance;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessStats;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeployCloudFoundryServerGroupDescription;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryServerGroup;
@@ -39,6 +39,7 @@ import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import io.vavr.collection.HashMap;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Supplier;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
@@ -80,12 +81,13 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
         new DeployCloudFoundryServerGroupAtomicOperation(
             new PassThroughOperationPoller(), description);
     final Applications apps = getApplications(clusterProvider, ProcessStats.State.RUNNING);
+    final ServiceInstances serviceInstances = getServiceInstances();
 
     // When
     final DeploymentResult result = operation.operate(Lists.emptyList());
 
     // Then
-    verifyInOrder(apps, () -> atLeastOnce());
+    verifyInOrder(apps, serviceInstances, () -> atLeastOnce());
 
     assertThat(testTask.getStatus().isFailed()).isFalse();
     assertThat(result.getServerGroupNames())
@@ -106,6 +108,11 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
     Exception exception = null;
     // When
     try {
+      when(description
+              .getClient()
+              .getServiceInstances()
+              .findAllServicesBySpaceAndNames(any(), any()))
+          .thenReturn(createServiceInstanceResource());
       operation.operate(Lists.emptyList());
     } catch (CloudFoundryApiException cloudFoundryApiException) {
       exception = cloudFoundryApiException;
@@ -128,20 +135,24 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
         new DeployCloudFoundryServerGroupAtomicOperation(
             new PassThroughOperationPoller(), description);
     final Applications apps = getApplications(clusterProvider, ProcessStats.State.RUNNING);
+    final ServiceInstances serviceInstances = getServiceInstances();
 
     // When
     final DeploymentResult result = operation.operate(Lists.emptyList());
 
     // Then
-    verifyInOrder(apps, () -> never());
+    verifyInOrder(apps, serviceInstances, () -> never());
 
     assertThat(testTask.getStatus().isFailed()).isFalse();
     assertThat(result.getServerGroupNames())
         .isEqualTo(Collections.singletonList("region1:app1-stack1-detail1-v000"));
   }
 
-  private void verifyInOrder(final Applications apps, Supplier<VerificationMode> calls) {
-    final InOrder inOrder = Mockito.inOrder(apps, cloudFoundryClient.getServiceInstances());
+  private void verifyInOrder(
+      final Applications apps,
+      ServiceInstances serviceInstances,
+      Supplier<VerificationMode> calls) {
+    InOrder inOrder = Mockito.inOrder(apps, serviceInstances);
     DeployCloudFoundryServerGroupDescription.ApplicationAttributes applicationAttributes =
         new DeployCloudFoundryServerGroupDescription.ApplicationAttributes();
     applicationAttributes.setBuildpacks(
@@ -157,10 +168,24 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
     inOrder.verify(apps).createBuild("serverGroupId_package");
     inOrder.verify(apps).scaleApplication("serverGroupId", 7, 1024, 2048);
     inOrder.verify(apps).updateProcess("serverGroupId", null, "http", "/health");
-    inOrder
-        .verify(cloudFoundryClient.getServiceInstances())
-        .createServiceBindingsByName(any(), eq(Collections.singletonList("service1")));
+    inOrder.verify(cloudFoundryClient.getServiceInstances()).createServiceBinding(any());
     inOrder.verify(apps, calls.get()).startApplication("serverGroupId");
+  }
+
+  private ServiceInstances getServiceInstances() {
+    final ServiceInstances serviceInstances = cloudFoundryClient.getServiceInstances();
+    when(serviceInstances.findAllServicesBySpaceAndNames(any(), any()))
+        .thenReturn(createServiceInstanceResource());
+    return serviceInstances;
+  }
+
+  private List<Resource<? extends AbstractServiceInstance>> createServiceInstanceResource() {
+    ServiceInstance serviceInstance = new ServiceInstance();
+    serviceInstance.setServicePlanGuid("plan-guid").setName("service1");
+    Resource<ServiceInstance> serviceInstanceResource = new Resource<>();
+    serviceInstanceResource.setMetadata(new Resource.Metadata().setGuid("service-instance-guid"));
+    serviceInstanceResource.setEntity(serviceInstance);
+    return List.of(serviceInstanceResource);
   }
 
   private Applications getApplications(
@@ -205,7 +230,7 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
                     .setHealthCheckType("http")
                     .setHealthCheckHttpEndpoint("/health")
                     .setBuildpacks(io.vavr.collection.List.of("buildpack1", "buildpack2").asJava())
-                    .setServices(io.vavr.collection.List.of("service1").asJava())
+                    .setServices(List.of("service1"))
                     .setEnv(HashMap.of("token", "ASDF").toJavaMap()));
     description.setClient(cloudFoundryClient);
     description.setRegion("region1");

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
@@ -165,10 +165,10 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
             getDeployCloudFoundryServerGroupDescription(true).getApplicationAttributes(),
             HashMap.of("token", "ASDF").toJavaMap());
     inOrder.verify(apps).uploadPackageBits(eq("serverGroupId_package"), any());
+    inOrder.verify(cloudFoundryClient.getServiceInstances()).createServiceBinding(any());
     inOrder.verify(apps).createBuild("serverGroupId_package");
     inOrder.verify(apps).scaleApplication("serverGroupId", 7, 1024, 2048);
     inOrder.verify(apps).updateProcess("serverGroupId", null, "http", "/health");
-    inOrder.verify(cloudFoundryClient.getServiceInstances()).createServiceBinding(any());
     inOrder.verify(apps, calls.get()).startApplication("serverGroupId");
   }
 


### PR DESCRIPTION
This change includes some refactoring for create service bindings that will allow us to use this same logic in a new stage specifically for binding to services with optional parameters. 

We've also moved the createServiceBindings() logic ahead of buildDroplet(). This allows the droplet creation to take advantage of environment variables/service bindings that are present now, rather than doing a restage after we've added service bindings. 