### PR TITLE
feat(aws/deploy): Auto-enable ipv6 in test by config

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -171,6 +171,12 @@ class AutoScalingWorker {
     String launchConfigName = null
 
     if (shouldSetLaunchTemplate(asgConfig)) {
+      if(asgConfig.getAssociateIPv6Address() == null) {
+        def asgConfigEnv = asgConfig.getCredentials().getEnvironment()
+        def autoEnableIPv6 = dynamicConfigService.getConfig(Boolean.class, "aws.features.launch-templates.ipv6.${asgConfigEnv}", false)
+        asgConfig.setAssociateIPv6Address(autoEnableIPv6)
+      }
+
       def asgConfigWithSecGroups = AsgConfigHelper.setAppSecurityGroups(
               asgConfig,
               regionScopedProvider.getSecurityGroupService(),

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -70,7 +70,7 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
    * Associate an IPv6 address
    * This is a Launch Template only feature
    */
-  Boolean associateIPv6Address = false
+  Boolean associateIPv6Address
 
   /**
    * Applicable only for burstable performance instance types like t2/t3.

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorkerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorkerUnitSpec.groovy
@@ -144,6 +144,7 @@ class AutoScalingWorkerUnitSpec extends Specification {
     0 * dynamicConfigService.getConfig(String.class, "aws.features.launch-templates.allowed-accounts", "") >> ""
     1 * dynamicConfigService.getConfig(String.class,"aws.features.launch-templates.excluded-applications", "") >> ""
     1 * dynamicConfigService.getConfig(String.class,"aws.features.launch-templates.allowed-applications", "") >> { "myasg:foo:us-east-1" }
+    1 * dynamicConfigService.getConfig(Boolean.class, 'aws.features.launch-templates.ipv6.foo', false) >> false
     0 * dynamicConfigService._
 
     and:
@@ -195,7 +196,7 @@ class AutoScalingWorkerUnitSpec extends Specification {
     1 * dynamicConfigService.getConfig(String.class, "aws.features.launch-templates.excluded-applications", "") >> ""
     1 * dynamicConfigService.getConfig(String.class, "aws.features.launch-templates.excluded-accounts", "") >> ""
     1 * dynamicConfigService.getConfig(String.class,"aws.features.launch-templates.allowed-applications", "") >> { "myasg:foo:us-east-1" }
-
+    1 * dynamicConfigService.getConfig(Boolean.class, 'aws.features.launch-templates.ipv6.foo', false) >> false
     0 * dynamicConfigService._
 
     and:


### PR DESCRIPTION
For apps with launch templates enabled, IPv6 assignment can now be automated by configuration. In this phase of the rollout, only asgs in the `test` environment with the config enabled will be automated. 