### PR TITLE
fix(ecs): add application name filter to findCluster

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -37,6 +37,7 @@ import com.netflix.spinnaker.clouddriver.ecs.model.EcsServerCluster;
 import com.netflix.spinnaker.clouddriver.ecs.model.EcsServerGroup;
 import com.netflix.spinnaker.clouddriver.ecs.model.EcsTask;
 import com.netflix.spinnaker.clouddriver.ecs.model.TaskDefinition;
+import com.netflix.spinnaker.clouddriver.ecs.names.MonikerHelper;
 import com.netflix.spinnaker.clouddriver.ecs.security.NetflixECSCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.services.ContainerInformationService;
 import com.netflix.spinnaker.clouddriver.ecs.services.SubnetSelector;
@@ -533,8 +534,9 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
 
     try {
       AmazonCredentials credentials = getEcsCredentials(account);
-      // Can't filter by application as there's not enough information in the serverGroupName
-      clusterMap = findClusters(clusterMap, credentials);
+      Moniker moniker = MonikerHelper.applicationNameToMoniker(serverGroupName);
+      log.debug("App Name is: " + moniker.getApp());
+      clusterMap = findClusters(clusterMap, credentials, moniker.getApp());
     } catch (NoSuchElementException exception) {
       /* This is ugly, but not sure how else to do it. If we don't have creds due
        *  to not being an ECS account, there's nothing to do here, and we should


### PR DESCRIPTION
As a part of the Moniker PR, logic was removed that enabled filtering on the App name. This allowed the server group info to be returned quickly. In release 1.24.0, users have been seeing timeouts, and this change will look to add back the previously removed application filter.

Current 1.24.0 Release Experience: Users with large amounts of AWS resources (such as services, task definitions, and tasks) are starting to see their server group/clusters view timing out with errors.

Testing done: As this is a performance improvement, it is difficult to add unit tests (load tests would be the best to test this scenario).
- Manually tested it against my test stack. I'm not seeing any regression, and verified that the new Application filter (using Monikers) and the old Application filter (inferring from Server Group Name) are both returning the same value.

Closes: https://github.com/spinnaker/spinnaker/issues/6245