### PR TITLE
chore(dependencies): upgrade of jGit for performance improvements

### DIFF
--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -29,8 +29,9 @@ dependencies {
   implementation "org.codehaus.groovy:groovy-all"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
-  implementation "org.eclipse.jgit:org.eclipse.jgit:5.7.0.202003110725-r"
-  implementation "org.eclipse.jgit:org.eclipse.jgit.archive:5.7.0.202003110725-r"
+  implementation "org.eclipse.jgit:org.eclipse.jgit:5.10.0.202012080955-r"
+  implementation "org.eclipse.jgit:org.eclipse.jgit.archive:5.10.0.202012080955-r"
+  implementation "org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:5.10.0.202012080955-r"
 
   testImplementation "com.github.tomakehurst:wiremock:latest.release"
   testImplementation "org.assertj:assertj-core"


### PR DESCRIPTION
This PR is including changes from jGit that may speedup performance 
```
JGit 5.9.0 supports git repositories using git index version 4. In version 4 entry path names are prefix-compressed relative to the path name for the previous entry which reduces the size of the git index and improves performance.
```