### PR TITLE
fix(titus): Handle constraint violation errors during retry

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/SubmitTitusJob.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/SubmitTitusJob.java
@@ -96,8 +96,10 @@ public class SubmitTitusJob extends AbstractTitusDeployAction
                 if (isServiceExceptionRetryable(description, e)) {
                   String statusDescription = e.getStatus().getDescription();
                   if (statusDescription != null
-                      && statusDescription.contains(
-                          "Job sequence id reserved by another pending job")) {
+                      && (statusDescription.contains(
+                              "Job sequence id reserved by another pending job")
+                          || statusDescription.contains(
+                              "Constraint violation - job with group sequence"))) {
                     nextServerGroupName[0] =
                         TitusJobNameResolver.resolveJobName(titusClient, description);
                     saga.log("Retrying with job name %s", nextServerGroupName[0]);


### PR DESCRIPTION
- We have been handling the job pending case, but not the case where the job is already running and we retry , adding the additional check.