### PR TITLE
fix(clouddriver/appengine): Fix Validation errors when multiple services have same named versions

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StandardAppengineAttributeValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StandardAppengineAttributeValidator.groovy
@@ -187,7 +187,7 @@ class StandardAppengineAttributeValidator {
       if (!serverGroup) {
         reject.notFound << serverGroupName
         return reject
-      } else if (loadBalancerName && serverGroup?.loadBalancers[0] != loadBalancerName) {
+      } else if (loadBalancerName && serverGroup?.loadBalancers.contains(loadBalancerName) != true ) {
         reject.notRegisteredWithLoadBalancer << serverGroupName
         return reject
       } else {

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppengineServerGroup.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppengineServerGroup.groovy
@@ -78,6 +78,24 @@ class AppengineServerGroup implements ServerGroup, Serializable {
     )
   }
 
+  def update(Version version, String account, String region, String loadBalancerName, Boolean isDisabled) {
+    this.account = account
+    this.region = region
+    this.name = version.getId()
+    this.loadBalancers.add(loadBalancerName)
+    this.createdTime = AppengineModelUtil.translateTime(version.getCreateTime())
+    this.disabled = isDisabled
+    this.scalingPolicy = AppengineModelUtil.getScalingPolicy(version)
+    this.servingStatus = version.getServingStatus() ? ServingStatus.valueOf(version.getServingStatus()) : null
+    this.env = version.getEnv() ? Environment.valueOf(version.getEnv().toUpperCase()) : null
+    this.httpUrl = AppengineModelUtil.getHttpUrl(version.getName())
+    this.httpsUrl = AppengineModelUtil.getHttpsUrl(version.getName())
+    this.instanceClass = version.getInstanceClass()
+    this.launchConfig.instanceType = this.instanceClass
+    this.zones = [region] as Set
+    this.allowsGradualTrafficMigration = versionAllowsGradualTrafficMigration(version)
+  }
+
   @Override
   ServerGroup.Capacity getCapacity() {
     Integer instanceCount = instances?.size() ?: 0

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AppengineServerGroupCachingAgent.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AppengineServerGroupCachingAgent.groovy
@@ -267,11 +267,19 @@ class AppengineServerGroupCachingAgent extends AbstractAppengineCachingAgent imp
           cachedServerGroups[serverGroupKey].with {
             attributes.name = serverGroupName
             def isDisabled = !loadBalancer.getSplit().getAllocations().containsKey(serverGroupName);
-            attributes.serverGroup = new AppengineServerGroup(serverGroup,
-                                                              accountName,
-                                                              credentials.region,
-                                                              loadBalancerName,
-                                                              isDisabled)
+            if (attributes.serverGroup == null) {
+              attributes.serverGroup = new AppengineServerGroup(serverGroup,
+                accountName,
+                credentials.region,
+                loadBalancerName,
+                isDisabled)
+            } else {
+              attributes.serverGroup.update(serverGroup,
+                accountName,
+                credentials.region,
+                loadBalancerName,
+                isDisabled)
+            }
             relationships[APPLICATIONS.ns].add(applicationKey)
             relationships[CLUSTERS.ns].add(clusterKey)
             relationships[INSTANCES.ns].addAll(instanceKeys)


### PR DESCRIPTION
Fixes spinnaker/spinnaker#6305

Uses the ServerGroup `loadBalancer` set to validate Appengine versions with identical names in differerent services(Load Balancers).