### PR TITLE
feat(ecs): add a default ECS Application Caching Agent

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 public class Keys implements KeyParser {
   public enum Namespace {
+    APPLICATIONS,
     IAM_ROLE,
     SERVICES,
     ECS_CLUSTERS,
@@ -85,9 +86,9 @@ public class Keys implements KeyParser {
     Map<String, String> result = new HashMap<>();
     result.put("provider", parts[0]);
     result.put("type", parts[1]);
-    result.put("account", parts[2]);
 
-    if (!canParse(parts[1]) && parts[1].equals(HEALTH.getNs())) {
+    if (parts[1].equals(HEALTH.getNs())) {
+      result.put("account", parts[2]);
       result.put("region", parts[3]);
       result.put("taskId", parts[4]);
       return result;
@@ -96,42 +97,62 @@ public class Keys implements KeyParser {
     Namespace namespace =
         Namespace.valueOf(CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, parts[1]));
 
-    if (!namespace.equals(Namespace.IAM_ROLE)) {
-      result.put("region", parts[3]);
-    }
-
     switch (namespace) {
+      case APPLICATIONS:
+        result.put("application", parts[2]);
+        break;
       case SERVICES:
+        result.put("account", parts[2]);
+        result.put("region", parts[3]);
         result.put("serviceName", parts[4]);
         break;
       case ECS_CLUSTERS:
+        result.put("account", parts[2]);
+        result.put("region", parts[3]);
         result.put("clusterName", parts[4]);
         break;
       case TASKS:
+        result.put("account", parts[2]);
+        result.put("region", parts[3]);
         result.put("taskId", parts[4]);
         break;
       case CONTAINER_INSTANCES:
+        result.put("account", parts[2]);
+        result.put("region", parts[3]);
         result.put("containerInstanceArn", parts[4]);
         break;
       case TASK_DEFINITIONS:
+        result.put("account", parts[2]);
+        result.put("region", parts[3]);
         result.put("taskDefinitionArn", parts[4]);
         break;
       case ALARMS:
+        result.put("account", parts[2]);
+        result.put("region", parts[3]);
         result.put("alarmArn", parts[4]);
         break;
       case IAM_ROLE:
+        result.put("account", parts[2]);
         result.put("roleName", parts[3]);
         break;
       case SECRETS:
+        result.put("account", parts[2]);
+        result.put("region", parts[3]);
         result.put("secretName", parts[4]);
         break;
       case SERVICE_DISCOVERY_REGISTRIES:
+        result.put("account", parts[2]);
+        result.put("region", parts[3]);
         result.put("serviceId", parts[4]);
         break;
       case SCALABLE_TARGETS:
+        result.put("account", parts[2]);
+        result.put("region", parts[3]);
         result.put("resource", parts[4]);
         break;
       case TARGET_HEALTHS:
+        result.put("account", parts[2]);
+        result.put("region", parts[3]);
         result.put("targetGroupArn", parts[4]);
         break;
       default:
@@ -152,6 +173,10 @@ public class Keys implements KeyParser {
 
   public static String getClusterKey(String account, String region, String clusterName) {
     return buildKey(Namespace.ECS_CLUSTERS.ns, account, region, clusterName);
+  }
+
+  public static String getApplicationKey(String name) {
+    return ID + SEPARATOR + Namespace.APPLICATIONS + SEPARATOR + name.toLowerCase();
   }
 
   public static String getTaskKey(String account, String region, String taskId) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/Application.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/Application.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.cache.model;
+
+import java.util.Collection;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class Application {
+  String name;
+  Map<String, Collection<String>> relationships;
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.APPLICATIONS;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.IAM_ROLE;
 
@@ -212,11 +213,15 @@ abstract class AbstractEcsCachingAgent<T> implements CachingAgent, AccountAware 
   protected boolean keyAccountRegionFilter(String authoritativeKeyName, String key) {
     Map<String, String> keyParts = Keys.parse(key);
     return keyParts != null
-        && keyParts.get("account").equals(accountName)
-        &&
-        // IAM role keys are not region specific, so it will be true. The region will be checked of
-        // other keys.
-        (authoritativeKeyName.equals(IAM_ROLE.ns) || keyParts.get("region").equals(region));
+        && ((accountName.equals(keyParts.get("account"))
+                &&
+                // IAM role keys are not region specific, so it will be true. The region will be
+                // checked of other keys.
+                (authoritativeKeyName.equals(IAM_ROLE.ns) || keyParts.get("region").equals(region)))
+            // Application keys are not account or region specific so this will be true. The region
+            // and
+            // account will be checked for other keys.
+            || (authoritativeKeyName.equals(APPLICATIONS.ns)));
   }
 
   /**

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ApplicationCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ApplicationCachingAgent.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.APPLICATIONS;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ecs.AmazonECS;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.cats.provider.ProviderCache;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.Application;
+import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ApplicationCachingAgent extends AbstractEcsOnDemandAgent<Application> {
+  private static final Collection<AgentDataType> types =
+      Collections.unmodifiableCollection(
+          Arrays.asList(AUTHORITATIVE.forType(APPLICATIONS.toString())));
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private ObjectMapper objectMapper;
+
+  public ApplicationCachingAgent(
+      NetflixAmazonCredentials account,
+      String region,
+      AmazonClientProvider amazonClientProvider,
+      AWSCredentialsProvider awsCredentialsProvider,
+      Registry registry,
+      ObjectMapper objectMapper) {
+    super(account, region, amazonClientProvider, awsCredentialsProvider, registry);
+    this.objectMapper = objectMapper;
+  }
+
+  public static Map<String, Object> convertApplicationToAttributes(Application application) {
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("name", application.getName());
+    return attributes;
+  }
+
+  @Override
+  public Collection<AgentDataType> getProvidedDataTypes() {
+    return types;
+  }
+
+  @Override
+  public String getAgentType() {
+    return accountName + "/" + region + "/" + getClass().getSimpleName();
+  }
+
+  @Override
+  protected List<Application> getItems(AmazonECS ecs, ProviderCache providerCache) {
+    List<Application> applications = new ArrayList<>();
+    return applications;
+  }
+
+  @Override
+  protected Map<String, Collection<CacheData>> generateFreshData(
+      Collection<Application> applications) {
+    Collection<CacheData> applicationData = new LinkedList<>();
+
+    Map<String, Collection<CacheData>> cacheDataMap = new HashMap<>();
+    log.info("Amazon ECS ApplicationCachingAgent will cache applications in a future update");
+    cacheDataMap.put(APPLICATIONS.toString(), applicationData);
+
+    return cacheDataMap;
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsCredentialsLifeCycleHandler.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsCredentialsLifeCycleHandler.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.cats.module.CatsModule;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
+import com.netflix.spinnaker.clouddriver.ecs.provider.agent.ApplicationCachingAgent;
 import com.netflix.spinnaker.clouddriver.ecs.provider.agent.ContainerInstanceCachingAgent;
 import com.netflix.spinnaker.clouddriver.ecs.provider.agent.EcsCloudMetricAlarmCachingAgent;
 import com.netflix.spinnaker.clouddriver.ecs.provider.agent.EcsClusterCachingAgent;
@@ -95,6 +96,14 @@ public class EcsCredentialsLifeCycleHandler
     Set<String> scheduledAccounts = ProviderUtils.getScheduledAccounts(ecsProvider);
     List<Agent> newAgents = new LinkedList<>();
     newAgents.add(new IamRoleCachingAgent(credentials, amazonClientProvider, iamPolicyReader));
+    newAgents.add(
+        new ApplicationCachingAgent(
+            credentials,
+            "us-east-1",
+            amazonClientProvider,
+            awsCredentialsProvider,
+            registry,
+            objectMapper));
     if (!scheduledAccounts.contains(credentials.getName())) {
       for (AmazonCredentials.AWSRegion region : credentials.getRegions()) {
         newAgents.add(

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/KeysSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/KeysSpec.groovy
@@ -51,6 +51,26 @@ class KeysSpec extends Specification {
     'test-account-10' | 'us-west-10' | TARGET_HEALTHS.ns | 'arn:aws:elasticloadbalancing' + region + ':012345678910:targetgroup/ECSTG/htgbfvv' | buildParsedKey(account, region, namespace, [targetGroupArn: identifier])
   }
 
+  def 'should parse a given application key properly'() {
+    given:
+    def application_1 = 'test-application-1'
+    def application_2 = 'test-application-2'
+
+    expect:
+    Keys.parse(ID + SEPARATOR + APPLICATIONS.ns + SEPARATOR + application_1) == [provider: ID, type: APPLICATIONS.ns, application: application_1]
+    Keys.parse(ID + SEPARATOR + APPLICATIONS.ns + SEPARATOR + application_2) == [provider: ID, type: APPLICATIONS.ns, application: application_2]
+  }
+
+  def 'should generate the proper application key'() {
+    given:
+    def application_1 = 'test-application-1'
+    def application_2 = 'test-application-2'
+
+    expect:
+    Keys.getApplicationKey(application_1) == ID + SEPARATOR + APPLICATIONS.ns + SEPARATOR + application_1
+    Keys.getApplicationKey(application_2) == ID + SEPARATOR + APPLICATIONS.ns + SEPARATOR + application_2
+  }
+
   def 'should parse a given iam role key properly'() {
     expect:
     Keys.parse(ID + SEPARATOR + IAM_ROLE.ns + SEPARATOR + account + SEPARATOR + roleName) == [provider: ID, type: IAM_ROLE.ns, account: account, roleName: roleName]

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/security/EcsCredentialsLifeCyclerHandlerSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/security/EcsCredentialsLifeCyclerHandlerSpec.groovy
@@ -45,7 +45,8 @@ class EcsCredentialsLifeCyclerHandlerSpec extends Specification {
     Set<Class> expectedClasses = [ IamRoleCachingAgent.class, EcsClusterCachingAgent.class, ServiceCachingAgent.class,
                          TaskCachingAgent.class, ContainerInstanceCachingAgent.class, TaskDefinitionCachingAgent.class,
                          TaskHealthCachingAgent.class, EcsCloudMetricAlarmCachingAgent.class, ScalableTargetsCachingAgent.class,
-                         SecretCachingAgent.class, ServiceDiscoveryCachingAgent.class, TargetHealthCachingAgent.class ]
+                         SecretCachingAgent.class, ServiceDiscoveryCachingAgent.class, TargetHealthCachingAgent.class,
+                         ApplicationCachingAgent.class ]
     Set<Class> actualClasses =[]
 
     when:
@@ -53,7 +54,7 @@ class EcsCredentialsLifeCyclerHandlerSpec extends Specification {
 
     then:
     1 * ecsAccountMapper.addMapEntry({it.getName() == credOne.getName()})
-    ecsProvider.getAgents().size() == 23 // 2 * 12 - 1 ( One IamRoleCachingAgent per account )
+    ecsProvider.getAgents().size() == 24 // 2 * 11 + 1 + 1 ( One IamRoleCachingAgent and ApplicationCachingAgent per account )
     ecsProvider.getHealthAgents().size() == 4
     ecsProvider.getAgents().each({actualClasses.add(it.getClass())})
     (actualClasses - expectedClasses).isEmpty()


### PR DESCRIPTION
This PR creates and initializes an empty ApplicationCachingAgent which will always return an empty list of Applications from the cache. The intent is that this is the initial commit prior to implementing logic within the ApplicationCachingAgent, that uses services to determine and store Applications and their relationship to an ECS service.