### PR TITLE
chore(web): Removed `IllegalArgumentExceptionHandler` as it has been moved to `kork-web`

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/WebConfig.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/WebConfig.groovy
@@ -91,13 +91,4 @@ public class WebConfig extends WebMvcConfigurerAdapter {
       .favorPathExtension(false)
       .ignoreAcceptHeader(true)
   }
-
-  @ControllerAdvice
-  @Order(Ordered.HIGHEST_PRECEDENCE)
-  static class IllegalArgumentExceptionHandler {
-    @ExceptionHandler(IllegalArgumentException)
-    public void handle(HttpServletResponse response, IllegalArgumentException ex) {
-      response.sendError(HttpStatus.BAD_REQUEST.value(), ex.getMessage())
-    }
-  }
 }


### PR DESCRIPTION
relates to https://github.com/spinnaker/kork/pull/831
