### PR TITLE
feat(kubernetes): add visibility to kubectl job executor by adding lo…

### DIFF
--- a/clouddriver-core-tck/src/main/java/com/netflix/spinnaker/clouddriver/core/test/TaskRepositoryTck.java
+++ b/clouddriver-core-tck/src/main/java/com/netflix/spinnaker/clouddriver/core/test/TaskRepositoryTck.java
@@ -200,6 +200,32 @@ public abstract class TaskRepositoryTck<T extends TaskRepository> {
     }
   }
 
+  @Test
+  public void testTaskOutputStatus() {
+    Task t1 = subject.create("Test", "Test Status");
+
+    t1.updateOutput("some-manifest", "Deploy K8s Manifest", "output", "");
+
+    assertThat(t1.getOutputs()).hasSize(1);
+    assertThat(getField(t1.getOutputs().get(0), "manifest")).isEqualTo("some-manifest");
+    assertThat(getField(t1.getOutputs().get(0), "phase")).isEqualTo("Deploy K8s Manifest");
+    assertThat(getField(t1.getOutputs().get(0), "stdOut")).isEqualTo("output");
+    assertThat(getField(t1.getOutputs().get(0), "stdError")).isEqualTo("");
+  }
+
+  @Test
+  public void testTaskOutputStatusWithNullValues() {
+    Task t1 = subject.create("Test", "Test Status");
+
+    t1.updateOutput("some-manifest", "Deploy K8s Manifest", null, "");
+
+    assertThat(t1.getOutputs()).hasSize(1);
+    assertThat(getField(t1.getOutputs().get(0), "manifest")).isEqualTo("some-manifest");
+    assertThat(getField(t1.getOutputs().get(0), "phase")).isEqualTo("Deploy K8s Manifest");
+    assertThat(getField(t1.getOutputs().get(0), "stdOut")).isNull();
+    assertThat(getField(t1.getOutputs().get(0), "stdError")).isEqualTo("");
+  }
+
   private Object getField(Object object, String fieldName) {
     // TODO rz - Turns out the Redis & InMemory implementations behave totally different
     // in how they handle result objects. For now, the TCK is going to support the two

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/data/task/DefaultTask.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/data/task/DefaultTask.java
@@ -17,6 +17,7 @@ public class DefaultTask implements Task {
   private final Deque<Status> statusHistory = new ConcurrentLinkedDeque<Status>();
   private final Deque<Object> resultObjects = new ConcurrentLinkedDeque<Object>();
   private final Deque<SagaId> sagaIdentifiers = new ConcurrentLinkedDeque<SagaId>();
+  private final Deque<TaskOutput> taskOutputs = new ConcurrentLinkedDeque<TaskOutput>();
   private final long startTimeMs = System.currentTimeMillis();
 
   public String getOwnerId() {
@@ -35,7 +36,7 @@ public class DefaultTask implements Task {
 
   public void updateStatus(String phase, String status) {
     statusHistory.addLast(currentStatus().update(phase, status));
-    log.info("[" + phase + "] - " + status);
+    log.info("[" + phase + "] - Task: " + id + " " + status);
   }
 
   public void complete() {
@@ -98,6 +99,18 @@ public class DefaultTask implements Task {
   @Override
   public void retry() {
     statusHistory.addLast(currentStatus().update(TaskState.STARTED));
+  }
+
+  @Override
+  public void updateOutput(String manifest, String phase, String stdOut, String stdError) {
+    log.info("[" + phase + "] - Capturing output for Task: " + id + ", manifest: " + manifest);
+    TaskDisplayOutput output = new TaskDisplayOutput(manifest, phase, stdOut, stdError);
+    taskOutputs.addLast(output);
+  }
+
+  @Override
+  public List<? extends TaskOutput> getOutputs() {
+    return new ArrayList<>(taskOutputs);
   }
 
   public final String getId() {

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/data/task/Task.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/data/task/Task.java
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.clouddriver.data.task;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import org.springframework.lang.Nullable;
 
 /**
  * This interface represents the state of a given execution. Implementations must allow for updating
@@ -96,4 +97,16 @@ public interface Task {
 
   /** Updates the status of a failed Task to running in response to a retry operation. */
   void retry();
+
+  /**
+   * This method is used to capture any output produced by the task.
+   *
+   * @param stdOut - captures std output
+   * @param stdError - captures errors
+   */
+  void updateOutput(
+      String manifest, String phase, @Nullable String stdOut, @Nullable String stdError);
+
+  /** @return */
+  List<? extends TaskOutput> getOutputs();
 }

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/data/task/TaskDisplayOutput.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/data/task/TaskDisplayOutput.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.data.task;
+
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TaskDisplayOutput implements TaskOutput {
+  @Nullable private String manifest;
+  @Nullable private String phase;
+  @Nullable private String stdOut;
+  @Nullable private String stdError;
+}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/data/task/TaskOutput.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/data/task/TaskOutput.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.data.task;
+
+public interface TaskOutput {
+
+  /** Indicates the manifest in the task for which the output is captured */
+  String getManifest();
+
+  /**
+   * Returns the current phase of the execution. This is useful for representing different parts of
+   * a Task execution
+   */
+  String getPhase();
+
+  /** Returns the Stdout logs associated with the task */
+  String getStdOut();
+
+  /** Returns the Stderr logs associated with the task */
+  String getStdError();
+}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTask.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTask.java
@@ -6,6 +6,8 @@ import com.google.common.collect.Iterables;
 import com.netflix.spinnaker.clouddriver.data.task.SagaId;
 import com.netflix.spinnaker.clouddriver.data.task.Status;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
+import com.netflix.spinnaker.clouddriver.data.task.TaskDisplayOutput;
+import com.netflix.spinnaker.clouddriver.data.task.TaskOutput;
 import com.netflix.spinnaker.clouddriver.data.task.TaskState;
 import java.util.List;
 import java.util.Set;
@@ -65,7 +67,7 @@ public class JedisTask implements Task {
   public void updateStatus(String phase, String status) {
     checkMutable();
     repository.addToHistory(repository.currentState(this).update(phase, status), this);
-    log.info("[" + phase + "] " + status);
+    log.info("[" + phase + "] Task: " + id + " Status: " + status);
   }
 
   @Override
@@ -137,6 +139,17 @@ public class JedisTask implements Task {
   public void retry() {
     checkMutable();
     repository.addToHistory(repository.currentState(this).update(TaskState.STARTED), this);
+  }
+
+  @Override
+  public void updateOutput(String manifestName, String phase, String stdOut, String stdError) {
+    log.info("[" + phase + "] Capturing output for Task " + id + ", manifest: " + manifestName);
+    repository.addOutput(new TaskDisplayOutput(manifestName, phase, stdOut, stdError), this);
+  }
+
+  @Override
+  public List<? extends TaskOutput> getOutputs() {
+    return repository.getOutputs(this);
   }
 
   private void checkMutable() {

--- a/clouddriver-core/src/test/resources/com/netflix/spinnaker/clouddriver/data/task/jedis/task_with_output.json
+++ b/clouddriver-core/src/test/resources/com/netflix/spinnaker/clouddriver/data/task/jedis/task_with_output.json
@@ -31,5 +31,12 @@
     "retryable" : false,
     "status" : "Finished deploy"
   },
-  "outputs": []
+  "outputs": [
+    {
+      "manifest":"some-manifest",
+      "phase":"DEPLOY_K8S_MANIFEST",
+      "stdOut":"output",
+      "stdError":""
+    }
+  ]
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -35,6 +35,9 @@ public class KubernetesConfigurationProperties {
 
   @Data
   public static class KubernetesJobExecutorProperties {
+    private boolean persistTaskOutput = false;
+    private boolean enableTaskOutputForAllAccounts = false;
+
     private Retries retries = new Retries();
 
     @Data

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDeployManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDeployManifestConverter.java
@@ -22,6 +22,7 @@ import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.D
 import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.artifact.ResourceVersioner;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesDeployManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
@@ -50,13 +51,16 @@ public class KubernetesDeployManifestConverter
   private static final String KIND_LIST_ITEMS_KEY = "items";
 
   private final ResourceVersioner resourceVersioner;
+  private final KubernetesConfigurationProperties kubernetesConfigurationProperties;
 
   @Autowired
   public KubernetesDeployManifestConverter(
       CredentialsRepository<KubernetesNamedAccountCredentials> credentialsRepository,
-      ResourceVersioner resourceVersioner) {
+      ResourceVersioner resourceVersioner,
+      KubernetesConfigurationProperties kubernetesConfigurationProperties) {
     this.setCredentialsRepository(credentialsRepository);
     this.resourceVersioner = resourceVersioner;
+    this.kubernetesConfigurationProperties = kubernetesConfigurationProperties;
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
@@ -395,4 +395,24 @@ public class KubernetesManifest extends HashMap<String, Object> {
       return KubernetesKind.from(kind, kubernetesApiGroup);
     }
   }
+
+  @JsonIgnore
+  public void setOutput(String output) {
+    put("stdOut", output);
+  }
+
+  @JsonIgnore
+  public void setErrorLogs(String errorLogs) {
+    put("stdError", errorLogs);
+  }
+
+  @JsonIgnore
+  public Optional<String> getOutput() {
+    return Optional.ofNullable((String) get("stdOut"));
+  }
+
+  @JsonIgnore
+  public Optional<String> getErrorLogs() {
+    return Optional.ofNullable((String) get("stdError"));
+  }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/artifact/KubernetesCleanupArtifactsOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/artifact/KubernetesCleanupArtifactsOperation.java
@@ -92,7 +92,14 @@ public class KubernetesCleanupArtifactsOperation implements AtomicOperation<Oper
           result.merge(
               properties
                   .getHandler()
-                  .delete(credentials, a.getLocation(), name, null, new V1DeleteOptions()));
+                  .delete(
+                      credentials,
+                      a.getLocation(),
+                      name,
+                      null,
+                      new V1DeleteOptions(),
+                      getTask(),
+                      OP_NAME));
         });
 
     result.setManifests(null);

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanDelete.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanDelete.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.op.handler;
 
 import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.OperationResult;
@@ -37,10 +38,12 @@ public interface CanDelete {
       String namespace,
       String name,
       KubernetesSelectorList labelSelectors,
-      V1DeleteOptions options) {
+      V1DeleteOptions options,
+      Task task,
+      String opName) {
     options = options == null ? new V1DeleteOptions() : options;
     List<String> deletedNames =
-        credentials.delete(kind(), namespace, name, labelSelectors, options);
+        credentials.delete(kind(), namespace, name, labelSelectors, options, task, opName);
     OperationResult result = new OperationResult();
     Set<String> fullNames =
         deletedNames.stream()

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanPatch.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanPatch.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.op.handler;
 
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.JsonPatch;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPatchOptions;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
@@ -34,8 +35,10 @@ public interface CanPatch {
       String namespace,
       String name,
       KubernetesPatchOptions options,
-      KubernetesManifest manifest) {
-    credentials.patch(kind(), namespace, name, options, manifest);
+      KubernetesManifest manifest,
+      Task task,
+      String opName) {
+    credentials.patch(kind(), namespace, name, options, manifest, task, opName);
     return patch(namespace, name);
   }
 
@@ -44,8 +47,10 @@ public interface CanPatch {
       String namespace,
       String name,
       KubernetesPatchOptions options,
-      List<JsonPatch> patches) {
-    credentials.patch(kind(), namespace, name, options, patches);
+      List<JsonPatch> patches,
+      Task task,
+      String opName) {
+    credentials.patch(kind(), namespace, name, options, patches, task, opName);
     return patch(namespace, name);
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanResize.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanResize.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.op.handler;
 
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.model.ServerGroup.Capacity;
@@ -25,7 +26,12 @@ public interface CanResize {
   KubernetesKind kind();
 
   default void resize(
-      KubernetesCredentials credentials, String namespace, String name, Capacity capacity) {
-    credentials.scale(kind(), namespace, name, capacity.getDesired());
+      KubernetesCredentials credentials,
+      String namespace,
+      String name,
+      Capacity capacity,
+      Task task,
+      String opName) {
+    credentials.scale(kind(), namespace, name, capacity.getDesired(), task, opName);
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanResumeRollout.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanResumeRollout.java
@@ -17,13 +17,15 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.op.handler;
 
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 
 public interface CanResumeRollout {
   KubernetesKind kind();
 
-  default void resumeRollout(KubernetesCredentials credentials, String namespace, String name) {
-    credentials.resumeRollout(kind(), namespace, name);
+  default void resumeRollout(
+      KubernetesCredentials credentials, String namespace, String name, Task task, String opName) {
+    credentials.resumeRollout(kind(), namespace, name, task, opName);
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanRollingRestart.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanRollingRestart.java
@@ -17,13 +17,15 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.op.handler;
 
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 
 public interface CanRollingRestart {
   KubernetesKind kind();
 
-  default void rollingRestart(KubernetesCredentials credentials, String namespace, String name) {
-    credentials.rollingRestart(kind(), namespace, name);
+  default void rollingRestart(
+      KubernetesCredentials credentials, String namespace, String name, Task task, String opName) {
+    credentials.rollingRestart(kind(), namespace, name, task, opName);
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanScale.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanScale.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.op.handler;
 
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 
@@ -24,7 +25,12 @@ public interface CanScale {
   KubernetesKind kind();
 
   default void scale(
-      KubernetesCredentials credentials, String namespace, String name, int replicas) {
-    credentials.scale(kind(), namespace, name, replicas);
+      KubernetesCredentials credentials,
+      String namespace,
+      String name,
+      int replicas,
+      Task task,
+      String opName) {
+    credentials.scale(kind(), namespace, name, replicas, task, opName);
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
@@ -110,7 +110,9 @@ public abstract class AbstractKubernetesEnableDisableManifestOperation
         target.getNamespace(),
         target.getName(),
         KubernetesPatchOptions.json(),
-        patch);
+        patch,
+        getTask(),
+        OP_NAME);
 
     HasPods podHandler = null;
     try {
@@ -127,14 +129,27 @@ public abstract class AbstractKubernetesEnableDisableManifestOperation
       for (KubernetesManifest pod : pods) {
         patch = patchResource(loadBalancerHandler, loadBalancer, pod);
         credentials.patch(
-            pod.getKind(), pod.getNamespace(), pod.getName(), KubernetesPatchOptions.json(), patch);
+            pod.getKind(),
+            pod.getNamespace(),
+            pod.getName(),
+            KubernetesPatchOptions.json(),
+            patch,
+            getTask(),
+            OP_NAME);
       }
     }
   }
 
   @Override
   public OperationResult operate(List<OperationResult> priorOutputs) {
-    getTask().updateStatus(OP_NAME, "Starting " + getVerbName() + " operation...");
+    getTask()
+        .updateStatus(
+            OP_NAME,
+            "Starting "
+                + getVerbName()
+                + " operation in account "
+                + credentials.getAccountName()
+                + "...");
     KubernetesCoordinates coordinates = description.getPointCoordinates();
     KubernetesManifest target =
         Optional.ofNullable(credentials.get(coordinates))

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeleteManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeleteManifestOperation.java
@@ -47,7 +47,11 @@ public class KubernetesDeleteManifestOperation implements AtomicOperation<Operat
 
   @Override
   public OperationResult operate(List<OperationResult> priorOutputs) {
-    getTask().updateStatus(OP_NAME, "Starting delete operation...");
+    getTask()
+        .updateStatus(
+            OP_NAME,
+            "Starting delete operation in account " + credentials.getAccountName() + "...");
+
     List<KubernetesCoordinates> coordinates;
 
     if (description.isDynamic()) {
@@ -76,17 +80,23 @@ public class KubernetesDeleteManifestOperation implements AtomicOperation<Operat
               .updateStatus(OP_NAME, "Looking up resource properties for " + c.getKind() + "...");
           KubernetesHandler deployer =
               credentials.getResourcePropertyRegistry().get(c.getKind()).getHandler();
-          getTask().updateStatus(OP_NAME, "Calling delete operation...");
+          getTask().updateStatus(OP_NAME, "Calling delete operation on resource" + c + "...");
           result.merge(
               deployer.delete(
                   credentials,
                   c.getNamespace(),
                   c.getName(),
                   description.getLabelSelectors(),
-                  deleteOptions));
+                  deleteOptions,
+                  getTask(),
+                  OP_NAME));
           getTask()
               .updateStatus(OP_NAME, " delete operation completed successfully for " + c.getName());
         });
+
+    getTask()
+        .updateStatus(
+            OP_NAME, " delete operation completed successfully for all applicable resources");
 
     return result;
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
@@ -67,7 +67,9 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
 
   @Override
   public OperationResult operate(List<OperationResult> _unused) {
-    getTask().updateStatus(OP_NAME, "Beginning deployment of manifest...");
+    getTask()
+        .updateStatus(
+            OP_NAME, "Beginning deployment of manifests in account " + accountName + " ...");
 
     final List<KubernetesManifest> inputManifests = getManifestsFromDescription();
     sortManifests(inputManifests);
@@ -153,14 +155,47 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
                       + holder.manifest.getFullResourceName()
                       + " to kubernetes master...");
           log.debug("Manifest in {} to be deployed: {}", accountName, holder.manifest);
-          result.merge(deployer.deploy(credentials, holder.manifest, strategy.getDeployStrategy()));
+          try {
+            OperationResult manifestOperationResult =
+                deployer.deploy(credentials, holder.manifest, strategy.getDeployStrategy());
+            // deploy returns a new OperationsResult with the manifest added to it - so at this
+            // point,
+            // its size will be 1
+            if (manifestOperationResult.getManifests().size() == 1) {
+              Optional<KubernetesManifest> returnedManifest =
+                  manifestOperationResult.getManifests().stream().findFirst();
+              returnedManifest.ifPresent(
+                  kubernetesManifest ->
+                      getTask()
+                          .updateOutput(
+                              kubernetesManifest.getFullResourceName(),
+                              OP_NAME,
+                              kubernetesManifest.getOutput().orElse(""),
+                              kubernetesManifest.getErrorLogs().orElse("")));
+            }
+            result.merge(manifestOperationResult);
+          } catch (Exception e) {
+            getTask()
+                .updateOutput(holder.manifest.getFullResourceName(), OP_NAME, "", e.toString());
+            throw e;
+          }
 
           result.getCreatedArtifacts().add(holder.artifact);
+          getTask()
+              .updateStatus(
+                  OP_NAME,
+                  "Deploy manifest task completed successfully for manifest "
+                      + holder.manifest.getFullResourceName()
+                      + " in account "
+                      + accountName);
         });
 
     result.removeSensitiveKeys(credentials.getResourcePropertyRegistry());
-
-    getTask().updateStatus(OP_NAME, "Deploy manifest task completed successfully.");
+    getTask()
+        .updateStatus(
+            OP_NAME,
+            "Deploy manifest task completed successfully for all manifests in account "
+                + accountName);
     return result;
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
@@ -155,30 +155,9 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
                       + holder.manifest.getFullResourceName()
                       + " to kubernetes master...");
           log.debug("Manifest in {} to be deployed: {}", accountName, holder.manifest);
-          try {
-            OperationResult manifestOperationResult =
-                deployer.deploy(credentials, holder.manifest, strategy.getDeployStrategy());
-            // deploy returns a new OperationsResult with the manifest added to it - so at this
-            // point,
-            // its size will be 1
-            if (manifestOperationResult.getManifests().size() == 1) {
-              Optional<KubernetesManifest> returnedManifest =
-                  manifestOperationResult.getManifests().stream().findFirst();
-              returnedManifest.ifPresent(
-                  kubernetesManifest ->
-                      getTask()
-                          .updateOutput(
-                              kubernetesManifest.getFullResourceName(),
-                              OP_NAME,
-                              kubernetesManifest.getOutput().orElse(""),
-                              kubernetesManifest.getErrorLogs().orElse("")));
-            }
-            result.merge(manifestOperationResult);
-          } catch (Exception e) {
-            getTask()
-                .updateOutput(holder.manifest.getFullResourceName(), OP_NAME, "", e.toString());
-            throw e;
-          }
+          result.merge(
+              deployer.deploy(
+                  credentials, holder.manifest, strategy.getDeployStrategy(), getTask(), OP_NAME));
 
           result.getCreatedArtifacts().add(holder.artifact);
           getTask()

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesPatchManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesPatchManifestOperation.java
@@ -56,7 +56,9 @@ public class KubernetesPatchManifestOperation implements AtomicOperation<Operati
 
   @Override
   public OperationResult operate(List<OperationResult> _unused) {
-    updateStatus("Beginning patching of manifest");
+    updateStatus(
+        "Beginning patching of manifest in account " + credentials.getAccountName() + "...");
+
     KubernetesCoordinates objToPatch = description.getPointCoordinates();
 
     updateStatus("Finding patch handler for " + objToPatch + "...");
@@ -79,7 +81,9 @@ public class KubernetesPatchManifestOperation implements AtomicOperation<Operati
               objToPatch.getNamespace(),
               objToPatch.getName(),
               description.getOptions(),
-              jsonPatches));
+              jsonPatches,
+              getTask(),
+              OP_NAME));
     } else {
       updateStatus("Swapping out artifacts in " + objToPatch + " from context...");
       ReplaceResult replaceResult = replaceArtifacts(objToPatch, patchHandler);
@@ -92,11 +96,14 @@ public class KubernetesPatchManifestOperation implements AtomicOperation<Operati
               objToPatch.getNamespace(),
               objToPatch.getName(),
               description.getOptions(),
-              replaceResult.getManifest()));
+              replaceResult.getManifest(),
+              getTask(),
+              OP_NAME));
       result.getBoundArtifacts().addAll(replaceResult.getBoundArtifacts());
     }
 
     result.removeSensitiveKeys(credentials.getResourcePropertyRegistry());
+    getTask().updateStatus(OP_NAME, "Patch manifest operation completed successfully");
     return result;
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesPauseRolloutManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesPauseRolloutManifestOperation.java
@@ -44,7 +44,10 @@ public class KubernetesPauseRolloutManifestOperation implements AtomicOperation<
 
   @Override
   public Void operate(List<Void> priorOutputs) {
-    getTask().updateStatus(OP_NAME, "Starting pause rollout operation...");
+    getTask()
+        .updateStatus(
+            OP_NAME,
+            "Starting pause rollout operation in account " + credentials.getAccountName() + "...");
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 
     getTask().updateStatus(OP_NAME, "Looking up resource properties...");
@@ -58,8 +61,16 @@ public class KubernetesPauseRolloutManifestOperation implements AtomicOperation<
 
     CanPauseRollout canPauseRollout = (CanPauseRollout) deployer;
 
-    getTask().updateStatus(OP_NAME, "Calling pause rollout operation...");
+    getTask()
+        .updateStatus(
+            OP_NAME,
+            "Calling pause rollout operation for "
+                + coordinates.getName()
+                + " in namespace "
+                + coordinates.getName()
+                + "...");
     canPauseRollout.pauseRollout(credentials, coordinates.getNamespace(), coordinates.getName());
+    getTask().updateStatus(OP_NAME, "Pause rollout operation completed successfully");
 
     return null;
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesResumeRolloutManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesResumeRolloutManifestOperation.java
@@ -44,7 +44,12 @@ public class KubernetesResumeRolloutManifestOperation implements AtomicOperation
 
   @Override
   public Void operate(List<Void> priorOutputs) {
-    getTask().updateStatus(OP_NAME, "Starting resume rollout operation...");
+    getTask()
+        .updateStatus(
+            OP_NAME,
+            "Starting resume rollout operation in account "
+                + credentials.getAccountName()
+                + " ...");
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 
     getTask().updateStatus(OP_NAME, "Looking up resource properties...");
@@ -57,9 +62,17 @@ public class KubernetesResumeRolloutManifestOperation implements AtomicOperation
     }
 
     CanResumeRollout canResumeRollout = (CanResumeRollout) deployer;
-
-    getTask().updateStatus(OP_NAME, "Calling resume rollout operation...");
-    canResumeRollout.resumeRollout(credentials, coordinates.getNamespace(), coordinates.getName());
+    getTask()
+        .updateStatus(
+            OP_NAME,
+            "Calling resume rollout operation for "
+                + coordinates.getName()
+                + " in namespace "
+                + coordinates.getName()
+                + "...");
+    canResumeRollout.resumeRollout(
+        credentials, coordinates.getNamespace(), coordinates.getName(), getTask(), OP_NAME);
+    getTask().updateStatus(OP_NAME, "Resume rollout operation completed successfully");
 
     return null;
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesRollingRestartManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesRollingRestartManifestOperation.java
@@ -44,7 +44,13 @@ public class KubernetesRollingRestartManifestOperation implements AtomicOperatio
 
   @Override
   public Void operate(List<Void> priorOutputs) {
-    getTask().updateStatus(OP_NAME, "Starting rolling restart operation...");
+    getTask()
+        .updateStatus(
+            OP_NAME,
+            "Starting rolling restart operation in account "
+                + credentials.getAccountName()
+                + "...");
+
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 
     getTask().updateStatus(OP_NAME, "Looking up resource properties...");
@@ -58,9 +64,19 @@ public class KubernetesRollingRestartManifestOperation implements AtomicOperatio
 
     CanRollingRestart canRollingRestart = (CanRollingRestart) deployer;
 
+    getTask()
+        .updateStatus(
+            OP_NAME,
+            "Calling rolling restart operation for"
+                + coordinates.getName()
+                + " in namespace "
+                + coordinates.getName()
+                + "...");
+
     getTask().updateStatus(OP_NAME, "Calling rolling restart operation...");
     canRollingRestart.rollingRestart(
-        credentials, coordinates.getNamespace(), coordinates.getName());
+        credentials, coordinates.getNamespace(), coordinates.getName(), getTask(), OP_NAME);
+    getTask().updateStatus(OP_NAME, "Rolling rollout operation completed successfully");
 
     return null;
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesScaleManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesScaleManifestOperation.java
@@ -43,7 +43,10 @@ public class KubernetesScaleManifestOperation implements AtomicOperation<Void> {
 
   @Override
   public Void operate(List<Void> priorOutputs) {
-    getTask().updateStatus(OP_NAME, "Starting scale operation...");
+    getTask()
+        .updateStatus(
+            OP_NAME, "Starting scale operation in account " + credentials.getAccountName() + "...");
+
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 
     getTask().updateStatus(OP_NAME, "Looking up resource properties...");
@@ -57,9 +60,26 @@ public class KubernetesScaleManifestOperation implements AtomicOperation<Void> {
 
     CanScale canScale = (CanScale) deployer;
 
-    getTask().updateStatus(OP_NAME, "Calling scale operation...");
+    getTask()
+        .updateStatus(
+            OP_NAME,
+            "Calling scale operation for "
+                + coordinates.getName()
+                + " in namespace "
+                + coordinates.getName()
+                + " with replicas "
+                + description.getReplicas()
+                + "...");
+
     canScale.scale(
-        credentials, coordinates.getNamespace(), coordinates.getName(), description.getReplicas());
+        credentials,
+        coordinates.getNamespace(),
+        coordinates.getName(),
+        description.getReplicas(),
+        getTask(),
+        OP_NAME);
+
+    getTask().updateStatus(OP_NAME, "Scale operation completed successfully");
 
     return null;
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesUndoRolloutManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesUndoRolloutManifestOperation.java
@@ -44,7 +44,11 @@ public class KubernetesUndoRolloutManifestOperation implements AtomicOperation<V
 
   @Override
   public Void operate(List<Void> priorOutputs) {
-    getTask().updateStatus(OP_NAME, "Starting undo rollout operation...");
+    getTask()
+        .updateStatus(
+            OP_NAME,
+            "Starting undo rollout operation in account " + credentials.getAccountName() + "...");
+
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 
     getTask().updateStatus(OP_NAME, "Looking up resource properties...");
@@ -80,10 +84,21 @@ public class KubernetesUndoRolloutManifestOperation implements AtomicOperation<V
       getTask().updateStatus(OP_NAME, "Picked revision " + revision + "...");
     }
 
-    getTask().updateStatus(OP_NAME, "Calling undo rollout operation...");
+    getTask()
+        .updateStatus(
+            OP_NAME,
+            "Calling undo rollout operation for "
+                + coordinates.getName()
+                + " in namespace "
+                + coordinates.getNamespace()
+                + " with revision "
+                + revision
+                + "...");
+
     canUndoRollout.undoRollout(
         credentials, coordinates.getNamespace(), coordinates.getName(), revision);
 
+    getTask().updateStatus(OP_NAME, "Undo rollout operation completed successfully");
     return null;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/servergroup/KubernetesResizeServerGroupOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/servergroup/KubernetesResizeServerGroupOperation.java
@@ -59,7 +59,12 @@ public class KubernetesResizeServerGroupOperation implements AtomicOperation<Voi
 
     getTask().updateStatus(OP_NAME, "Calling resize operation...");
     canResize.resize(
-        credentials, coordinates.getNamespace(), coordinates.getName(), description.getCapacity());
+        credentials,
+        coordinates.getNamespace(),
+        coordinates.getName(),
+        description.getCapacity(),
+        getTask(),
+        OP_NAME);
 
     return null;
   }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/manifest/KubernetesDeployManifestConverterTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/manifest/KubernetesDeployManifestConverterTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.MapType;
 import com.google.common.io.CharStreams;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.converter.manifest.KubernetesDeployManifestConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesDeployManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKindProperties;
@@ -51,7 +52,9 @@ public class KubernetesDeployManifestConverterTest {
         Mockito.mock(CredentialsRepository.class);
     Mockito.when(credentialsRepository.getOne("kubernetes"))
         .thenReturn(Mockito.mock(KubernetesNamedAccountCredentials.class));
-    converter = new KubernetesDeployManifestConverter(credentialsRepository, null);
+    converter =
+        new KubernetesDeployManifestConverter(
+            credentialsRepository, null, new KubernetesConfigurationProperties());
     mapper = converter.getObjectMapper();
     mapType = mapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class);
   }
@@ -145,7 +148,9 @@ public class KubernetesDeployManifestConverterTest {
     CredentialsRepository<KubernetesNamedAccountCredentials> credentialsRepository =
         Mockito.mock(CredentialsRepository.class);
     Mockito.when(credentialsRepository.getOne("kubernetes")).thenReturn(accountCredentials);
-    converter = new KubernetesDeployManifestConverter(credentialsRepository, null);
+    converter =
+        new KubernetesDeployManifestConverter(
+            credentialsRepository, null, new KubernetesConfigurationProperties());
 
     String listTemplate = getResourceAsString("list-manifest.json");
     String deploymentJson = getResourceAsString("deployment-manifest.json");

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeleteManifestOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeleteManifestOperationTest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.MapType;
 import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.data.task.DefaultTask;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesAccountProperties.ManagedAccount;
 import com.netflix.spinnaker.clouddriver.kubernetes.converter.manifest.KubernetesDeleteManifestConverter;
@@ -135,7 +136,9 @@ public class KubernetesDeleteManifestOperationTest {
             namespaceCaptor.capture(),
             anyString(),
             any(KubernetesSelectorList.class),
-            any(V1DeleteOptions.class));
+            any(V1DeleteOptions.class),
+            any(Task.class),
+            anyString());
 
     assertEquals(KubernetesKind.CUSTOM_RESOURCE_DEFINITION, kindCaptor.getValue());
   }
@@ -176,7 +179,9 @@ public class KubernetesDeleteManifestOperationTest {
             namespaceCaptor.capture(),
             anyString(),
             any(KubernetesSelectorList.class),
-            any(V1DeleteOptions.class));
+            any(V1DeleteOptions.class),
+            any(Task.class),
+            anyString());
 
     assertEquals(customResource, kindCaptor.getValue());
     assertEquals(namespace, namespaceCaptor.getValue());
@@ -219,7 +224,9 @@ public class KubernetesDeleteManifestOperationTest {
             anyString(),
             anyString(),
             labelSelectorsCaptor.capture(),
-            any(V1DeleteOptions.class));
+            any(V1DeleteOptions.class),
+            any(Task.class),
+            anyString());
 
     assertEquals(customResource, kindCaptor.getValue());
     assertEquals(
@@ -366,7 +373,9 @@ public class KubernetesDeleteManifestOperationTest {
             anyString(),
             anyString(),
             any(KubernetesSelectorList.class),
-            deleteOptionsCaptor.capture());
+            deleteOptionsCaptor.capture(),
+            any(Task.class),
+            anyString());
     return deleteOptionsCaptor.getValue();
   }
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -30,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.netflix.spinnaker.clouddriver.data.task.DefaultTask;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.artifact.ResourceVersioner;
@@ -386,7 +388,7 @@ final class KubernetesDeployManifestOperationTest {
             ManifestFetcher.getManifest(
                     KubernetesDeployManifestOperationTest.class, "deploy/service-no-selector.yml")
                 .get(0));
-    when(credentialsMock.deploy(any(KubernetesManifest.class)))
+    when(credentialsMock.deploy(any(KubernetesManifest.class), any(Task.class), anyString()))
         .thenAnswer(
             invocation -> {
               // This simulates the fact that the Kubernetes API will add the default namespace if

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.op.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +27,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.netflix.spinnaker.clouddriver.data.task.DefaultTask;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.artifact.ResourceVersioner;
@@ -140,7 +142,7 @@ final class KubernetesRunJobOperationTest {
                 KubernetesKindProperties.withDefaultProperties(
                     invocation.getArgument(0, KubernetesKind.class)));
     when(credentialsMock.getResourcePropertyRegistry()).thenReturn(resourcePropertyRegistry);
-    when(credentialsMock.deploy(any(KubernetesManifest.class)))
+    when(credentialsMock.deploy(any(KubernetesManifest.class), any(Task.class), anyString()))
         .thenAnswer(
             invocation -> {
               KubernetesManifest result =
@@ -152,7 +154,7 @@ final class KubernetesRunJobOperationTest {
               }
               return result;
             });
-    when(credentialsMock.create(any(KubernetesManifest.class)))
+    when(credentialsMock.create(any(KubernetesManifest.class), any(Task.class), anyString()))
         .thenAnswer(
             invocation -> {
               // This simulates the fact that the Kubernetes API will add a suffix to a generated

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTask.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTask.kt
@@ -16,11 +16,7 @@
 package com.netflix.spinnaker.clouddriver.sql
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.netflix.spinnaker.clouddriver.data.task.SagaId
-import com.netflix.spinnaker.clouddriver.data.task.Status
-import com.netflix.spinnaker.clouddriver.data.task.Task
-import com.netflix.spinnaker.clouddriver.data.task.TaskDisplayStatus
-import com.netflix.spinnaker.clouddriver.data.task.TaskState
+import com.netflix.spinnaker.clouddriver.data.task.*
 import java.util.concurrent.atomic.AtomicBoolean
 import org.slf4j.LoggerFactory
 
@@ -42,6 +38,7 @@ class SqlTask(
 
   private var resultObjects: MutableList<Any> = mutableListOf()
   private var history: MutableList<Status> = mutableListOf()
+  private var taskOutputs: MutableList<TaskOutput> = mutableListOf()
 
   private val dirty = AtomicBoolean(false)
 
@@ -118,6 +115,17 @@ class SqlTask(
     repository.updateState(this, TaskState.STARTED)
   }
 
+  override fun getOutputs(): List<TaskOutput> {
+    refresh()
+    return taskOutputs
+  }
+
+  override fun updateOutput(manifestName: String, phase: String, stdOut: String?, stdError: String?) {
+    this.dirty.set(true)
+    repository.updateOutput( TaskDisplayOutput(manifestName, phase, stdOut, stdError),this)
+    log.debug("Updated output for task {} for manifest {} for phase {} ", id, manifestName, phase)
+  }
+
   internal fun hydrateResultObjects(resultObjects: MutableList<Any>) {
     this.dirty.set(false)
     this.resultObjects = resultObjects
@@ -128,14 +136,21 @@ class SqlTask(
     this.history = history
   }
 
+  internal fun hydrateTaskOutputs(taskOutputs: MutableList<TaskOutput>) {
+    this.dirty.set(false)
+    this.taskOutputs = taskOutputs
+  }
+
   internal fun refresh(force: Boolean = false) {
     if (this.dirty.getAndSet(false) || force) {
       val task = repository.retrieveInternal(this.id)
       if (task != null) {
         history.clear()
         resultObjects.clear()
+        taskOutputs.clear()
         history.addAll(task.history)
         resultObjects.addAll(task.resultObjects)
+        taskOutputs.addAll(task.outputs)
       }
     }
   }

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskCleanupAgent.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskCleanupAgent.kt
@@ -67,6 +67,7 @@ class SqlTaskCleanupAgent(
 
         val candidateTaskStateIds = mutableListOf<String>()
         val candidateResultIds = mutableListOf<String>()
+        val candidateOutputIds = mutableListOf<String>()
 
         if (candidateTaskIds.isNotEmpty()) {
           candidateTaskIds.chunked(properties.batchSize) { chunk ->
@@ -85,22 +86,32 @@ class SqlTaskCleanupAgent(
                 .fetch("id", String::class.java)
                 .filterNotNull()
             )
+
+            candidateOutputIds.addAll(
+              j.select(field("id"))
+                .from(taskOutputsTable)
+                .where(field("task_id").`in`(*chunk.toTypedArray()))
+                .fetch("id", String::class.java)
+                .filterNotNull()
+            )
           }
         }
 
         CleanupCandidateIds(
           taskIds = candidateTaskIds,
           stateIds = candidateTaskStateIds,
-          resultIds = candidateResultIds
+          resultIds = candidateResultIds,
+          outputIds = candidateOutputIds
         )
       }
 
       if (candidates.hasAny()) {
         log.info(
-          "Cleaning up {} completed tasks ({} states, {} result objects)",
+          "Cleaning up {} completed tasks ({} states, {} result, {} output objects)",
           candidates.taskIds.size,
           candidates.stateIds.size,
-          candidates.resultIds.size
+          candidates.resultIds.size,
+          candidates.outputIds.size
         )
 
         registry.timer(timingId).record {
@@ -115,6 +126,14 @@ class SqlTaskCleanupAgent(
           candidates.stateIds.chunked(properties.batchSize) { chunk ->
             jooq.transactional { ctx ->
               ctx.deleteFrom(taskStatesTable)
+                .where(field("id").`in`(*chunk.toTypedArray()))
+                .execute()
+            }
+          }
+
+          candidates.outputIds.chunked(properties.batchSize) { chunk ->
+            jooq.transactional { ctx ->
+              ctx.deleteFrom(taskOutputsTable)
                 .where(field("id").`in`(*chunk.toTypedArray()))
                 .execute()
             }
@@ -148,7 +167,8 @@ class SqlTaskCleanupAgent(
 private data class CleanupCandidateIds(
   val taskIds: List<String>,
   val stateIds: List<String>,
-  val resultIds: List<String>
+  val resultIds: List<String>,
+  val outputIds: List<String>
 ) {
   fun hasAny() = taskIds.isNotEmpty()
 
@@ -161,6 +181,7 @@ private data class CleanupCandidateIds(
     if (taskIds.size != other.taskIds.size || !taskIds.containsAll(other.taskIds)) return false
     if (stateIds.size != other.stateIds.size || !stateIds.containsAll(other.stateIds)) return false
     if (resultIds.size != other.resultIds.size || !resultIds.containsAll(other.resultIds)) return false
+    if (outputIds.size != other.outputIds.size || !outputIds.containsAll(other.outputIds)) return false
 
     return true
   }
@@ -169,6 +190,7 @@ private data class CleanupCandidateIds(
     var result = Arrays.hashCode(taskIds.toTypedArray())
     result = 31 * result + Arrays.hashCode(stateIds.toTypedArray())
     result = 31 * result + Arrays.hashCode(resultIds.toTypedArray())
+    result = 31 * result + Arrays.hashCode(outputIds.toTypedArray())
     return result
   }
 }

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt
@@ -17,10 +17,7 @@ package com.netflix.spinnaker.clouddriver.sql
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.core.ClouddriverHostname
-import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus
-import com.netflix.spinnaker.clouddriver.data.task.Task
-import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.data.task.TaskState
+import com.netflix.spinnaker.clouddriver.data.task.*
 import com.netflix.spinnaker.clouddriver.data.task.TaskState.FAILED
 import com.netflix.spinnaker.clouddriver.data.task.TaskState.STARTED
 import com.netflix.spinnaker.kork.sql.routing.withPool
@@ -192,6 +189,49 @@ class SqlTaskRepository(
     }
   }
 
+  internal fun updateOutput(taskOutput: TaskOutput, task: Task) {
+    val outputId = ulid.nextULID()
+    withPool(poolName) {
+      jooq.transactional { ctx ->
+        addToOutput(ctx, outputId, task.id, taskOutput.manifest, taskOutput.phase, taskOutput.stdOut, taskOutput.stdError)
+      }
+    }
+  }
+
+  private fun addToOutput(ctx: DSLContext,
+                          id: String,
+                          taskId: String,
+                          manifestName: String,
+                          phase: String,
+                          stdOut: String?,
+                          stdError: String?) {
+    ctx
+      .insertInto(
+        taskOutputsTable,
+        listOf(
+          field("id"),
+          field("task_id"),
+          field("created_at"),
+          field("manifest"),
+          field("phase"),
+          field("std_out"),
+          field("std_error")
+        )
+      )
+      .values(
+        listOf(
+          id,
+          taskId,
+          clock.millis(),
+          manifestName,
+          phase,
+          stdOut,
+          stdError
+        )
+      )
+      .execute()
+  }
+
   internal fun retrieveInternal(taskId: String): Task? {
     return retrieveInternal(field("id").eq(taskId), field("task_id").eq(taskId)).firstOrNull()
   }
@@ -210,6 +250,8 @@ class SqlTaskRepository(
          *  (select task_id, null as owner_id, null as request_id, null as created_at, null as saga_ids, null as body, state, phase, status from task_states_copy where task_id = '01D2H4H50VTF7CGBMP0D6HTGTF')
          *  UNION ALL
          *  (select task_id, null as owner_id, null as request_id, null as created_at, null as saga_ids, body, null as state, null as phase, null as status from task_results_copy where task_id = '01D2H4H50VTF7CGBMP0D6HTGTF')
+         *  UNION ALL
+         *  (select task_id, null as owner_id, null as request_id, null as created_at, null as saga_ids, null as body, null as state, manifest, phase, stdOut, stdError, null as status  from task_outputs_copy where task_id = '01D2H4H50VTF7CGBMP0D6HTGTF')
          */
         tasks.addAll(
           ctx
@@ -222,7 +264,10 @@ class SqlTaskRepository(
               field(sql("null")).`as`("body"),
               field(sql("null")).`as`("state"),
               field(sql("null")).`as`("phase"),
-              field(sql("null")).`as`("status")
+              field(sql("null")).`as`("status"),
+              field(sql("null")).`as`("manifest"),
+              field(sql("null")).`as`("std_out"),
+              field(sql("null")).`as`("std_error")
             )
             .from(tasksTable)
             .where(condition)
@@ -237,7 +282,10 @@ class SqlTaskRepository(
                   field(sql("null")).`as`("body"),
                   field("state"),
                   field("phase"),
-                  field("status")
+                  field("status"),
+                  field(sql("null")).`as`("manifest"),
+                  field(sql("null")).`as`("std_out"),
+                  field(sql("null")).`as`("std_error")
                 )
                 .from(taskStatesTable)
                 .where(relationshipCondition ?: condition)
@@ -253,9 +301,31 @@ class SqlTaskRepository(
                   field("body"),
                   field(sql("null")).`as`("state"),
                   field(sql("null")).`as`("phase"),
-                  field(sql("null")).`as`("status")
+                  field(sql("null")).`as`("status"),
+                  field(sql("null")).`as`("manifest"),
+                  field(sql("null")).`as`("std_out"),
+                  field(sql("null")).`as`("std_error")
                 )
                 .from(taskResultsTable)
+                .where(relationshipCondition ?: condition)
+            )
+            .unionAll(
+              ctx
+                .select(
+                  field("task_id"),
+                  field(sql("null")).`as`("owner_id"),
+                  field(sql("null")).`as`("request_id"),
+                  field(sql("null")).`as`("created_at"),
+                  field(sql("null")).`as`("saga_ids"),
+                  field(sql("null")).`as`("body"),
+                  field(sql("null")).`as`("state"),
+                  field("phase"),
+                  field(sql("null")).`as`("status"),
+                  field("manifest"),
+                  field("std_out"),
+                  field("std_error")
+                )
+                .from(taskOutputsTable)
                 .where(relationshipCondition ?: condition)
             )
             .fetchTasks()

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/sql.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/sql.kt
@@ -24,10 +24,12 @@ import org.jooq.impl.DSL.table
 internal val tasksTable = table("tasks")
 internal val taskStatesTable = table("task_states")
 internal val taskResultsTable = table("task_results")
+internal val taskOutputsTable = table("task_outputs")
 
 internal val tasksFields = listOf("id", "request_id", "owner_id", "created_at").map { field(it) }
 internal val taskStatesFields = listOf("id", "task_id", "created_at", "state", "phase", "status").map { field(it) }
 internal val taskResultsFields = listOf("id", "task_id", "body").map { field(it) }
+internal val taskOutputsFields = listOf("id", "task_id", "created_at", "manifest", "phase", "std_out", "std_error").map { field(it) }
 
 /**
  * Run the provided [fn] in a transaction, retrying on failures using resilience4j.retry.instances.sqlTransaction

--- a/clouddriver-sql/src/main/resources/db/changelog-master.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog-master.yml
@@ -20,3 +20,6 @@ databaseChangeLog:
 - include:
     file: changelog/20210311-caching-replicas.yml
     relativeToChangelogFile: true
+- include:
+    file: changelog/20211124-task-outputs.yml
+    relativeToChangelogFile: true

--- a/clouddriver-sql/src/main/resources/db/changelog/20211124-task-outputs.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog/20211124-task-outputs.yml
@@ -1,0 +1,43 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-task-outputs-table
+      author: apoorvmahajan
+      changes:
+        - createTable:
+            tableName: task_outputs
+            columns:
+              - column:
+                  name: id
+                  type: char(36)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: task_id
+                  type: char(36)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: manifest
+                  type: text
+              - column:
+                  name: phase
+                  type: varchar(255)
+              - column:
+                  name: std_out
+                  type: longtext
+              - column:
+                  name: std_error
+                  type: longtext
+        - modifySql:
+            dbms: mysql
+            append:
+              value: " engine innodb"
+    rollback:
+      - dropTable:
+          tableName: task_outputs

--- a/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskCleanupAgentTest.kt
+++ b/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskCleanupAgentTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.sql
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.clouddriver.sql.event.SqlEventCleanupAgent
+import com.netflix.spinnaker.config.SqlEventCleanupAgentConfigProperties
+import com.netflix.spinnaker.config.SqlTaskCleanupAgentProperties
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import java.sql.Timestamp
+import java.time.Clock
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+
+class SqlTaskCleanupAgentTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    before {
+      listOf(
+        Instant.now().minus(3, ChronoUnit.DAYS),
+        Instant.now().minus(10, ChronoUnit.DAYS),
+      ).forEachIndexed { i, ts ->
+        database.context
+          .insertInto(tasksTable)
+          .values(
+            "myid$i",
+            "7b96fe8de1e5e8e8620036480771195b8e25c583c9f4f0098a23e97bf2ba013b",
+            "95637b33-6699-4abf-b1ab-d4077e1cf867@spin-clouddriver-7847bc646b-hgkfd",
+            ts.toEpochMilli(),
+            mutableListOf<String>()
+          )
+          .execute()
+
+        database.context
+          .insertInto(taskResultsTable)
+          .values(
+            "$i",
+            "myid$i",
+            "body"
+          )
+          .execute()
+
+        database.context
+          .insertInto(taskStatesTable)
+          .values(
+            "$i",
+            "myid$i",
+            ts.toEpochMilli(),
+            "COMPLETED",
+            "ORCHESTRATION",
+            "Orchestration completed"
+          )
+          .execute()
+
+        database.context
+          .insertInto(taskOutputsTable)
+          .values(
+            "$i",
+            "myid$i",
+            ts.toEpochMilli(),
+            "configMap render-helm-output-manifest-test-v000",
+            "DEPLOY_KUBERNETES_MANIFEST",
+            "stOut",
+            "stdError"
+          )
+          .execute()
+      }
+    }
+
+    after {
+      SqlTestUtil.cleanupDb(database.context)
+    }
+
+    test("deletes old tasks and related data") {
+      expectThat(database.context.fetchCount(tasksTable)).isEqualTo(2)
+      expectThat(database.context.fetchCount(taskStatesTable)).isEqualTo(2)
+      expectThat(database.context.fetchCount(taskResultsTable)).isEqualTo(2)
+      expectThat(database.context.fetchCount(taskOutputsTable)).isEqualTo(2)
+      subject.run()
+
+      expectThat(database.context.fetchCount(tasksTable)).isEqualTo(1)
+      expectThat(database.context.fetchCount(taskStatesTable)).isEqualTo(1)
+      expectThat(database.context.fetchCount(taskResultsTable)).isEqualTo(1)
+      expectThat(database.context.fetchCount(taskOutputsTable)).isEqualTo(1)
+
+      val tasksResultset = database.context.select()
+        .from(tasksTable)
+        .fetch("id", String::class.java)
+        .toTypedArray()
+
+      expectThat(tasksResultset.size).isEqualTo(1)
+      expectThat(tasksResultset.get(0)).isEqualTo("myid0")
+
+      val taskResultsResultset = database.context.select()
+        .from(taskResultsTable)
+        .fetch("task_id", String::class.java)
+        .toTypedArray()
+
+      expectThat(taskResultsResultset.size).isEqualTo(1)
+      expectThat(taskResultsResultset.get(0)).isEqualTo("myid0")
+
+      val taskStatesResultset = database.context.select()
+        .from(taskStatesTable)
+        .fetch("task_id", String::class.java)
+        .toTypedArray()
+
+      expectThat(taskStatesResultset.size).isEqualTo(1)
+      expectThat(taskStatesResultset.get(0)).isEqualTo("myid0")
+
+      val taskOutputsResultset = database.context.select()
+        .from(taskOutputsTable)
+        .fetch("task_id", String::class.java)
+        .toTypedArray()
+
+      expectThat(taskOutputsResultset.size).isEqualTo(1)
+      expectThat(taskOutputsResultset.get(0)).isEqualTo("myid0")
+    }
+  }
+
+  private inner class Fixture {
+    val database = SqlTestUtil.initTcMysqlDatabase()!!
+
+    val subject = SqlTaskCleanupAgent(
+      jooq = database.context,
+      clock = Clock.systemDefaultZone(),
+      registry = NoopRegistry(),
+      SqlTaskCleanupAgentProperties()
+    )
+  }
+}

--- a/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskOutputTest.kt
+++ b/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskOutputTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.sql
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.netflix.spinnaker.config.ConnectionPools
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import java.time.Clock
+
+class SqlTaskOutputTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    after {
+      SqlTestUtil.cleanupDb(database.context)
+    }
+
+    context("task output") {
+      test("verify if the task outputs with null/empty values can be stored and retrieved successfully from the db") {
+        val t1 = subject.create("TEST", "Test Status")
+
+        t1.updateOutput("some-manifest", "TEST", null, "")
+        assert(t1.outputs[0].manifest == "some-manifest")
+        assert(t1.outputs[0].phase == "TEST")
+        assert(t1.outputs[0].stdOut.isNullOrBlank())
+        assert(t1.outputs[0].stdError.isNullOrBlank())
+      }
+
+      test("verify if the task outputs can be stored and retrieved successfully from the db") {
+        val t1 = subject.create("TEST", "Test Status")
+
+        t1.updateOutput("some-manifest", "TEST", "output", "")
+        assert(t1.outputs[0].manifest == "some-manifest")
+        assert(t1.outputs[0].phase == "TEST")
+        assert(t1.outputs[0].stdOut == "output")
+        assert(t1.outputs[0].stdError.isNullOrBlank())
+      }
+
+      test("task has outputs from multiple manifests") {
+        val t1 = subject.create("TEST", "Test Status")
+
+        t1.updateOutput("some-manifest", "TEST", "output", "")
+        t1.updateOutput("some-manifest-2", "Deploy", "other output", "")
+        assert(t1.outputs.size == 2)
+        assert(t1.outputs[0].manifest == "some-manifest")
+        assert(t1.outputs[0].phase == "TEST")
+        assert(t1.outputs[0].stdOut == "output")
+        assert(t1.outputs[0].stdError == "")
+        assert(t1.outputs[1].manifest == "some-manifest-2")
+        assert(t1.outputs[1].phase == "Deploy")
+        assert(t1.outputs[1].stdOut == "other output")
+        assert(t1.outputs[0].stdError.isNullOrBlank())
+      }
+
+      test("multiple tasks with only one task having outputs from multiple manifests") {
+        val t1 = subject.create("TEST", "Test Status")
+        val t2 = subject.create("TEST", "Test Status")
+
+        t1.updateOutput("some-manifest", "TEST", "output", "")
+        t1.updateOutput("some-manifest-2", "Deploy", "other output", "")
+        assert(t1.outputs.size == 2)
+        assert(t1.outputs[0].manifest == "some-manifest")
+        assert(t1.outputs[0].phase == "TEST")
+        assert(t1.outputs[0].stdOut == "output")
+        assert(t1.outputs[0].stdError.isNullOrBlank())
+        assert(t1.outputs[1].manifest == "some-manifest-2")
+        assert(t1.outputs[1].phase == "Deploy")
+        assert(t1.outputs[1].stdOut == "other output")
+        assert(t1.outputs[0].stdError.isNullOrBlank())
+        assert(t2.outputs.isEmpty())
+      }
+    }
+  }
+
+  private inner class Fixture {
+    val database = SqlTestUtil.initTcMysqlDatabase()!!
+
+    val subject = SqlTaskRepository(
+      jooq = database.context,
+      mapper = ObjectMapper().apply {
+        registerModules(KotlinModule(), JavaTimeModule())
+      },
+      clock = Clock.systemDefaultZone(),
+      poolName = ConnectionPools.TASKS.value
+    )
+  }
+}


### PR DESCRIPTION
…gs and extending kato task object to include stdout and stderr info

## Purpose
* We have seen a few transient errors spanning across Orca and Clouddriver when the Clouddriver's Kubernetes Kubectl Job Executor attempts to perform a task (mainly the Deploy Manifest task). To gain more visibility into what was the last task action, we felt the need to extend the Kato Task object to include stdOut and stdError information in it as the current logs in the system do not capture that effectively.

This PR is meant to enable us to gain more visibility by adding more logs to the Deploy Manifest operation as well as to the KubectlJobExecutor. It also extends the kato task object to include stdOut and stdError information for all the manifests being processed in such a task.

## Changes
* Add logging statements and update existing logs for various common Kubernetes tasks to include more information about which manifest is being executed by the K8s job executor and for which account
* Extend Kato task object to include stdout and stderr info for the task in question
* Add implementation for the updated kato task object across in memory, redis and sql implementations