### PR TITLE
fix(aws/titus cache): fix cluster and application cache eviction

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AbstractClusterCleanupAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AbstractClusterCleanupAgent.java
@@ -1,0 +1,92 @@
+package com.netflix.spinnaker.clouddriver.aws.provider.agent;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE;
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*;
+
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.cats.agent.CacheResult;
+import com.netflix.spinnaker.cats.agent.CachingAgent;
+import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
+import com.netflix.spinnaker.cats.provider.ProviderCache;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A caching agent that handles eviction of clusters that no longer have server groups.
+ *
+ * <p>Clusters exist due to the existence of server groups, but the caching agents that supply
+ * server groups (can can cause clusters to exist) do not have a global view of the data so they can
+ * not definitively say a cluster should be removed once there are no server groups in that region.
+ *
+ * <p>This agent just indexes the server groups that exist to find clusters that should be removed
+ * and causes them to be evicted.
+ *
+ * <p>This class is abstract to allow for an AWS and Titus subclass to handle the differentiation in
+ * cache key parsing, globbing, and construction but otherwise the logic is the same across both
+ * providers.
+ */
+@Slf4j
+public abstract class AbstractClusterCleanupAgent implements CachingAgent {
+
+  @Override
+  public String getAgentType() {
+    return getCloudProviderId() + "/" + getClass().getSimpleName();
+  }
+
+  @Override
+  public Collection<AgentDataType> getProvidedDataTypes() {
+    return Collections.singleton(INFORMATIVE.forType(CLUSTERS.ns));
+  }
+
+  protected abstract String getCloudProviderId();
+
+  @Override
+  public CacheResult loadData(ProviderCache providerCache) {
+    final Collection<String> serverGroups =
+        providerCache.filterIdentifiers(
+            SERVER_GROUPS.ns, buildMatchAllGlob(getCloudProviderId(), SERVER_GROUPS.ns));
+    final Collection<String> clusters =
+        new HashSet<>(
+            providerCache.filterIdentifiers(
+                CLUSTERS.ns, buildMatchAllGlob(getCloudProviderId(), CLUSTERS.ns)));
+
+    for (String sgId : serverGroups) {
+      final Map<String, String> parts = parseServerGroupId(sgId);
+      if (parts != null
+          && parts.containsKey("cluster")
+          && parts.containsKey("application")
+          && parts.containsKey("account")) {
+        final String clusterId =
+            buildClusterId(parts.get("cluster"), parts.get("application"), parts.get("account"));
+        clusters.remove(clusterId);
+      }
+    }
+
+    if (clusters.isEmpty()) {
+      return new DefaultCacheResult(Collections.emptyMap());
+    }
+
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "Evicting {} clusters. Count: {}, keys: {}",
+          getCloudProviderId(),
+          clusters.size(),
+          clusters);
+    } else {
+      log.info("Evicting {} clusters. Count: {}", getCloudProviderId(), clusters.size());
+    }
+
+    return new DefaultCacheResult(Collections.emptyMap(), Map.of(CLUSTERS.ns, clusters));
+  }
+
+  protected abstract Map<String, String> parseServerGroupId(String serverGroupId);
+
+  protected abstract String buildClusterId(String cluster, String application, String account);
+
+  protected static String buildMatchAllGlob(String cloudProviderId, String type) {
+    return cloudProviderId + ":" + type + ":*";
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
@@ -69,9 +69,14 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
   private static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}
 
   static final Set<AgentDataType> types = Collections.unmodifiableSet([
-    AUTHORITATIVE.forType(CLUSTERS.ns),
     AUTHORITATIVE.forType(SERVER_GROUPS.ns),
-    AUTHORITATIVE.forType(APPLICATIONS.ns),
+    // clusters exist globally and the caching agent only
+    // caches regionally so we can't authoritatively evict
+    // clusters. There is a ClusterCleanupAgent that handles
+    // eviction of clusters that no longer contain
+    // server groups.
+    INFORMATIVE.forType(CLUSTERS.ns),
+    INFORMATIVE.forType(APPLICATIONS.ns),
     INFORMATIVE.forType(LOAD_BALANCERS.ns),
     INFORMATIVE.forType(TARGET_GROUPS.ns),
     INFORMATIVE.forType(LAUNCH_CONFIGS.ns),

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCleanupAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCleanupAgent.java
@@ -1,0 +1,29 @@
+package com.netflix.spinnaker.clouddriver.aws.provider.agent;
+
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider;
+import com.netflix.spinnaker.clouddriver.aws.data.Keys;
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider;
+import java.util.Map;
+
+public class ClusterCleanupAgent extends AbstractClusterCleanupAgent {
+
+  @Override
+  public String getProviderName() {
+    return AwsProvider.PROVIDER_NAME;
+  }
+
+  @Override
+  protected String getCloudProviderId() {
+    return AmazonCloudProvider.ID;
+  }
+
+  @Override
+  protected Map<String, String> parseServerGroupId(String serverGroupId) {
+    return Keys.parse(serverGroupId);
+  }
+
+  @Override
+  protected String buildClusterId(String cluster, String application, String account) {
+    return Keys.getClusterKey(cluster, application, account);
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
@@ -30,25 +30,7 @@ import com.netflix.spinnaker.clouddriver.aws.edda.EddaApiFactory;
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider;
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider;
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonApplicationLoadBalancerCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCachingAgentFilter;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCertificateCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCloudFormationCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonElasticIpCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonInstanceTypeCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonKeyPairCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonLaunchTemplateCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonLoadBalancerCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonLoadBalancerInstanceStateCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonSecurityGroupCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonSubnetCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonVpcCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.ClusterCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.EddaLoadBalancerCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.ImageCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.InstanceCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.LaunchConfigCachingAgent;
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservedInstancesCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.*;
 import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3DataProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig;
@@ -135,6 +117,7 @@ public class ProviderHelpers {
       Set<String> publicRegions) {
     Set<String> scheduledAccounts = ProviderUtils.getScheduledAccounts(awsProvider);
     List<Agent> newlyAddedAgents = new ArrayList<>();
+    newlyAddedAgents.add(new ClusterCleanupAgent());
     for (NetflixAmazonCredentials.AWSRegion region : credentials.getRegions()) {
       if (!scheduledAccounts.contains(credentials.getName())) {
         newlyAddedAgents.add(

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgentSpec.groovy
@@ -141,7 +141,7 @@ class ClusterCachingAgentSpec extends Specification {
     def result = agent.handle(providerCache, data)
 
     then:
-    result.authoritativeTypes as Set == ["clusters", "serverGroups", "applications"] as Set
+    result.authoritativeTypes as Set == ["serverGroups"] as Set
   }
 
   void "asg should filter excluded tags"() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProviderSpec.groovy
@@ -93,7 +93,8 @@ class AmazonClusterProviderSpec extends Specification {
       Keys.getApplicationKey(app), [name: app], [serverGroups: [serverGroupId], clusters: [clusterId]]
     )
     cacheView.getAll(LAUNCH_CONFIGS.ns, _ as Set) >> [launchConfiguration]
-    cacheView.getAll(CLUSTERS.ns, _, _) >> [new DefaultCacheData(clusterId, clusterAttributes, [serverGroups: [serverGroupId]])]
+    cacheView.filterIdentifiers(CLUSTERS.ns, _) >> [clusterId]
+    cacheView.getAll(CLUSTERS.ns, _ as Collection<String>) >> [new DefaultCacheData(clusterId, clusterAttributes, [serverGroups: [serverGroupId]])]
     cacheView.getAll(SERVER_GROUPS.ns, [ serverGroupId ], _ as CacheFilter) >> [
       new DefaultCacheData(serverGroupId, serverGroup, [launchConfigs: [launchConfiguration.id]])
     ]
@@ -144,7 +145,8 @@ class AmazonClusterProviderSpec extends Specification {
     ]
 
     cacheView.getAll(LAUNCH_CONFIGS.ns, _ as Set) >> [launchConfiguration]
-    cacheView.getAll(CLUSTERS.ns, _, _) >> [cluster]
+    cacheView.filterIdentifiers(CLUSTERS.ns, _) >> [cluster.id]
+    cacheView.getAll(CLUSTERS.ns, _ as Collection<String>) >> [cluster]
     cacheView.getAll(SERVER_GROUPS.ns, [ serverGroupId ], _ as CacheFilter) >> [serverGroup]
 
     cacheView.getAll(IMAGES.ns, _ as Set) >> [image]
@@ -153,10 +155,6 @@ class AmazonClusterProviderSpec extends Specification {
     def result = provider.getClusterDetails(app)
 
     then:
-    1 * cacheView.get(APPLICATIONS.ns, Keys.getApplicationKey(app)) >> new DefaultCacheData(
-      Keys.getApplicationKey(app), [name: app], [serverGroups: [serverGroupId], clusters: [clusterId]]
-    )
-
     def clusters = result.values()
     def allServerGroups = clusters*.serverGroups.flatten() as Set<AmazonServerGroup>
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandlerSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandlerSpec.groovy
@@ -123,7 +123,7 @@ class AmazonCredentialsLifecycleHandlerSpec extends Specification {
 
     then:
     awsInfrastructureProvider.getAgents().size() == 12
-    awsProvider.getAgents().size() == 21
+    awsProvider.getAgents().size() == 22
     handler.publicRegions.size() == 2
     handler.awsInfraRegions.size() == 2
     handler.reservationReportCachingAgentScheduled

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProviderConfig.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProviderConfig.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.cats.agent.CachingAgent
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.titus.TitusClientProvider
 import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider
+import com.netflix.spinnaker.clouddriver.titus.caching.agents.ClusterCleanupAgent
 import com.netflix.spinnaker.clouddriver.titus.caching.agents.TitusStreamingUpdateAgent
 import com.netflix.spinnaker.clouddriver.titus.caching.utils.AwsLookupUtil
 import com.netflix.spinnaker.clouddriver.titus.caching.utils.CachingSchemaUtil
@@ -71,6 +72,7 @@ class TitusCachingProviderConfig {
         )
       }
     }
+    agents << new ClusterCleanupAgent()
     new TitusCachingProvider(agents, cachingSchemaUtilProvider)
   }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/ClusterCleanupAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/ClusterCleanupAgent.java
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.clouddriver.titus.caching.agents;
+
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AbstractClusterCleanupAgent;
+import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider;
+import com.netflix.spinnaker.clouddriver.titus.caching.Keys;
+import com.netflix.spinnaker.clouddriver.titus.caching.TitusCachingProvider;
+import java.util.*;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ClusterCleanupAgent extends AbstractClusterCleanupAgent {
+
+  @Override
+  public String getProviderName() {
+    return TitusCachingProvider.PROVIDER_NAME;
+  }
+
+  @Override
+  protected String getCloudProviderId() {
+    return TitusCloudProvider.ID;
+  }
+
+  @Override
+  protected Map<String, String> parseServerGroupId(String serverGroupId) {
+    return Keys.parse(serverGroupId);
+  }
+
+  @Override
+  protected String buildClusterId(String cluster, String application, String account) {
+    return Keys.getClusterV2Key(cluster, application, account);
+  }
+}


### PR DESCRIPTION
Clusters and Applications are global entities and can not be
authoritatively cached by a regionally scoped caching agent.

This moves them to INFORMATIVE and adds a new ClusterCleanupAgent
to handle eviction of clusters with no serverGroups.

Also includes changes in the Application and Cluster providers to
account for inconsistent reads (particularly when doing
titus streaming updates) by looking for the presence of cluster
or server groups rather than assuming the application -> cluster
relationship is valid.