### PR TITLE
refactor(aws):  Refactoring to better encapsulate Asg config related fields and separate launch template/launch config code

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AsgConfigHelper.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AsgConfigHelper.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy;
+
+import com.netflix.spinnaker.clouddriver.aws.services.SecurityGroupService;
+import com.netflix.spinnaker.clouddriver.helpers.OperationPoller;
+import com.netflix.spinnaker.config.AwsConfiguration.DeployDefaults;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.LocalDateTime;
+
+/** A helper class for utility methods related to {@link AutoScalingWorker.AsgConfiguration} */
+@Slf4j
+public class AsgConfigHelper {
+
+  public static String createName(String baseName, String suffix) {
+    StringBuilder name = new StringBuilder(baseName);
+    if (StringUtils.isNotEmpty(suffix)) {
+      name.append('-').append(suffix);
+    } else {
+      name.append('-').append(createDefaultSuffix());
+    }
+    return name.toString();
+  }
+
+  /**
+   * Set resolved security groups for an application.
+   *
+   * @param asgConfig Asg Configuration to work with
+   * @param securityGroupService SecurityGroup service
+   * @param deployDefaults defaults
+   * @return asgConfig with resolved security groups and classicLinkVpcSecurityGroups
+   */
+  public static AutoScalingWorker.AsgConfiguration setAppSecurityGroups(
+      AutoScalingWorker.AsgConfiguration asgConfig,
+      SecurityGroupService securityGroupService,
+      DeployDefaults deployDefaults) {
+
+    // resolve security group ids and names in request
+    List<String> securityGroupIds =
+        securityGroupService.resolveSecurityGroupIdsWithSubnetType(
+            asgConfig.getSecurityGroups(), asgConfig.getSubnetType());
+
+    // conditionally, find or create an application security group
+    if ((securityGroupIds == null || securityGroupIds.isEmpty())
+        || (deployDefaults.isAddAppGroupToServerGroup()
+            && securityGroupIds.size() < deployDefaults.getMaxSecurityGroups())) {
+
+      // get a mapping of security group names to ids and find an existing security group for
+      // application
+      final Map<String, String> names =
+          securityGroupService.getSecurityGroupNamesFromIds(securityGroupIds);
+      String existingAppGroup =
+          (names != null && !names.isEmpty())
+              ? names.keySet().stream()
+                  .filter(it -> it.contains(asgConfig.getApplication()))
+                  .findFirst()
+                  .orElse(null)
+              : null;
+
+      // if no existing security group, find by subnet type / create a new security group for
+      // application
+      if (StringUtils.isEmpty(existingAppGroup)) {
+        String applicationSecurityGroupId =
+            (String)
+                OperationPoller.retryWithBackoff(
+                    o ->
+                        createSecurityGroupForApp(
+                            securityGroupService,
+                            asgConfig.getApplication(),
+                            asgConfig.getSubnetType()),
+                    500,
+                    3);
+        securityGroupIds.add(applicationSecurityGroupId);
+      }
+    }
+    asgConfig.setSecurityGroups(securityGroupIds.stream().distinct().collect(Collectors.toList()));
+
+    if (asgConfig.getClassicLinkVpcSecurityGroups() != null
+        && !asgConfig.getClassicLinkVpcSecurityGroups().isEmpty()) {
+      if (StringUtils.isEmpty(asgConfig.getClassicLinkVpcId())) {
+        throw new IllegalStateException(
+            "Can't provide classic link security groups without classiclink vpc Id");
+      }
+      List<String> classicLinkIds =
+          securityGroupService.resolveSecurityGroupIdsInVpc(
+              asgConfig.getClassicLinkVpcSecurityGroups(), asgConfig.getClassicLinkVpcId());
+      asgConfig.setClassicLinkVpcSecurityGroups(classicLinkIds);
+    }
+
+    return asgConfig;
+  }
+
+  private static String createSecurityGroupForApp(
+      SecurityGroupService securityGroupService, String application, String subnetType) {
+
+    // find security group by subnet type
+    String applicationSecurityGroupId =
+        securityGroupService.getSecurityGroupForApplication(application, subnetType);
+
+    // conditionally, create security group
+    if (StringUtils.isEmpty(applicationSecurityGroupId)) {
+      log.debug("Creating security group for application {}", application);
+      applicationSecurityGroupId =
+          securityGroupService.createSecurityGroup(application, subnetType);
+    }
+    return applicationSecurityGroupId;
+  }
+
+  private static String createDefaultSuffix() {
+    return new LocalDateTime().toString("MMddYYYYHHmmss");
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertScalingPolicyDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertScalingPolicyDescription.groovy
@@ -47,7 +47,7 @@ class UpsertScalingPolicyDescription extends AbstractAmazonCredentialsDescriptio
 
   static class Simple {
     Integer cooldown = 600
-    Integer	scalingAdjustment
+    Integer scalingAdjustment
   }
 
   static class Step {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/SecurityGroupService.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/SecurityGroupService.groovy
@@ -161,4 +161,16 @@ class SecurityGroupService {
       return []
     }
   }
+
+  List<String> resolveSecurityGroupIdsWithSubnetType(List<String> securityGroupNamesAndIds, String subnetPurpose) {
+    return this.resolveSecurityGroupIdsByStrategy(securityGroupNamesAndIds) { List<String> names ->
+      this.getSecurityGroupIdsWithSubnetPurpose(names, subnetPurpose)
+    }
+  }
+
+  List<String> resolveSecurityGroupIdsInVpc(List<String> securityGroupNamesAndIds, String vpcId) {
+    return this.resolveSecurityGroupIdsByStrategy(securityGroupNamesAndIds) { List<String> names ->
+      this.getSecurityGroupIds(names, vpcId)
+    }
+  }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AsgConfigHelperSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AsgConfigHelperSpec.groovy
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy
+
+import com.netflix.spinnaker.config.AwsConfiguration
+import com.netflix.spinnaker.clouddriver.aws.services.SecurityGroupService
+import org.joda.time.LocalDateTime
+import spock.lang.Specification
+
+class AsgConfigHelperSpec extends Specification {
+  def securityGroupServiceMock = Mock(SecurityGroupService)
+  def deployDefaults = new AwsConfiguration.DeployDefaults()
+  def asgConfig = new AutoScalingWorker.AsgConfiguration(
+      application: "fooTest",
+      stack: "stack")
+
+  void "should return name correctly"() {
+    when:
+    def actualName = AsgConfigHelper.createName(baseName, suffix)
+
+    then:
+    actualName.contains(expectedName)
+
+    where:
+    baseName | suffix   || expectedName
+    "base"   | "suffix" || "base-suffix"
+    "base"   | null     || "base-${new LocalDateTime().toString("MMddYYYYHHmm")}"
+    "base"   | ""       || "base-${new LocalDateTime().toString("MMddYYYYHHmm")}"
+  }
+
+  void "should lookup security groups when provided by name"() {
+    given:
+    asgConfig.subnetType = null
+    asgConfig.classicLinkVpcSecurityGroups = null
+    asgConfig.securityGroups = securityGroupsInput
+
+    and:
+    deployDefaults.addAppGroupToServerGroup = false
+
+    when:
+    def actualAsgCfg = AsgConfigHelper.setAppSecurityGroups(asgConfig, securityGroupServiceMock, deployDefaults)
+
+    then:
+    1 * securityGroupServiceMock.resolveSecurityGroupIdsWithSubnetType(_, _) >> securityGroupsRet
+    0 * _
+
+    and:
+    actualAsgCfg.securityGroups == expectedGroups
+
+    where:
+    securityGroupsInput        | securityGroupsRet        || expectedGroups
+    ['foo']                    | ['sg-12345']             || ['sg-12345']
+    ['bar']                    | ['sg-45678']             || ['sg-45678']
+    ['foo', 'bar', 'sg-45678'] | ['sg-45678', 'sg-12345'] || ['sg-45678', 'sg-12345']
+    ['bar', 'sg-45678']        | ['sg-45678']             || ['sg-45678']
+    ['sg-12345']               | ['sg-12345']             || ['sg-12345']
+  }
+
+  void "should attach an existing application security group based on deploy defaults"() {
+    given:
+    asgConfig.application = "foo"
+    asgConfig.subnetType = null
+    asgConfig.classicLinkVpcSecurityGroups = null
+    asgConfig.securityGroups = securityGroupsInput
+
+    and:
+    deployDefaults.addAppGroupToServerGroup = appGroupToServerGroup
+    deployDefaults.maxSecurityGroups = maxSgs
+
+    when:
+    def actualAsgCfg = AsgConfigHelper.setAppSecurityGroups(asgConfig, securityGroupServiceMock, deployDefaults)
+
+    then:
+    1 * securityGroupServiceMock.resolveSecurityGroupIdsWithSubnetType(_, _) >> securityGroupsRet
+    getNamesCount * securityGroupServiceMock.getSecurityGroupNamesFromIds(_) >> securityGroupNamesFromIds
+    0 * _
+    actualAsgCfg.securityGroups == expectedGroups
+
+    where:
+    securityGroupsInput | securityGroupsRet | appGroupToServerGroup | maxSgs | securityGroupNamesFromIds | getNamesCount || expectedGroups
+    ['sg-12345']        | ['sg-12345']      | true                  | 5      | ['foo': 'sg-12345']       | 1             || ['sg-12345']
+    ['foo']             | ['sg-12345']      | true                  | 5      | ['foo': 'sg-12345']       | 1             || ['sg-12345']
+    ['sg-12345']        | ['sg-12345']      | true                  | 1      | _                         | 0             || ['sg-12345']
+    ['sg-12345']        | ['sg-12345']      | false                 | 5      | _                         | 0             || ['sg-12345']
+  }
+
+  void "should attach application security group using subnet purpose if no security groups provided or no existing app security group found"() {
+    given:
+    asgConfig.application = "foo"
+    asgConfig.subnetType = null
+    asgConfig.classicLinkVpcSecurityGroups = null
+    asgConfig.securityGroups = securityGroupsInput
+
+    and:
+    deployDefaults.addAppGroupToServerGroup = true
+    deployDefaults.maxSecurityGroups = 5
+
+    when:
+    def actualAsgCfg = AsgConfigHelper.setAppSecurityGroups(asgConfig, securityGroupServiceMock, deployDefaults)
+
+    then:
+    1 * securityGroupServiceMock.resolveSecurityGroupIdsWithSubnetType(_, _) >> securityGroupsRet
+    1 * securityGroupServiceMock.getSecurityGroupNamesFromIds(_) >> securityGroupNamesFromIds
+    1 * securityGroupServiceMock.getSecurityGroupForApplication(_, _) >> 'sg-12345'
+    actualAsgCfg.securityGroups == expectedGroups
+    0 * _
+
+    where:
+    securityGroupsInput | securityGroupsRet | securityGroupNamesFromIds || expectedGroups
+    null                | []                | [:]                       || ['sg-12345']
+    []                  | []                | [:]                       || ['sg-12345']
+    ['sg-45678']        | ['sg-45678']      | ['bar': 'sg-45678']       || ['sg-45678', 'sg-12345']
+    ['bar']             | ['sg-45678']      | ['bar': 'sg-45678']       || ['sg-45678', 'sg-12345']
+  }
+
+  void "should create an application security group conditionally"() {
+    given:
+    asgConfig.application = "foo"
+    asgConfig.subnetType = null
+    asgConfig.classicLinkVpcSecurityGroups = null
+    asgConfig.securityGroups = securityGroupsInput
+
+    and:
+    deployDefaults.addAppGroupToServerGroup = true
+    deployDefaults.maxSecurityGroups = 5
+
+    when:
+    def actualAsgCfg = AsgConfigHelper.setAppSecurityGroups(asgConfig, securityGroupServiceMock, deployDefaults)
+
+    then:
+    1 * securityGroupServiceMock.resolveSecurityGroupIdsWithSubnetType(_, _) >> securityGroupsRet
+    1 * securityGroupServiceMock.getSecurityGroupNamesFromIds(_) >> securityGroupNamesFromIds
+    1 * securityGroupServiceMock.getSecurityGroupForApplication(_, _) >> null
+    1 * securityGroupServiceMock.createSecurityGroup(_, _) >> 'sg-000-new'
+    actualAsgCfg.securityGroups == expectedGroups
+    0 * _
+
+    where:
+    securityGroupsInput | securityGroupsRet | securityGroupNamesFromIds || expectedGroups
+    null                | []                | [:]                       || ['sg-000-new']
+    []                  | []                | [:]                       || ['sg-000-new']
+    ['sg-45678']        | ['sg-45678']      | ['bar': 'sg-45678']       || ['sg-45678', 'sg-000-new']
+    ['bar']             | ['sg-45678']      | ['bar': 'sg-45678']       || ['sg-45678', 'sg-000-new']
+  }
+
+  void "throws exception if asked to attach classic link security group without providing classic link VPC id"() {
+    given:
+    asgConfig.subnetType = null
+    asgConfig.classicLinkVpcSecurityGroups = ["sg-12345"]
+    asgConfig.classicLinkVpcId = classicLinkVpcId
+
+    when:
+    AsgConfigHelper.setAppSecurityGroups(asgConfig, securityGroupServiceMock, deployDefaults)
+
+    then:
+    1 * securityGroupServiceMock.resolveSecurityGroupIdsWithSubnetType(_, _) >> ["sg-12345"]
+    0 * _
+
+    and:
+    def ex = thrown(IllegalStateException)
+    ex.message == "Can't provide classic link security groups without classiclink vpc Id"
+
+    where:
+    classicLinkVpcId << ['', null]
+  }
+
+  void "should attach classic link security group if vpc is linked"() {
+    given:
+    asgConfig.subnetType = null
+    asgConfig.securityGroups = ["sg-00000"]
+    asgConfig.classicLinkVpcId = "vpc-123"
+    asgConfig.classicLinkVpcSecurityGroups = classicLinkVpcSecurityGroups
+
+    when:
+    def actualAsgCfg = AsgConfigHelper.setAppSecurityGroups(asgConfig, securityGroupServiceMock, deployDefaults)
+
+    then:
+    1 * securityGroupServiceMock.resolveSecurityGroupIdsWithSubnetType(_,_) >> ["sg-12345"]
+    callCount * securityGroupServiceMock.resolveSecurityGroupIdsInVpc(_,_) >> classicLinkVpcSGsRet
+    0 * _
+    actualAsgCfg.classicLinkVpcSecurityGroups == expectedClassicLinkVpcSGs
+
+    where:
+    classicLinkVpcSecurityGroups | classicLinkVpcSGsRet |  callCount  || expectedClassicLinkVpcSGs
+    null                         | _                    |  0          ||  null
+    []                           | _                    |  0          ||  []
+    ['sg-45678']                 | ['sg-45678']         |  1          ||  ['sg-45678']
+    ['bar']                      | ['sg-45678']         |  1          ||  ['sg-45678']
+    ["sg-12345"]                 | ['sg-45678']         |  1          ||  ['sg-45678']
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilderSpec.groovy
@@ -50,7 +50,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, userDataOverride)
 
     then:
-    1 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> ['sg-feef000', 'sg-named']
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType(_, _) >> ['sg-feef000', 'sg-named']
     1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->
       assert req.securityGroups.toList().sort() == expectedGroups.toList().sort()
     }
@@ -76,7 +76,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, userDataOverride)
 
     then:
-    1 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> []
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType(_, _) >> []
     1 * securityGroupService.getSecurityGroupNamesFromIds(_) >> [:]
     1 * securityGroupService.getSecurityGroupForApplication(application, subnetType) >> application
     1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->
@@ -103,7 +103,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, userDataOverride)
 
     then:
-    1 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> []
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType(_, _) >> []
     1 * securityGroupService.getSecurityGroupNamesFromIds(_) >> [:]
     1 * securityGroupService.getSecurityGroupForApplication(application, subnetType) >> application
     1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->
@@ -132,9 +132,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, new UserDataOverride(enabled: true))
 
     then:
-    1 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> []
-    1 * securityGroupService.getSecurityGroupNamesFromIds(_) >> [:]
-    1 * securityGroupService.getSecurityGroupForApplication(application, subnetType) >> application
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType([], null) >> ["sg-123"]
     1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->
       assert req.getUserData() == expectedUserData
     }
@@ -164,7 +162,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, userDataOverride)
 
     then:
-    1 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> []
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType(_, _) >> []
     1 * securityGroupService.getSecurityGroupNamesFromIds(_) >> [:]
     1 * securityGroupService.getSecurityGroupForApplication(application, subnetType) >> application
     1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->
@@ -192,7 +190,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, userDataOverride)
 
     then:
-    1 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> []
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType(_, _) >> []
     1 * securityGroupService.getSecurityGroupNamesFromIds(_) >> [:]
     1 * securityGroupService.getSecurityGroupForApplication(application, subnetType) >> null
     1 * securityGroupService.createSecurityGroup(application, subnetType) >> "sg-$application"
@@ -221,7 +219,8 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, userDataOverride)
 
     then:
-    2 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> ["sg-123", "sg-456"]
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType(_, _) >> ["sg-123", "sg-456"]
+    1 * securityGroupService.resolveSecurityGroupIdsInVpc(_, _) >> ["sg-123", "sg-456"]
     1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->
       assert req.classicLinkVPCId == "vpc-123"
       assert req.classicLinkVPCSecurityGroups == ["sg-123", "sg-456"]
@@ -248,7 +247,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, userDataOverride)
 
     then:
-    1 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> ["sg-123"]
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType(_, _) >> ["sg-123"]
     1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->
       assert req.classicLinkVPCId == "vpc-123"
       assert req.classicLinkVPCSecurityGroups == []
@@ -277,7 +276,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, userDataOverride)
 
     then:
-    1 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> securityGroups
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType(_, _) >> securityGroups
     1 * securityGroupService.getSecurityGroupNamesFromIds(_) >> [(appGroup): securityGroups[0]]
     1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->
       assert req.securityGroups.toList().sort() == expectedGroups.toList().sort()
@@ -307,7 +306,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, userDataOverride)
 
     then:
-    1 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> securityGroups
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType(_, _) >> securityGroups
     1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->
       assert req.securityGroups.toList().sort() == expectedGroups.toList().sort()
     }
@@ -337,7 +336,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, userDataOverride)
 
     then:
-    1 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> securityGroups
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType(_, _) >> securityGroups
     1 * securityGroupService.getSecurityGroupNamesFromIds(_) >> [notappgroup: securityGroups[0]]
     1 * securityGroupService.getSecurityGroupForApplication(application, subnetType) >> appGroup
     1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->
@@ -368,7 +367,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, userDataOverride)
 
     then:
-    1 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> securityGroups
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType(_, _) >> securityGroups
     1 * securityGroupService.getSecurityGroupNamesFromIds(_) >> [:]
     1 * securityGroupService.getSecurityGroupForApplication(application, subnetType) >> null
     1 * securityGroupService.createSecurityGroup(application, subnetType) >> appGroup
@@ -398,7 +397,8 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, userDataOverride)
 
     then:
-    2 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> ["sg-123"]
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType(_, _) >> ["sg-123"]
+    1 * securityGroupService.resolveSecurityGroupIdsInVpc(_, _) >> ["sg-123"]
     1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->
       assert req.classicLinkVPCId == "vpc-123"
       assert req.classicLinkVPCSecurityGroups == ["sg-123"]
@@ -425,7 +425,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
     builder.buildLaunchConfiguration(application, subnetType, settings, null, userDataOverride)
 
     then:
-    1 * securityGroupService.resolveSecurityGroupIdsByStrategy(_, _) >> []
+    1 * securityGroupService.resolveSecurityGroupIdsWithSubnetType(_, _) >> []
     1 * securityGroupService.getSecurityGroupNamesFromIds(_) >> [:]
     1 * securityGroupService.getSecurityGroupForApplication(application, subnetType) >> "sg-$application"
     1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidatorSpec.groovy
@@ -328,15 +328,15 @@ class BasicAmazonDeployDescriptionValidatorSpec extends Specification {
 
     where:
     requireIMDSv2 | associateIPv6Address | unlimitedCpuCredits  | expectedFieldsInWarning
-    false		  |      false           |        true          | ["unlimitedCpuCredits"]
-    false		  |      false           |       false          | ["unlimitedCpuCredits"]
-    true		  |      false           |        null          | ["requireIMDSv2"]
-    false		  |      true            |        null          | ["associateIPv6Address"]
-    true		  |      false           |        true          | ["requireIMDSv2, unlimitedCpuCredits"]
-    false		  |      true            |       false          | ["associateIPv6Address, unlimitedCpuCredits"]
-    true		  |      true            |        null          | ["requireIMDSv2, associateIPv6Address"]
-    true		  |      true            |        true          | ["requireIMDSv2, associateIPv6Address, unlimitedCpuCredits"]
-    true		  |      true            |       false          | ["requireIMDSv2, associateIPv6Address, unlimitedCpuCredits"]
+    false         |      false           |        true          | ["unlimitedCpuCredits"]
+    false         |      false           |       false          | ["unlimitedCpuCredits"]
+    true          |      false           |        null          | ["requireIMDSv2"]
+    false         |      true            |        null          | ["associateIPv6Address"]
+    true          |      false           |        true          | ["requireIMDSv2, unlimitedCpuCredits"]
+    false         |      true            |       false          | ["associateIPv6Address, unlimitedCpuCredits"]
+    true          |      true            |        null          | ["requireIMDSv2, associateIPv6Address"]
+    true          |      true            |        true          | ["requireIMDSv2, associateIPv6Address, unlimitedCpuCredits"]
+    true          |      true            |       false          | ["requireIMDSv2, associateIPv6Address, unlimitedCpuCredits"]
   }
 
   void "invalid request with unlimited cpu credits and unsupported instance type fails validation"() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/services/SecurityGroupServiceSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/services/SecurityGroupServiceSpec.groovy
@@ -158,6 +158,50 @@ class SecurityGroupServiceSpec extends Specification {
     result == ["sg-456", "sg-123"]
   }
 
+  void "should resolve Security Group for Application given security group names and subnet purpose"() {
+    def callCount = 0
+    def sgNamesInCall = []
+    def subnetPurposeInCall = ""
+    securityGroupService.metaClass.getSecurityGroupIdsWithSubnetPurpose = { List<String> sgNames, String subnetPurpose ->
+      sgNamesInCall.addAll(sgNames)
+      subnetPurposeInCall = subnetPurpose
+      callCount++
+      ["myApp": "sg-123"]
+    }
+
+    when:
+    def result = securityGroupService.resolveSecurityGroupIdsWithSubnetType(["myApp", "sg-456"], "internal")
+
+    then:
+    result == ["sg-456","sg-123"]
+    callCount == 1
+    sgNamesInCall == ["myApp"]
+    subnetPurposeInCall == "internal"
+    0 * _
+  }
+
+  void "should resolve Security Group for Application given security group names and vpc id"() {
+    def callCount = 0
+    def sgNamesInCall = []
+    def vpcIdInCall = ""
+    securityGroupService.metaClass.getSecurityGroupIds = { List<String> sgNames, String vpcId ->
+      sgNamesInCall.addAll(sgNames)
+      vpcIdInCall = vpcId
+      callCount++
+      ["myApp": "sg-123"]
+    }
+
+    when:
+    def result = securityGroupService.resolveSecurityGroupIdsInVpc(["myApp", "sg-456"], "vpc-1234")
+
+    then:
+    result == ["sg-456","sg-123"]
+    callCount == 1
+    sgNamesInCall == ["myApp"]
+    vpcIdInCall == "vpc-1234"
+    0 * _
+  }
+
   private Matcher<DescribeSecurityGroupsRequest> matchRequest(String... groupNames) {
     hasProperty("filters", contains(new Filter("group-name", groupNames.toList())))
   }


### PR DESCRIPTION
## Summary
  - refactored config related to ASG creation into ASGWorker.AsgConfiguration (previously, class fields of AsgWorker)
  - removed usage of LaunchConfigurationSettings in LaunchTemplate code path, replaced it with AsgConfiguration
     - facilitates for easier addition of LT related features without an expanding list of method parameters
  - moved security group related functions to SecurityGroupService (previously in DefaultLaunchConfigurationBuilder)
  - extracted common config setup code to a helper, out of DefaultLaunchConfigurationBuilder
  - added/updated unit tests

## Related Issue
https://github.com/spinnaker/spinnaker/issues/5989

## Background / Upcoming
As part of adding AWS EC2 support for multiple instance types and instance diversification, some refactoring is necessary: 
* Current PR - ASG configuration can now be passed around and is not just confined to _AutoScalingWorker_
* [Next PR (WIP)](https://github.com/pdk27/clouddriver/commit/b96aa49782820988d6df948aafccd573e7280572) - ASG builders will be added to separate ASG request building and ASG creation from conditional logic and dynamic configuration logic in _AutoScalingWorker_
* Next to next PR (WIP) - Support for ASG creation with mixed instances policy (currently, launch template and launch config options are supported) - https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_MixedInstancesPolicy.html

## Tests 
Manual local tests done to verify creation of ASG with various input parameters

