### PR TITLE
feat(kubernetes/clouddriver): sharding logic added for kubernetes accounts for clouddriver caching

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/sharding/DefaultKubernetesShardingFilter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/sharding/DefaultKubernetesShardingFilter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.sharding;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+import lombok.Data;
+
+@Data
+public class DefaultKubernetesShardingFilter implements KubernetesShardingFilter {
+  private Map<String, Object> config = new HashMap<>();
+
+  @Override
+  public boolean applyFilter(KubernetesConfigurationProperties.ManagedAccount account) {
+    if (!config.containsKey("selectorType")) {
+      throw new RuntimeException("Sharding selectorType not configured!!");
+    }
+    String selectorType = (String) config.get("selectorType");
+    switch (selectorType) {
+      case "AccountName":
+        return applyAccountNameFilter(account, (String) config.get("pattern"));
+      default:
+        throw new RuntimeException("Unknown Sharding selectorType - " + selectorType);
+    }
+  }
+
+  private boolean applyAccountNameFilter(
+      KubernetesConfigurationProperties.ManagedAccount account, String pattern) {
+    Pattern accountNamePattern = Pattern.compile(pattern);
+    return accountNamePattern.matcher(account.getName()).matches();
+  }
+}

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/sharding/KubernetesShardingFilter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/sharding/KubernetesShardingFilter.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.sharding;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+
+public interface KubernetesShardingFilter {
+  boolean applyFilter(KubernetesConfigurationProperties.ManagedAccount account);
+}

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/config/KubernetesShardingConfig.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/config/KubernetesShardingConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.config;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.sharding.DefaultKubernetesShardingFilter;
+import com.netflix.spinnaker.clouddriver.kubernetes.sharding.KubernetesShardingFilter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty("kubernetes.sharding-enabled")
+public class KubernetesShardingConfig {
+
+  @Bean
+  @ConditionalOnProperty(value = "caching.write-enabled", matchIfMissing = true)
+  @ConfigurationProperties("kubernetes.sharding")
+  public KubernetesShardingFilter kubernetesShardingFilter() {
+    return new DefaultKubernetesShardingFilter();
+  }
+}


### PR DESCRIPTION
Addressing the issue [#6315](https://github.com/spinnaker/spinnaker/issues/6315)

This feature is added on top of custom binding of kubernetes accounts for bootstrap sources.

The following configuration enables and provides **account name pattern** based on which clouddriver caching services filter the accounts. The assumption is that there will be more than one clouddriver caching deployments each having a unique name(say clouddriver-caching, clouddriver-caching-1 etc). 

```
---
spring:
  profiles: local

kubernetes:
  customPropertyBindingEnabled: true
  shardingEnabled: false

---
spring:
  profiles: caching-local

kubernetes:
  sharding:
    config:
      selectorType: AccountName
      pattern: k8s-acc-v1.*

---
spring:
  profiles: caching-1-local

kubernetes:
  sharding:
    config:
      selectorType: AccountName
      pattern: k8s-acc-v2.*|.*acc-v3.*

``` 

This way, every caching service is ensured to look for only a limited and same set of accounts in every run of caching agents resulting in optimal memory utilization.
