### PR TITLE
fix(aws): always schedule agent for private images

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
@@ -141,10 +141,17 @@ public class ProviderHelpers {
         newlyAddedAgents.add(
             new LaunchConfigCachingAgent(
                 amazonClientProvider, credentials, region.getName(), objectMapper, registry));
-        boolean publicImages = false;
         if (!publicRegions.contains(region.getName())) {
-          publicImages = true;
           publicRegions.add(region.getName());
+          newlyAddedAgents.add(
+              new ImageCachingAgent(
+                  amazonClientProvider,
+                  credentials,
+                  region.getName(),
+                  objectMapper,
+                  registry,
+                  true,
+                  dynamicConfigService));
         }
         newlyAddedAgents.add(
             new ImageCachingAgent(
@@ -153,7 +160,7 @@ public class ProviderHelpers {
                 region.getName(),
                 objectMapper,
                 registry,
-                publicImages,
+                false,
                 dynamicConfigService));
         newlyAddedAgents.add(
             new InstanceCachingAgent(


### PR DESCRIPTION
This fixes a regression added in 1.23 but fixed in 1.24. Image caching agents were either public or private, we need both.