### PR TITLE
fix(ecs): rename capacityProviderStrategies to capacityProviderStrategy

### DIFF
--- a/clouddriver-ecs/src/integration/resources/testoperations/createServerGroup-artifact-FARGATE-capacityProviderStrategy.json
+++ b/clouddriver-ecs/src/integration/resources/testoperations/createServerGroup-artifact-FARGATE-capacityProviderStrategy.json
@@ -17,7 +17,7 @@
   "credentials": "ecs-account",
   "dockerImageAddress": "nginx",
   "ecsClusterName": "integArtifactsFargateCapacityProviderStrategy-cluster",
-  "capacityProviderStrategies": [
+  "capacityProviderStrategy": [
     {
       "capacityProvider": "FARGATE",
       "weight": 1

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CreateServerGroupDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CreateServerGroupDescription.java
@@ -98,7 +98,7 @@ public class CreateServerGroupDescription extends AbstractECSDescription {
 
   Set<TargetGroupProperties> targetGroupMappings;
 
-  List<CapacityProviderStrategyItem> capacityProviderStrategies;
+  List<CapacityProviderStrategyItem> capacityProviderStrategy;
 
   @Override
   public String getRegion() {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
@@ -317,10 +317,10 @@ public class CreateServerGroupAtomicOperation
       }
     }
 
-    if (description.getCapacityProviderStrategies() != null
-        && !description.getCapacityProviderStrategies().isEmpty()) {
+    if (description.getCapacityProviderStrategy() != null
+        && !description.getCapacityProviderStrategy().isEmpty()) {
 
-      for (CapacityProviderStrategyItem cpStrategy : description.getCapacityProviderStrategies()) {
+      for (CapacityProviderStrategyItem cpStrategy : description.getCapacityProviderStrategy()) {
         if (FARGATE.equals(cpStrategy.getCapacityProvider())
             || FARGATE_SPOT.equals(cpStrategy.getCapacityProvider())) {
           request.setRequiresCompatibilities(Arrays.asList(FARGATE));
@@ -407,9 +407,9 @@ public class CreateServerGroupAtomicOperation
       if (templateExecutionRole == null || templateExecutionRole.isEmpty()) {
         requestTemplate.setExecutionRoleArn(ecsServiceRole);
       }
-    } else if (description.getCapacityProviderStrategies() != null
-        && !description.getCapacityProviderStrategies().isEmpty()) {
-      for (CapacityProviderStrategyItem cpStrategy : description.getCapacityProviderStrategies()) {
+    } else if (description.getCapacityProviderStrategy() != null
+        && !description.getCapacityProviderStrategy().isEmpty()) {
+      for (CapacityProviderStrategyItem cpStrategy : description.getCapacityProviderStrategy()) {
         if (FARGATE.equals(cpStrategy.getCapacityProvider())
             || FARGATE_SPOT.equals(cpStrategy.getCapacityProvider())) {
           String templateExecutionRole = requestTemplate.getExecutionRoleArn();
@@ -605,9 +605,9 @@ public class CreateServerGroupAtomicOperation
 
     if (!StringUtils.isEmpty(description.getLaunchType())) {
       request.withLaunchType(description.getLaunchType());
-    } else if (description.getCapacityProviderStrategies() != null
-        && !description.getCapacityProviderStrategies().isEmpty()) {
-      request.withCapacityProviderStrategy(description.getCapacityProviderStrategies());
+    } else if (description.getCapacityProviderStrategy() != null
+        && !description.getCapacityProviderStrategy().isEmpty()) {
+      request.withCapacityProviderStrategy(description.getCapacityProviderStrategy());
     }
 
     if (!StringUtils.isEmpty(description.getPlatformVersion())) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/EcsCreateServerGroupDescriptionValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/EcsCreateServerGroupDescriptionValidator.java
@@ -201,20 +201,20 @@ public class EcsCreateServerGroupDescriptionValidator extends CommonValidator {
 
   private void validateComputeOptions(
       CreateServerGroupDescription createServerGroupDescription, ValidationErrors errors) {
-    if (createServerGroupDescription.getCapacityProviderStrategies() != null
-        && !createServerGroupDescription.getCapacityProviderStrategies().isEmpty()) {
+    if (createServerGroupDescription.getCapacityProviderStrategy() != null
+        && !createServerGroupDescription.getCapacityProviderStrategy().isEmpty()) {
       if (!StringUtils.isBlank(createServerGroupDescription.getLaunchType())) {
         errors.rejectValue(
             "launchType",
             errorKey + "." + "launchType" + "." + "invalid",
-            "LaunchType cannot be specified when CapacityProviderStrategies are specified.");
+            "LaunchType cannot be specified when CapacityProviderStrategy are specified.");
       }
-    } else if (createServerGroupDescription.getCapacityProviderStrategies() == null
+    } else if (createServerGroupDescription.getCapacityProviderStrategy() == null
         && StringUtils.isBlank(createServerGroupDescription.getLaunchType())) {
       errors.rejectValue(
           "launchType",
           errorKey + "." + "launchType" + "." + "invalid",
-          "LaunchType or CapacityProviderStrategies must be specified.");
+          "LaunchType or CapacityProviderStrategy must be specified.");
     }
   }
 

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
@@ -343,7 +343,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       capacity: new ServerGroup.Capacity(1, 1, 1),
       availabilityZones: ['us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c']],
       placementStrategySequence: [],
-      capacityProviderStrategies: [capacityProviderStrategy],
+      capacityProviderStrategy: [capacityProviderStrategy],
       platformVersion: '1.0.0',
       networkMode: 'awsvpc',
       subnetType: 'public',
@@ -789,7 +789,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     description.getFreeFormDetails() >> 'test'
     description.getEcsClusterName() >> 'test-cluster'
     description.getIamRole() >> 'None (No IAM role)'
-    description.getCapacityProviderStrategies() >> [capacityProviderStrategy]
+    description.getCapacityProviderStrategy() >> [capacityProviderStrategy]
     description.getResolvedTaskDefinitionArtifact() >> resolvedArtifact
     description.getContainerToImageMap() >> [
       web: "docker-image-url"

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/EcsCreateServergroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/EcsCreateServergroupDescriptionValidatorSpec.groovy
@@ -191,7 +191,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
       weight: 1
     )
     def description = getDescription()
-    description.capacityProviderStrategies = [capacityProviderStrategy]
+    description.capacityProviderStrategy = [capacityProviderStrategy]
     description.launchType = 'FARGATE'
     def errors = Mock(ValidationErrors)
 
@@ -199,13 +199,13 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     validator.validate([], description, errors)
 
     then:
-    1 * errors.rejectValue('launchType', 'createServerGroupDescription.launchType.invalid', 'LaunchType cannot be specified when CapacityProviderStrategies are specified.')
+    1 * errors.rejectValue('launchType', 'createServerGroupDescription.launchType.invalid', 'LaunchType cannot be specified when CapacityProviderStrategy are specified.')
   }
 
   void 'should fail when neither launch type or capacity provider strategy are defined'() {
     given:
     def description = getDescription()
-    description.capacityProviderStrategies = null
+    description.capacityProviderStrategy = null
     description.launchType = null
     def errors = Mock(ValidationErrors)
 
@@ -213,7 +213,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     validator.validate([], description, errors)
 
     then:
-    1 * errors.rejectValue('launchType', 'createServerGroupDescription.launchType.invalid', 'LaunchType or CapacityProviderStrategies must be specified.')
+    1 * errors.rejectValue('launchType', 'createServerGroupDescription.launchType.invalid', 'LaunchType or CapacityProviderStrategy must be specified.')
   }
 
   void 'target group mappings should fail when container name is specified but load balancer is missing'() {


### PR DESCRIPTION
Rename capacityProviderStrategies to capacityProviderStrategy to align with CreateService api. As this is a new feature for this release, this would not be backwards incompatible.
