### PR TITLE
fix(aws): Update only spinnaker specific tags during security group u…

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
@@ -291,10 +291,10 @@ class SecurityGroupLookupFactory {
           new Filter("resource-id", [groupId])
         )
         DescribeTagsResult tagsResult = amazonEC2.describeTags(describeTagsRequest)
-        List<TagDescription> tags1 = tagsResult.getTags()
+        List<TagDescription> currentTags = tagsResult.getTags()
         Collection<Tag> oldTags = new HashSet()
         // Filter Spinnaker specific tags, update to other tags might result in permission errors
-        tags1.each {
+        currentTags.each {
           it ->
             if (it.key.equals("Name") || description.tags.keySet().contains(it.key)) {
               oldTags.add(new Tag(it.key, it.value))

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
@@ -293,8 +293,12 @@ class SecurityGroupLookupFactory {
         DescribeTagsResult tagsResult = amazonEC2.describeTags(describeTagsRequest)
         List<TagDescription> tags1 = tagsResult.getTags()
         Collection<Tag> oldTags = new HashSet()
+        // Filter Spinnaker specific tags, update to other tags might result in permission errors
         tags1.each {
-          it -> oldTags.add(new Tag(it.key, it.value))
+          it ->
+            if(it.key.equals("Name") || description.tags.keySet().contains(it.key)){
+              oldTags.add(new Tag(it.key, it.value))
+            }
         }
 
         DeleteTagsRequest deleteTagsRequest = new DeleteTagsRequest()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
@@ -296,7 +296,7 @@ class SecurityGroupLookupFactory {
         // Filter Spinnaker specific tags, update to other tags might result in permission errors
         tags1.each {
           it ->
-            if(it.key.equals("Name") || description.tags.keySet().contains(it.key)){
+            if (it.key.equals("Name") || description.tags.keySet().contains(it.key)) {
               oldTags.add(new Tag(it.key, it.value))
             }
         }


### PR DESCRIPTION
- Previously we were updating all available tags during `upsert` operation , this fails with `UnauthorizedOperation` error if some additional tags are present on the resource which have more restricted permissions. This fix will filter tags which are spinnaker specific while updating tags. 