### PR TITLE
feat(kubernetes): add visibility to the task being processed by kubectl job executor

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DefaultTask.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DefaultTask.java
@@ -17,6 +17,7 @@ public class DefaultTask implements Task {
   private final Deque<Status> statusHistory = new ConcurrentLinkedDeque<Status>();
   private final Deque<Object> resultObjects = new ConcurrentLinkedDeque<Object>();
   private final Deque<SagaId> sagaIdentifiers = new ConcurrentLinkedDeque<SagaId>();
+  private final Deque<TaskOutput> taskOutputs = new ConcurrentLinkedDeque<TaskOutput>();
   private final long startTimeMs = System.currentTimeMillis();
 
   public String getOwnerId() {
@@ -35,7 +36,7 @@ public class DefaultTask implements Task {
 
   public void updateStatus(String phase, String status) {
     statusHistory.addLast(currentStatus().update(phase, status));
-    log.info("[" + phase + "] - " + status);
+    log.info("[" + phase + "] - Task: " + id + " " + status);
   }
 
   public void complete() {
@@ -98,6 +99,18 @@ public class DefaultTask implements Task {
   @Override
   public void retry() {
     statusHistory.addLast(currentStatus().update(TaskState.STARTED));
+  }
+
+  @Override
+  public void updateOutput(String manifest, String phase, String stdOut, String stdError) {
+    log.info("[" + phase + "] - Capturing output for Task: " + id + ", manifest: " + manifest);
+    TaskDisplayOutput output = new TaskDisplayOutput(manifest, phase, stdOut, stdError);
+    taskOutputs.addLast(output);
+  }
+
+  @Override
+  public List<? extends TaskOutput> getOutputs() {
+    return new ArrayList<>(taskOutputs);
   }
 
   public final String getId() {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/Task.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/Task.java
@@ -96,4 +96,15 @@ public interface Task {
 
   /** Updates the status of a failed Task to running in response to a retry operation. */
   void retry();
+
+  /**
+   * This method is used to capture any output produced by the task.
+   *
+   * @param stdOut - captures std output
+   * @param stdError - captures errors
+   */
+  void updateOutput(String manifest, String phase, String stdOut, String stdError);
+
+  /** @return */
+  List<? extends TaskOutput> getOutputs();
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/TaskDisplayOutput.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/TaskDisplayOutput.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.data.task;
+
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TaskDisplayOutput implements TaskOutput {
+  @Nullable private String manifest;
+  @Nullable private String phase;
+  @Nullable private String stdOut;
+  @Nullable private String stdError;
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/TaskOutput.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/TaskOutput.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.data.task;
+
+public interface TaskOutput {
+
+  /** Indicates the manifest in the task for which the output is captured */
+  String getManifest();
+
+  /**
+   * Returns the current phase of the execution. This is useful for representing different parts of
+   * a Task execution
+   */
+  String getPhase();
+
+  /** Returns the Stdout logs associated with the task */
+  String getStdOut();
+
+  /** Returns the Stderr logs associated with the task */
+  String getStdError();
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTask.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTask.java
@@ -6,6 +6,8 @@ import com.google.common.collect.Iterables;
 import com.netflix.spinnaker.clouddriver.data.task.SagaId;
 import com.netflix.spinnaker.clouddriver.data.task.Status;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
+import com.netflix.spinnaker.clouddriver.data.task.TaskDisplayOutput;
+import com.netflix.spinnaker.clouddriver.data.task.TaskOutput;
 import com.netflix.spinnaker.clouddriver.data.task.TaskState;
 import java.util.List;
 import java.util.Set;
@@ -65,7 +67,7 @@ public class JedisTask implements Task {
   public void updateStatus(String phase, String status) {
     checkMutable();
     repository.addToHistory(repository.currentState(this).update(phase, status), this);
-    log.info("[" + phase + "] " + status);
+    log.info("[" + phase + "] Task: " + id + " Status: " + status);
   }
 
   @Override
@@ -137,6 +139,17 @@ public class JedisTask implements Task {
   public void retry() {
     checkMutable();
     repository.addToHistory(repository.currentState(this).update(TaskState.STARTED), this);
+  }
+
+  @Override
+  public void updateOutput(String manifestName, String phase, String stdOut, String stdError) {
+    log.info("[" + phase + "] Capturing output for Task " + id + ", manifest: " + manifestName);
+    repository.addOutput(new TaskDisplayOutput(manifestName, phase, stdOut, stdError), this);
+  }
+
+  @Override
+  public List<? extends TaskOutput> getOutputs() {
+    return repository.getOutputs(this);
   }
 
   private void checkMutable() {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
@@ -21,9 +21,12 @@ import java.util.List;
 import java.util.Map;
 import lombok.Getter;
 import org.apache.commons.exec.CommandLine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Getter
 public class JobRequest {
+  private static final Logger log = LoggerFactory.getLogger(JobRequest.class);
   private final List<String> tokenizedCommand;
   private final CommandLine commandLine;
   private final Map<String, String> environment;
@@ -39,6 +42,7 @@ public class JobRequest {
 
   public JobRequest(
       List<String> tokenizedCommand, Map<String, String> environment, InputStream inputStream) {
+    log.debug("running command {}", tokenizedCommand);
     this.tokenizedCommand = tokenizedCommand;
     this.commandLine = createCommandLine(tokenizedCommand);
     this.environment = environment;

--- a/clouddriver-core/src/test/resources/com/netflix/spinnaker/clouddriver/data/task/jedis/task_with_output.json
+++ b/clouddriver-core/src/test/resources/com/netflix/spinnaker/clouddriver/data/task/jedis/task_with_output.json
@@ -31,5 +31,12 @@
     "retryable" : false,
     "status" : "Finished deploy"
   },
-  "outputs": []
+  "outputs": [
+    {
+      "manifest":"some-manifest",
+      "phase":"DEPLOY_K8S_MANIFEST",
+      "stdOut":"output",
+      "stdError":""
+    }
+  ]
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
@@ -383,4 +383,24 @@ public class KubernetesManifest extends HashMap<String, Object> {
       return KubernetesKind.from(kind, kubernetesApiGroup);
     }
   }
+
+  @JsonIgnore
+  public void setOutput(String output) {
+    put("stdOut", output);
+  }
+
+  @JsonIgnore
+  public void setErrorLogs(String errorLogs) {
+    put("stdError", errorLogs);
+  }
+
+  @JsonIgnore
+  public Optional<String> getOutput() {
+    return Optional.ofNullable((String) get("stdOut"));
+  }
+
+  @JsonIgnore
+  public Optional<String> getErrorLogs() {
+    return Optional.ofNullable((String) get("stdError"));
+  }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
@@ -112,6 +112,7 @@ public class KubernetesJobProvider implements JobProvider<KubernetesJobStatus> {
   }
 
   private Optional<V1Job> getKubernetesJob(String account, String location, String id) {
+    log.debug("Getting kubernetesJob for account {} at {} with id {}", account, location, id);
     return Optional.ofNullable(manifestProvider.getManifest(account, location, id, false))
         .map(KubernetesManifestContainer::getManifest)
         .map(m -> KubernetesCacheDataConverter.getResource(m, V1Job.class));

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTask.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTask.kt
@@ -19,8 +19,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.clouddriver.data.task.SagaId
 import com.netflix.spinnaker.clouddriver.data.task.Status
 import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskDisplayOutput
 import com.netflix.spinnaker.clouddriver.data.task.TaskDisplayStatus
+import com.netflix.spinnaker.clouddriver.data.task.TaskOutput
 import com.netflix.spinnaker.clouddriver.data.task.TaskState
+
 import java.util.concurrent.atomic.AtomicBoolean
 import org.slf4j.LoggerFactory
 
@@ -42,6 +45,7 @@ class SqlTask(
 
   private var resultObjects: MutableList<Any> = mutableListOf()
   private var history: MutableList<Status> = mutableListOf()
+  private var taskOutputs: MutableList<TaskOutput> = mutableListOf()
 
   private val dirty = AtomicBoolean(false)
 
@@ -118,6 +122,17 @@ class SqlTask(
     repository.updateState(this, TaskState.STARTED)
   }
 
+  override fun getOutputs(): List<TaskOutput> {
+    refresh()
+    return taskOutputs
+  }
+
+  override fun updateOutput(manifestName: String, phase: String, stdOut: String, stdError: String) {
+    this.dirty.set(true)
+    repository.updateOutput( TaskDisplayOutput(manifestName, phase, stdOut, stdError),this)
+    log.debug("Updated output for task {} for manifest {} for phase {} ", id, manifestName, phase)
+  }
+
   internal fun hydrateResultObjects(resultObjects: MutableList<Any>) {
     this.dirty.set(false)
     this.resultObjects = resultObjects
@@ -128,14 +143,21 @@ class SqlTask(
     this.history = history
   }
 
+  internal fun hydrateTaskOutputs(taskOutputs: MutableList<TaskOutput>) {
+    this.dirty.set(false)
+    this.taskOutputs = taskOutputs
+  }
+
   internal fun refresh(force: Boolean = false) {
     if (this.dirty.getAndSet(false) || force) {
       val task = repository.retrieveInternal(this.id)
       if (task != null) {
         history.clear()
         resultObjects.clear()
+        taskOutputs.clear()
         history.addAll(task.history)
         resultObjects.addAll(task.resultObjects)
+        taskOutputs.addAll(task.outputs)
       }
     }
   }

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.core.ClouddriverHostname
 import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus
 import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskOutput
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.data.task.TaskState
 import com.netflix.spinnaker.clouddriver.data.task.TaskState.FAILED
@@ -192,6 +193,43 @@ class SqlTaskRepository(
     }
   }
 
+  internal fun updateOutput(taskOutput: TaskOutput, task: Task) {
+    val historyId = ulid.nextULID()
+    withPool(poolName) {
+      jooq.transactional { ctx ->
+        addToOutput(ctx, historyId, task.id, taskOutput.manifest, taskOutput.phase, taskOutput.stdOut, taskOutput.stdError)
+      }
+    }
+  }
+
+  private fun addToOutput(ctx: DSLContext, id: String, taskId: String, manifestName: String, phase: String, stdOut: String, stdError: String) {
+    ctx
+      .insertInto(
+        taskOutputsTable,
+        listOf(
+          field("id"),
+          field("task_id"),
+          field("created_at"),
+          field("manifest"),
+          field("phase"),
+          field("stdOut"),
+          field("stdError")
+        )
+      )
+      .values(
+        listOf(
+          id,
+          taskId,
+          clock.millis(),
+          manifestName,
+          phase,
+          stdOut,
+          stdError
+        )
+      )
+      .execute()
+  }
+
   internal fun retrieveInternal(taskId: String): Task? {
     return retrieveInternal(field("id").eq(taskId), field("task_id").eq(taskId)).firstOrNull()
   }
@@ -210,6 +248,8 @@ class SqlTaskRepository(
          *  (select task_id, null as owner_id, null as request_id, null as created_at, null as saga_ids, null as body, state, phase, status from task_states_copy where task_id = '01D2H4H50VTF7CGBMP0D6HTGTF')
          *  UNION ALL
          *  (select task_id, null as owner_id, null as request_id, null as created_at, null as saga_ids, body, null as state, null as phase, null as status from task_results_copy where task_id = '01D2H4H50VTF7CGBMP0D6HTGTF')
+         *  UNION ALL
+         *  (select task_id, null as owner_id, null as request_id, null as created_at, null as saga_ids, null as body, null as state, manifest, phase, stdOut, stdError, null as status  from task_outputs_copy where task_id = '01D2H4H50VTF7CGBMP0D6HTGTF')
          */
         tasks.addAll(
           ctx
@@ -222,7 +262,10 @@ class SqlTaskRepository(
               field(sql("null")).`as`("body"),
               field(sql("null")).`as`("state"),
               field(sql("null")).`as`("phase"),
-              field(sql("null")).`as`("status")
+              field(sql("null")).`as`("status"),
+              field(sql("null")).`as`("manifest"),
+              field(sql("null")).`as`("stdOut"),
+              field(sql("null")).`as`("stdError")
             )
             .from(tasksTable)
             .where(condition)
@@ -237,7 +280,10 @@ class SqlTaskRepository(
                   field(sql("null")).`as`("body"),
                   field("state"),
                   field("phase"),
-                  field("status")
+                  field("status"),
+                  field(sql("null")).`as`("manifest"),
+                  field(sql("null")).`as`("stdOut"),
+                  field(sql("null")).`as`("stdError")
                 )
                 .from(taskStatesTable)
                 .where(relationshipCondition ?: condition)
@@ -253,9 +299,31 @@ class SqlTaskRepository(
                   field("body"),
                   field(sql("null")).`as`("state"),
                   field(sql("null")).`as`("phase"),
-                  field(sql("null")).`as`("status")
+                  field(sql("null")).`as`("status"),
+                  field(sql("null")).`as`("manifest"),
+                  field(sql("null")).`as`("stdOut"),
+                  field(sql("null")).`as`("stdError")
                 )
                 .from(taskResultsTable)
+                .where(relationshipCondition ?: condition)
+            )
+            .unionAll(
+              ctx
+                .select(
+                  field("task_id"),
+                  field(sql("null")).`as`("owner_id"),
+                  field(sql("null")).`as`("request_id"),
+                  field(sql("null")).`as`("created_at"),
+                  field(sql("null")).`as`("saga_ids"),
+                  field(sql("null")).`as`("body"),
+                  field(sql("null")).`as`("state"),
+                  field(sql("null")).`as`("status"),
+                  field("manifest"),
+                  field("phase"),
+                  field("stdOut"),
+                  field("stdError")
+                )
+                .from(taskOutputsTable)
                 .where(relationshipCondition ?: condition)
             )
             .fetchTasks()

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskMapper.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskMapper.kt
@@ -21,6 +21,8 @@ import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus
 import com.netflix.spinnaker.clouddriver.data.task.SagaId
 import com.netflix.spinnaker.clouddriver.data.task.Status
 import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskDisplayOutput
+import com.netflix.spinnaker.clouddriver.data.task.TaskOutput
 import com.netflix.spinnaker.clouddriver.data.task.TaskState
 import java.io.IOException
 import java.lang.String.format
@@ -42,6 +44,7 @@ class TaskMapper(
     val tasks = mutableMapOf<String, SqlTask>()
     val results = mutableMapOf<String, MutableList<Any>>()
     val history = mutableMapOf<String, MutableList<Status>>()
+    val taskOutputs = mutableMapOf<String, MutableList<TaskOutput>>()
 
     while (rs.next()) {
       when {
@@ -83,12 +86,26 @@ class TaskMapper(
             )
           )
         }
+        rs.getString("manifest") != null -> {
+          if (!taskOutputs.containsKey(rs.getString("task_id"))) {
+            taskOutputs[rs.getString("task_id")] = mutableListOf()
+          }
+          taskOutputs[rs.getString("task_id")]!!.add(
+            TaskDisplayOutput(
+              rs.getString("manifest"),
+              rs.getString("phase"),
+              rs.getString("stdOut"),
+              rs.getString("stdError")
+            )
+          )
+        }
       }
     }
 
     return tasks.values.map { task ->
       task.hydrateResultObjects(results.getOrDefault(task.id, mutableListOf()))
       task.hydrateHistory(history.getOrDefault(task.id, mutableListOf()))
+      task.hydrateTaskOutputs(taskOutputs.getOrDefault(task.id, mutableListOf()))
       task
     }
   }

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/sql.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/sql.kt
@@ -24,10 +24,12 @@ import org.jooq.impl.DSL.table
 internal val tasksTable = table("tasks")
 internal val taskStatesTable = table("task_states")
 internal val taskResultsTable = table("task_results")
+internal val taskOutputsTable = table("task_outputs")
 
 internal val tasksFields = listOf("id", "request_id", "owner_id", "created_at").map { field(it) }
 internal val taskStatesFields = listOf("id", "task_id", "created_at", "state", "phase", "status").map { field(it) }
 internal val taskResultsFields = listOf("id", "task_id", "body").map { field(it) }
+internal val taskOutputsFields = listOf("id", "task_id", "created_at", "manifest", "phase", "stdOut", "stdError").map { field(it) }
 
 /**
  * Run the provided [fn] in a transaction, retrying on failures using resilience4j.retry.instances.sqlTransaction

--- a/clouddriver-sql/src/main/resources/db/changelog/20180919-initial-schema.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog/20180919-initial-schema.yml
@@ -121,6 +121,57 @@ databaseChangeLog:
         tableName: task_results
 
 - changeSet:
+    id: create-task-outputs-table
+    author: robzienert
+    changes:
+      - createTable:
+          tableName: task_outputs
+          columns:
+            - column:
+                name: id
+                type: char(36)
+                constraints:
+                  primaryKey: true
+                  nullable: false
+            - column:
+                name: task_id
+                type: char(36)
+                constraints:
+                  nullable: false
+            - column:
+                name: created_at
+                type: bigint
+                constraints:
+                  nullable: false
+            - column:
+                name: manifest
+                type: text
+                constraints:
+                  nullable: false
+            - column:
+                name: phase
+                type: varchar(255)
+                constraints:
+                  nullable: false
+            - column:
+                name: stdOut
+                type: text
+                constraints:
+                  nullable: false
+            - column:
+                name: stdError
+                type: text
+                constraints:
+                  nullable: false
+      - modifySql:
+          dbms: mysql
+          append:
+            value: " engine innodb"
+    rollback:
+      - dropTable:
+          tableName: task_outputs
+
+- changeSet:
     id: create-indices
     author: robzienert
     changes:


### PR DESCRIPTION
## Purpose
* We have seen a few transient errors spanning across Orca and Clouddriver when the Clouddriver's Kubernetes Kubectl Job Executor attempts to perform a task (mainly the Deploy Manifest task). To gain more visibility into what was the last task action, we felt the need to extend the Kato Task object to include stdOut and stdError information in it as the current logs in the system do not capture that effectively.

This PR is meant to enable us to gain more visibility by adding more logs to the Deploy Manifest operation as well as to the KubectlJobExecutor. It also extends the kato task object to include stdOut and stdError information for all the manifests being processed in such a task.

## Changes
* Add logging statements and update existing logs for various common Kubernetes tasks to include more information about which manifest is being executed by the K8s job executor and for which account
* Extend Kato task object to include stdout and stderr info for the task in question
* Add implementation for the updated kato task object across in memory, redis and sql implementations
