### PR TITLE
feat(provider/aws): EBS encryption with KMS key id on LaunchTemplate

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonBlockDevice.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonBlockDevice.groovy
@@ -77,6 +77,12 @@ class AmazonBlockDevice {
    */
   Boolean encrypted
 
+  /**
+   *  The KMS key id to encrypt EBS
+   *  This is available only for LaunchTemplate
+   */
+  String kmsKeyId
+
   private AmazonBlockDevice(Builder builder) {
     deviceName = builder.deviceName
     virtualName = builder.virtualName
@@ -86,6 +92,7 @@ class AmazonBlockDevice {
     iops = builder.iops
     snapshotId = builder.snapshotId
     encrypted = builder.encrypted
+    kmsKeyId = builder.kmsKeyId
   }
 
   static class Builder {
@@ -97,6 +104,7 @@ class AmazonBlockDevice {
     Integer iops
     String snapshotId
     Boolean encrypted
+    String kmsKeyId
 
     Builder deviceName(String deviceName) {
       this.deviceName = deviceName
@@ -135,6 +143,11 @@ class AmazonBlockDevice {
 
     Builder encrypted(Boolean encrypted) {
       this.encrypted = encrypted
+      return this
+    }
+
+    Builder kmsKeyId(String kmsKeyId) {
+      this.kmsKeyId = kmsKeyId
       return this
     }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -412,6 +412,10 @@ public class LaunchTemplateService {
     if (blockDevice.getEncrypted() != null) {
       blockDeviceRequest.setEncrypted(blockDevice.getEncrypted());
     }
+
+    if (blockDevice.getKmsKeyId() != null) {
+      blockDeviceRequest.setKmsKeyId(blockDevice.getKmsKeyId());
+    }
     return blockDeviceRequest;
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateServiceSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateServiceSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.aws.services
+
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.LocalFileUserDataProperties;
+import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.UserDataProviderAggregator;
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
+import com.netflix.spinnaker.clouddriver.aws.services.LaunchTemplateService
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class LaunchTemplateServiceSpec extends Specification {
+
+  def launchTemplateService = new LaunchTemplateService(
+    Mock(AmazonEC2),
+    Mock(UserDataProviderAggregator),
+    Mock(LocalFileUserDataProperties)
+  )
+
+  void 'should match ebs encryption'() {
+    when:
+    def result = launchTemplateService.getLaunchTemplateEbsBlockDeviceRequest(blockDevice)
+
+    then:
+    result.getEncrypted() == encrypted && result.getKmsKeyId() == kmsKeyId
+
+    where:
+    blockDevice                                             | encrypted | kmsKeyId
+    new AmazonBlockDevice()                                 | null      | null
+    new AmazonBlockDevice(encrypted: true)                  | true      | null
+    new AmazonBlockDevice(encrypted: true, kmsKeyId: "xxx") | true      | "xxx"
+  }
+}


### PR DESCRIPTION
AWS EBS can be encrypted by customer managed key and it is supported with LaunchTemplate.
I added `kmsKeyId` in `AmazonBlockDevice` class and it is used to request AWS API to create LaunchTemplate.

See [this link](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-blockdevicemapping-ebs.html) to check the parameters `AWS::EC2::LaunchTemplate BlockDeviceMapping`.