### PR TITLE
fix(titus): Avoid fetching the job before terminating it

### DIFF
--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/DestroyTitusJobSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/DestroyTitusJobSpec.groovy
@@ -53,11 +53,6 @@ class DestroyTitusJobSpec extends Specification {
 
     then:
     1 * accountCredentialsProvider.getCredentials('test') >> testCredentials
-    1 * titusClient.getJobAndAllRunningAndCompletedTasks('1234') >> {
-      def job = new Job()
-      job.id = '1234'
-      return job
-    }
     1 * titusClient.terminateJob({ TerminateJobRequest terminateJobRequest ->
       assert terminateJobRequest.jobId == '1234'
       assert terminateJobRequest.user == 'testUser'


### PR DESCRIPTION
This can be a costly lookup should the job have many thousands of associated tasks.

If the job doesn't exist, Titus will return a `NOT_FOUND` exception that can be appropriately handled.
