### PR TITLE
feat(amazon/lb): Allow external load balancers to set IpAddressType

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAmazonLoadBalancerV2Description.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAmazonLoadBalancerV2Description.java
@@ -27,6 +27,7 @@ public class UpsertAmazonLoadBalancerV2Description extends UpsertAmazonLoadBalan
   public List<TargetGroup> targetGroups = new ArrayList<>();
   public Boolean deletionProtection = false;
   public Boolean loadBalancingCrossZone;
+  public String ipAddressType = "ipv4";
 
   public static class TargetGroup {
     private String name;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/LoadBalancerV2UpsertHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/LoadBalancerV2UpsertHandler.groovy
@@ -402,7 +402,7 @@ class LoadBalancerV2UpsertHandler {
     }
 
     def currentIpAddressType = loadBalancer.ipAddressType
-    if (ipAddressType  &&  ipAddressType != currentIpAddressType && (loadBalancer.type == 'application' || loadBalancer.type == 'network')) {
+    if (ipAddressType && ipAddressType != currentIpAddressType && (loadBalancer.type == 'application' || loadBalancer.type == 'network')) {
       def newIpAddressType = loadBalancer.scheme == 'internal' ? 'ipv4' : ipAddressType
        loadBalancing.setIpAddressType(new SetIpAddressTypeRequest(
          loadBalancerArn: loadBalancerArn,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/LoadBalancerV2UpsertHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/LoadBalancerV2UpsertHandler.groovy
@@ -380,7 +380,8 @@ class LoadBalancerV2UpsertHandler {
                                  DeployDefaults deployDefaults,
                                  Integer idleTimeout,
                                  Boolean deletionProtection,
-                                 Boolean loadBalancingCrossZone
+                                 Boolean loadBalancingCrossZone,
+                                 String ipAddressType
   ) {
     def amazonErrors = []
     def loadBalancerName = loadBalancer.loadBalancerName
@@ -398,6 +399,16 @@ class LoadBalancerV2UpsertHandler {
         ))
         task.updateStatus BASE_PHASE, "Security groups updated on ${loadBalancerName}."
       }
+    }
+
+    def currentIpAddressType = loadBalancer.ipAddressType
+    if (ipAddressType  &&  ipAddressType != currentIpAddressType && (loadBalancer.type == 'application' || loadBalancer.type == 'network')) {
+      def newIpAddressType = loadBalancer.scheme == 'internal' ? 'ipv4' : ipAddressType
+       loadBalancing.setIpAddressType(new SetIpAddressTypeRequest(
+         loadBalancerArn: loadBalancerArn,
+         ipAddressType: newIpAddressType
+       ))
+      task.updateStatus BASE_PHASE, "IP Address type updated ${loadBalancerName}."
     }
 
     // Update load balancer attributes
@@ -559,8 +570,15 @@ class LoadBalancerV2UpsertHandler {
                                          String type,
                                          Integer idleTimeout,
                                          boolean deletionProtection,
-                                         boolean loadBalancingCrossZone) {
-    def request = new CreateLoadBalancerRequest().withName(loadBalancerName)
+                                         boolean loadBalancingCrossZone,
+                                         String ipAddressType
+  ) {
+    def request = new CreateLoadBalancerRequest().withName(loadBalancerName);
+
+    if (ipAddressType && (type == 'application' || type == 'network')) {
+      def addressType = isInternal ? 'ipv4' : ipAddressType
+      request.withIpAddressType(addressType)
+    }
 
     // Networking Related
     if (subnetIds) {
@@ -593,7 +611,7 @@ class LoadBalancerV2UpsertHandler {
     List<LoadBalancer> loadBalancers = result.getLoadBalancers()
     if (loadBalancers != null && loadBalancers.size() > 0) {
       createdLoadBalancer = loadBalancers.get(0)
-      updateLoadBalancer(loadBalancing, createdLoadBalancer, securityGroups, targetGroups, listeners, deployDefaults, idleTimeout, deletionProtection, loadBalancingCrossZone)
+      updateLoadBalancer(loadBalancing, createdLoadBalancer, securityGroups, targetGroups, listeners, deployDefaults, idleTimeout, deletionProtection, loadBalancingCrossZone, ipAddressType)
     }
 
     createdLoadBalancer

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/UpsertAmazonLoadBalancerV2AtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/UpsertAmazonLoadBalancerV2AtomicOperation.groovy
@@ -113,7 +113,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperation implements AtomicOperation<Upser
             description.subnetType, SubnetTarget.ELB, 1)
         }
         handleSecurityGroupIngress(region, securityGroups)
-        loadBalancer = LoadBalancerV2UpsertHandler.createLoadBalancer(loadBalancing, loadBalancerName, isInternal, subnetIds, securityGroups, description.targetGroups, description.listeners, deployDefaults, description.loadBalancerType.toString(), description.idleTimeout, description.deletionProtection, !!description.loadBalancingCrossZone)
+        loadBalancer = LoadBalancerV2UpsertHandler.createLoadBalancer(loadBalancing, loadBalancerName, isInternal, subnetIds, securityGroups, description.targetGroups, description.listeners, deployDefaults, description.loadBalancerType.toString(), description.idleTimeout, description.deletionProtection, !!description.loadBalancingCrossZone, description.ipAddressType)
         dnsName = loadBalancer.DNSName
 
         // Enable AWS shield. We only do this on creation. The ELB must be external, the account must be enabled with
@@ -136,7 +136,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperation implements AtomicOperation<Upser
       } else {
         task.updateStatus BASE_PHASE, "Found existing load balancer named ${loadBalancerName} in ${region}... Using that."
         dnsName = loadBalancer.DNSName
-        LoadBalancerV2UpsertHandler.updateLoadBalancer(loadBalancing, loadBalancer, securityGroups, description.targetGroups, description.listeners, deployDefaults, description.idleTimeout, description.deletionProtection, description.loadBalancingCrossZone)
+        LoadBalancerV2UpsertHandler.updateLoadBalancer(loadBalancing, loadBalancer, securityGroups, description.targetGroups, description.listeners, deployDefaults, description.idleTimeout, description.deletionProtection, description.loadBalancingCrossZone, description.ipAddressType)
       }
 
       task.updateStatus BASE_PHASE, "Done deploying ${loadBalancerName} to ${description.credentials.name} in ${region}."

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/UpsertAmazonLoadBalancerV2AtomicOperationSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/UpsertAmazonLoadBalancerV2AtomicOperationSpec.groovy
@@ -109,7 +109,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
     ],
     subnetType: "internal",
     idleTimeout: 60,
-    deletionProtection: true,
+    deletionProtection: true
   )
   UpsertAmazonLoadBalancerV2Description descriptionWithNoAttributes = new UpsertAmazonLoadBalancerV2Description(
     loadBalancerType: AmazonLoadBalancerType.APPLICATION,
@@ -232,7 +232,9 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
     1 * mockSubnetAnalyzer.getSubnetIdsForZones(['us-east-1a'], 'internal', SubnetTarget.ELB, 1) >> ["subnet-1"]
     1 * loadBalancing.describeLoadBalancers(new DescribeLoadBalancersRequest(names: ["foo-main-frontend"])) >>
       new DescribeLoadBalancersResult(loadBalancers: existingLoadBalancers)
+    1 * loadBalancing.setIpAddressType(new SetIpAddressTypeRequest (loadBalancerArn: loadBalancerArn, ipAddressType: 'ipv4')) >> new SetIpAddressTypeResult(ipAddressType: 'ipv4')
     1 * loadBalancing.createLoadBalancer(new CreateLoadBalancerRequest(
+      ipAddressType: 'ipv4',
       name: "foo-main-frontend",
       subnets: ["subnet-1"],
       securityGroups: ["sg-1234"],
@@ -282,6 +284,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
     1 * loadBalancing.describeListeners(new DescribeListenersRequest(loadBalancerArn: loadBalancerArn)) >> new DescribeListenersResult(listeners: existingListeners)
     1 * loadBalancing.createListener(new CreateListenerRequest(loadBalancerArn: loadBalancerArn, port: 80, protocol: "HTTP", defaultActions: [new Action(targetGroupArn: targetGroupArn, type: ActionTypeEnum.Forward, order: 1)]))
     1 * loadBalancing.describeLoadBalancerAttributes(_) >> [attributes: loadBalancerAttributes]
+    1 * loadBalancing.setIpAddressType(new SetIpAddressTypeRequest (loadBalancerArn: loadBalancerArn, ipAddressType: 'ipv4')) >> new SetIpAddressTypeResult(ipAddressType: 'ipv4')
     0 * _
   }
 
@@ -301,6 +304,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
       loadBalancerArn: loadBalancerArn,
       securityGroups: ["sg-1234"]
     ))
+    1 * loadBalancing.setIpAddressType(new SetIpAddressTypeRequest (loadBalancerArn: loadBalancerArn, ipAddressType: 'ipv4')) >> new SetIpAddressTypeResult(ipAddressType: 'ipv4')
     1 * loadBalancing.describeTargetGroups(new DescribeTargetGroupsRequest(loadBalancerArn: loadBalancerArn)) >> new DescribeTargetGroupsResult(targetGroups: existingTargetGroups)
     1 * loadBalancing.createTargetGroup(_ as CreateTargetGroupRequest) >> new CreateTargetGroupResult(targetGroups: [targetGroup])
     1 * loadBalancing.describeListeners(new DescribeListenersRequest(loadBalancerArn: loadBalancerArn)) >> new DescribeListenersResult(listeners: existingListeners)
@@ -350,6 +354,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
       assert request.targetGroupArn == "test:target:group:arn"
       return new ModifyTargetGroupAttributesResult()
     }
+    1 * loadBalancing.setIpAddressType(new SetIpAddressTypeRequest (loadBalancerArn: loadBalancerArn, ipAddressType: 'ipv4')) >> new SetIpAddressTypeResult(ipAddressType: 'ipv4')
     0 * _
   }
 
@@ -376,7 +381,9 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
     1 * mockSubnetAnalyzer.getSubnetIdsForZones(['us-east-1a'], 'internal', SubnetTarget.ELB, 1) >> ["subnet-1"]
     1 * loadBalancing.describeLoadBalancers(new DescribeLoadBalancersRequest(names: ["foo-main-frontend"])) >>
       new DescribeLoadBalancersResult(loadBalancers: existingLoadBalancers)
+    1 * loadBalancing.setIpAddressType(new SetIpAddressTypeRequest (loadBalancerArn: loadBalancerArn, ipAddressType: 'ipv4')) >> new SetIpAddressTypeResult(ipAddressType: 'ipv4')
     1 * loadBalancing.createLoadBalancer(new CreateLoadBalancerRequest(
+      ipAddressType: 'ipv4',
       name: "foo-main-frontend",
       subnets: ["subnet-1"],
       scheme: "internal",
@@ -440,6 +447,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
     1 * loadBalancing.createListener(new CreateListenerRequest(loadBalancerArn: loadBalancerArn, port: 80, protocol: "HTTP", defaultActions: [new Action(targetGroupArn: targetGroupArn, type: ActionTypeEnum.Forward, order: 1)]))
     1 * loadBalancing.describeLoadBalancerAttributes(_) >> [attributes: nlbLoadBalancerAttributes]
     1 * loadBalancing.modifyTargetGroupAttributes(_ as ModifyTargetGroupAttributesRequest)
+    1 * loadBalancing.setIpAddressType(new SetIpAddressTypeRequest (loadBalancerArn: loadBalancerArn, ipAddressType: 'ipv4')) >> new SetIpAddressTypeResult(ipAddressType: 'ipv4')
     0 * _
   }
 
@@ -465,6 +473,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
     1 * loadBalancing.describeListeners(new DescribeListenersRequest(loadBalancerArn: loadBalancerArn)) >> new DescribeListenersResult(listeners: existingListeners)
     1 * loadBalancing.createListener(new CreateListenerRequest(loadBalancerArn: loadBalancerArn, port: 80, protocol: "HTTP", defaultActions: [new Action(targetGroupArn: targetGroupArn, type: ActionTypeEnum.Forward, order: 1)]))
     1 * loadBalancing.describeLoadBalancerAttributes(_) >> [attributes: loadBalancerAttributes]
+    1 * loadBalancing.setIpAddressType(new SetIpAddressTypeRequest (loadBalancerArn: loadBalancerArn, ipAddressType: 'ipv4')) >> new SetIpAddressTypeResult(ipAddressType: 'ipv4')
     0 * _
   }
 
@@ -502,6 +511,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
     1 * loadBalancing.describeListeners(new DescribeListenersRequest(loadBalancerArn: loadBalancerArn)) >> new DescribeListenersResult(listeners: existingListeners)
     1 * loadBalancing.createListener(new CreateListenerRequest(loadBalancerArn: loadBalancerArn, port: 80, protocol: "HTTP", defaultActions: [new Action(targetGroupArn: targetGroupArn, type: ActionTypeEnum.Forward, order: 1)]))
     1 * loadBalancing.describeLoadBalancerAttributes(_) >> [attributes: loadBalancerAttributes]
+    1 * loadBalancing.setIpAddressType(new SetIpAddressTypeRequest (loadBalancerArn: loadBalancerArn, ipAddressType: 'ipv4')) >> new SetIpAddressTypeResult(ipAddressType: 'ipv4')
     0 * _
   }
 
@@ -528,6 +538,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
     1 * loadBalancing.describeListeners(new DescribeListenersRequest(loadBalancerArn: loadBalancerArn)) >> new DescribeListenersResult(listeners: existingListeners)
     1 * loadBalancing.createListener(new CreateListenerRequest(loadBalancerArn: loadBalancerArn, port: 80, protocol: "HTTP", defaultActions: [new Action(targetGroupArn: targetGroupArn, type: ActionTypeEnum.Forward, order: 1)]))
     1 * loadBalancing.describeLoadBalancerAttributes(_) >> [attributes: loadBalancerAttributes]
+    1 * loadBalancing.setIpAddressType(new SetIpAddressTypeRequest (loadBalancerArn: loadBalancerArn, ipAddressType: 'ipv4')) >> new SetIpAddressTypeResult(ipAddressType: 'ipv4')
     0 * _
   }
 
@@ -555,6 +566,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
     1 * loadBalancing.describeListeners(new DescribeListenersRequest(loadBalancerArn: loadBalancerArn)) >> new DescribeListenersResult(listeners: existingListeners)
     1 * loadBalancing.createListener(new CreateListenerRequest(loadBalancerArn: loadBalancerArn, port: 80, protocol: "HTTP", defaultActions: []))
     1 * loadBalancing.describeLoadBalancerAttributes(_) >> [attributes: loadBalancerAttributes]
+    1 * loadBalancing.setIpAddressType(new SetIpAddressTypeRequest (loadBalancerArn: loadBalancerArn, ipAddressType: 'ipv4')) >> new SetIpAddressTypeResult(ipAddressType: 'ipv4')
     0 * _
     thrown AtomicOperationException
   }
@@ -582,6 +594,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
     1 * loadBalancing.deleteListener(new DeleteListenerRequest(listenerArn: listenerArn))
     1 * loadBalancing.createListener(new CreateListenerRequest(loadBalancerArn: loadBalancerArn, port: 80, protocol: "HTTP", defaultActions: [new Action(targetGroupArn: targetGroupArn, type: ActionTypeEnum.Forward, order: 1)]))
     1 * loadBalancing.describeLoadBalancerAttributes(_) >> [attributes: loadBalancerAttributes]
+    1 * loadBalancing.setIpAddressType(new SetIpAddressTypeRequest (loadBalancerArn: loadBalancerArn, ipAddressType: 'ipv4')) >> new SetIpAddressTypeResult(ipAddressType: 'ipv4')
     0 * _
   }
 
@@ -603,7 +616,9 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
     1 * mockSubnetAnalyzer.getSubnetIdsForZones(['us-east-1a'], 'internet-facing', SubnetTarget.ELB, 1) >> ["subnet-1"]
     1 * loadBalancing.describeLoadBalancers(new DescribeLoadBalancersRequest(names: ["foo-main-frontend"])) >>
       new DescribeLoadBalancersResult(loadBalancers: existingLoadBalancers)
+    1 * loadBalancing.setIpAddressType(new SetIpAddressTypeRequest (loadBalancerArn: loadBalancerArn, ipAddressType: 'ipv4')) >> new SetIpAddressTypeResult(ipAddressType: 'ipv4')
     1 * loadBalancing.createLoadBalancer(new CreateLoadBalancerRequest(
+      ipAddressType: "ipv4",
       name: "foo-main-frontend",
       subnets: ["subnet-1"],
       securityGroups: ["sg-1234"],


### PR DESCRIPTION
In an effort to expand Ipv6 support to load balancers, clouddriver must support setting the ALB/NLB `IpAddressType`. 

Currently, clouddriver does not set this so it defaults to `ipv4` in AWS. With this PR, the value can be either `ipv4` or `dualstack` for _external_ load balancers (AWS has does not allow dual-stacking of internal load balancers since all IPv6 are public). 