### PR TITLE
feat(provider/azure): Support termination notification profile

### DIFF
--- a/clouddriver-azure/clouddriver-azure.gradle
+++ b/clouddriver-azure/clouddriver-azure.gradle
@@ -18,7 +18,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation 'com.microsoft.azure:adal4j:1.6.3'
-  implementation 'com.microsoft.azure:azure:1.19.0'
+  implementation 'com.microsoft.azure:azure:1.35.0'
 
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/AzureServerGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/AzureServerGroupResourceTemplateSpec.groovy
@@ -42,6 +42,15 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     template.replaceAll('"createdTime" : "\\d+"', '"createdTime" : "1234567890"').replace('\r', '') == expectedFullTemplate
   }
 
+  def 'should generate correct ServerGroup resource template with scheduled event profile'() {
+    description = createDescription(false)
+    description.terminationNotBeforeTimeout = 15
+    String template = AzureServerGroupResourceTemplate.getTemplate(description)
+
+    expect:
+    template.replaceAll('"createdTime" : "\\d+"', '"createdTime" : "1234567890"').replace('\r', '') == expectedFullTemplateWithScheduledEventsProfile
+  }
+
   def 'should generate correct ServerGroup resource template with custom image'() {
     description = createDescription(true)
     String template = AzureServerGroupResourceTemplate.getTemplate(description)
@@ -228,7 +237,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   },
   "variables" : {
-    "apiVersion" : "2018-10-01",
+    "apiVersion" : "2019-03-01",
     "publicIPAddressName" : "",
     "publicIPAddressID" : "",
     "publicIPAddressType" : "",
@@ -324,6 +333,182 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
               } ]
             }
           } ]
+        },
+        "scheduledEventsProfile" : null
+      }
+    }
+  } ]
+}'''
+
+  private static String expectedFullTemplateWithScheduledEventsProfile = '''{
+  "$schema" : "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion" : "1.0.0.0",
+  "parameters" : {
+    "location" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "Location to deploy"
+      }
+    },
+    "subnetId" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "Subnet Resource ID"
+      },
+      "defaultValue" : ""
+    },
+    "appGatewayAddressPoolId" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "App Gateway backend address pool resource ID"
+      }
+    },
+    "vmUserName" : {
+      "type" : "securestring",
+      "metadata" : {
+        "description" : "Admin username on all VMs"
+      },
+      "defaultValue" : ""
+    },
+    "vmPassword" : {
+      "type" : "securestring",
+      "metadata" : {
+        "description" : "Admin password on all VMs"
+      },
+      "defaultValue" : ""
+    },
+    "vmSshPublicKey" : {
+      "type" : "securestring",
+      "metadata" : {
+        "description" : "SSH public key on all VMs"
+      },
+      "defaultValue" : ""
+    },
+    "loadBalancerAddressPoolId" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "Load balancer pool ID"
+      },
+      "defaultValue" : ""
+    },
+    "loadBalancerNatPoolId" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "Load balancer NAT pool ID"
+      },
+      "defaultValue" : ""
+    },
+    "customData" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "custom data to pass down to the virtual machine(s)"
+      },
+      "defaultValue" : "sample custom data"
+    }
+  },
+  "variables" : {
+    "apiVersion" : "2019-03-01",
+    "publicIPAddressName" : "",
+    "publicIPAddressID" : "",
+    "publicIPAddressType" : "",
+    "dnsNameForLBIP" : "",
+    "loadBalancerBackend" : "",
+    "loadBalancerFrontEnd" : "",
+    "loadBalancerName" : "",
+    "loadBalancerID" : "",
+    "frontEndIPConfigID" : "",
+    "inboundNatPoolName" : "",
+    "vhdContainerName" : "azuremasm-st1-d11",
+    "osType" : {
+      "publisher" : "Canonical",
+      "offer" : "UbuntuServer",
+      "sku" : "14.04.3-LTS",
+      "version" : "latest"
+    },
+    "imageReference" : "[variables('osType')]",
+    "uniqueStorageNameArray" : [ "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), 'sa')]" ]
+  },
+  "resources" : [ {
+    "apiVersion" : "[variables('apiVersion')]",
+    "name" : "[concat(variables('uniqueStorageNameArray')[copyIndex()])]",
+    "type" : "Microsoft.Storage/storageAccounts",
+    "location" : "[parameters('location')]",
+    "tags" : {
+      "appName" : "azureMASM",
+      "stack" : "st1",
+      "detail" : "d11",
+      "cluster" : "azureMASM-st1-d11",
+      "serverGroupName" : "azureMASM-st1-d11",
+      "createdTime" : "1234567890"
+    },
+    "copy" : {
+      "name" : "storageLoop",
+      "count" : 1
+    },
+    "properties" : {
+      "accountType" : "Premium_LRS"
+    }
+  }, {
+    "apiVersion" : "[variables('apiVersion')]",
+    "name" : "azureMASM-st1-d11",
+    "type" : "Microsoft.Compute/virtualMachineScaleSets",
+    "location" : "[parameters('location')]",
+    "tags" : {
+      "createdTime" : "1234567890"
+    },
+    "dependsOn" : [ ],
+    "sku" : {
+      "name" : "Standard_A1",
+      "tier" : "Standard",
+      "capacity" : 2
+    },
+    "properties" : {
+      "upgradePolicy" : {
+        "mode" : "Manual"
+      },
+      "virtualMachineProfile" : {
+        "storageProfile" : {
+          "osDisk" : {
+            "name" : "osdisk-azureMASM-st1-d11",
+            "caching" : "ReadOnly",
+            "createOption" : "FromImage",
+            "vhdContainers" : [ "[concat('https://', variables('uniqueStorageNameArray')[0], '.blob.core.windows.net/', variables('vhdContainerName'))]" ]
+          },
+          "imageReference" : "[variables('imageReference')]",
+          "dataDisks" : null
+        },
+        "osProfile" : {
+          "computerNamePrefix" : "azureMASM-",
+          "adminUsername" : "[parameters('vmUserName')]",
+          "adminPassword" : "[parameters('vmPassword')]",
+          "customData" : "[base64(parameters('customData'))]"
+        },
+        "networkProfile" : {
+          "networkInterfaceConfigurations" : [ {
+            "name" : "nic-azureMASM-st1-d11",
+            "properties" : {
+              "primary" : true,
+              "ipConfigurations" : [ {
+                "name" : "ipc-azureMASM-st1-d11",
+                "properties" : {
+                  "subnet" : {
+                    "id" : "[parameters('subnetId')]"
+                  },
+                  "loadBalancerBackendAddressPools" : [ ],
+                  "loadBalancerInboundNatPools" : [ ],
+                  "applicationGatewayBackendAddressPools" : [ {
+                    "id" : "[parameters('appGatewayAddressPoolId')]"
+                  } ]
+                }
+              } ]
+            }
+          } ]
+        },
+        "scheduledEventsProfile" : {
+          "terminateNotificationProfile" : {
+            "notBeforeTimeout" : "PT15M",
+            "enable" : true
+          }
         }
       }
     }
@@ -397,7 +582,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   },
   "variables" : {
-    "apiVersion" : "2018-10-01",
+    "apiVersion" : "2019-03-01",
     "publicIPAddressName" : "",
     "publicIPAddressID" : "",
     "publicIPAddressType" : "",
@@ -460,7 +645,8 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
               } ]
             }
           } ]
-        }
+        },
+        "scheduledEventsProfile" : null
       }
     }
   } ]
@@ -533,7 +719,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   },
   "variables" : {
-    "apiVersion" : "2018-10-01",
+    "apiVersion" : "2019-03-01",
     "publicIPAddressName" : "",
     "publicIPAddressID" : "",
     "publicIPAddressType" : "",
@@ -630,6 +816,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
             }
           } ]
         },
+        "scheduledEventsProfile" : null,
         "extensionProfile" : {
           "extensions" : [ {
             "name" : "azureMASM_ext",
@@ -717,7 +904,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   },
   "variables" : {
-    "apiVersion" : "2018-10-01",
+    "apiVersion" : "2019-03-01",
     "publicIPAddressName" : "",
     "publicIPAddressID" : "",
     "publicIPAddressType" : "",
@@ -814,6 +1001,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
             }
           } ]
         },
+        "scheduledEventsProfile" : null,
         "extensionProfile" : {
           "extensions" : [ {
             "name" : "azureMASM_ext",
@@ -901,7 +1089,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   },
   "variables" : {
-    "apiVersion" : "2018-10-01",
+    "apiVersion" : "2019-03-01",
     "publicIPAddressName" : "",
     "publicIPAddressID" : "",
     "publicIPAddressType" : "",
@@ -998,6 +1186,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
             }
           } ]
         },
+        "scheduledEventsProfile" : null,
         "extensionProfile" : {
           "extensions" : [ {
             "name" : "azureMASM_ext",
@@ -1086,7 +1275,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   },
   "variables" : {
-    "apiVersion" : "2018-10-01",
+    "apiVersion" : "2019-03-01",
     "publicIPAddressName" : "",
     "publicIPAddressID" : "",
     "publicIPAddressType" : "",
@@ -1183,6 +1372,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
             }
           } ]
         },
+        "scheduledEventsProfile" : null,
         "extensionProfile" : {
           "extensions" : [ {
             "name" : "azureMASM_ext",
@@ -1271,7 +1461,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   },
   "variables" : {
-    "apiVersion" : "2018-10-01",
+    "apiVersion" : "2019-03-01",
     "publicIPAddressName" : "",
     "publicIPAddressID" : "",
     "publicIPAddressType" : "",
@@ -1370,6 +1560,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
             }
           } ]
         },
+        "scheduledEventsProfile" : null,
         "extensionProfile" : {
           "extensions" : [ {
             "name" : "azureMASM_ext",


### PR DESCRIPTION
resolves https://github.com/spinnaker/spinnaker/issues/6135
bump api version from 2018-10-01 to 2019-03-01 for azure
updated to have unit tests for termination notification profile
updated all unit tests for server group to have the newly updated api version
