### PR TITLE
fix(titus): Support for entrypoint and cmd list

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Job.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Job.java
@@ -38,7 +38,9 @@ public class Job {
   private String user;
   private String version;
   private String entryPoint;
+  private List<String> entryPointList;
   private String cmd;
+  private List<String> cmdList;
   private String iamProfile;
   private String capacityGroup;
   private Boolean inService;
@@ -131,12 +133,13 @@ public class Job {
     applicationName = grpcJob.getJobDescriptor().getContainer().getImage().getName();
     version = grpcJob.getJobDescriptor().getContainer().getImage().getTag();
     digest = grpcJob.getJobDescriptor().getContainer().getImage().getDigest();
-    entryPoint =
-        grpcJob.getJobDescriptor().getContainer().getEntryPointList().stream()
-            .collect(Collectors.joining(" "));
-    cmd =
-        grpcJob.getJobDescriptor().getContainer().getCommandList().stream()
-            .collect(Collectors.joining(" "));
+
+    entryPointList = new ArrayList<>(grpcJob.getJobDescriptor().getContainer().getEntryPointList());
+    entryPoint = entryPointList.stream().collect(Collectors.joining(" "));
+
+    cmdList = new ArrayList<>(grpcJob.getJobDescriptor().getContainer().getCommandList());
+    cmd = cmdList.stream().collect(Collectors.joining(" "));
+
     capacityGroup = grpcJob.getJobDescriptor().getCapacityGroup();
     cpu = (int) grpcJob.getJobDescriptor().getContainer().getResources().getCpu();
     memory = grpcJob.getJobDescriptor().getContainer().getResources().getMemoryMB();
@@ -374,12 +377,28 @@ public class Job {
     this.entryPoint = entryPoint;
   }
 
+  public List<String> getEntryPointList() {
+    return entryPointList;
+  }
+
+  public void setEntryPointList(List<String> entryPointList) {
+    this.entryPointList = entryPointList;
+  }
+
   public String getCmd() {
     return cmd;
   }
 
   public void setCmd(String cmd) {
     this.cmd = cmd;
+  }
+
+  public List<String> getCmdList() {
+    return cmdList;
+  }
+
+  public void setCmdList(List<String> cmdList) {
+    this.cmdList = cmdList;
   }
 
   public int getInstances() {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/JobDescription.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/JobDescription.java
@@ -60,6 +60,13 @@ public class JobDescription {
 
   private String entryPoint;
   private String cmd;
+
+  /** If present this will take precedence over the single entry point */
+  private List<String> entryPointList = null;
+
+  /** If present this will take precedence over the single cmd */
+  private List<String> cmdList = null;
+
   private String iamProfile;
   private String capacityGroup;
   private Efs efs;
@@ -113,7 +120,9 @@ public class JobDescription {
             ? request.getContainerAttributes()
             : new HashMap<>();
     entryPoint = request.getEntryPoint();
+    entryPointList = request.getEntryPointList();
     cmd = request.getCmd();
+    cmdList = request.getCmdList();
     iamProfile = request.getIamProfile();
     capacityGroup = request.getCapacityGroup();
     securityGroups = request.getSecurityGroups();
@@ -358,12 +367,28 @@ public class JobDescription {
     this.entryPoint = entryPoint;
   }
 
+  public List<String> getEntryPointList() {
+    return entryPointList;
+  }
+
+  public void setEntryPointList(List<String> entryPointList) {
+    this.entryPointList = entryPointList;
+  }
+
   public String getCmd() {
     return cmd;
   }
 
   public void setCmd(String cmd) {
     this.cmd = cmd;
+  }
+
+  public List<String> getCmdList() {
+    return cmdList;
+  }
+
+  public void setCmdList(List<String> cmdList) {
+    this.cmdList = cmdList;
   }
 
   public String getIamProfile() {
@@ -546,11 +571,15 @@ public class JobDescription {
 
     containerBuilder.setImage(imageBuilder);
 
-    if (entryPoint != null) {
+    if (entryPointList != null) {
+      containerBuilder.addAllEntryPoint(entryPointList);
+    } else if (entryPoint != null) {
       containerBuilder.addEntryPoint(entryPoint);
     }
 
-    if (cmd != null && !cmd.isEmpty()) {
+    if (cmdList != null) {
+      containerBuilder.addAllCommand(cmdList);
+    } else if (cmd != null && !cmd.isEmpty()) {
       containerBuilder.addCommand(cmd);
     }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/SubmitJobRequest.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/SubmitJobRequest.java
@@ -79,7 +79,9 @@ public class SubmitJobRequest {
   private String detail;
   private String user;
   private String entryPoint;
+  @Builder.Default private List<String> entryPointList = null;
   private String cmd;
+  @Builder.Default private List<String> cmdList = null;
   private String iamProfile;
   private String capacityGroup;
   @Builder.Default private Boolean inService = true;

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.java
@@ -44,7 +44,9 @@ public class TitusDeployDescription extends AbstractTitusCredentialsDescription
   private Map<String, String> labels = new LinkedHashMap<>();
   private Map<String, String> containerAttributes = new LinkedHashMap<>();
   private String entryPoint;
+  private List<String> entryPointList;
   private String cmd;
+  private List<String> cmdList;
   private String iamProfile;
   private String capacityGroup;
   private String user;
@@ -127,6 +129,8 @@ public class TitusDeployDescription extends AbstractTitusCredentialsDescription
             .stack(stack)
             .detail(freeFormDetails)
             .entryPoint(entryPoint)
+            .entryPointList(entryPointList)
+            .cmdList(cmdList)
             .iamProfile(iamProfile)
             .capacityGroup(capacityGroup)
             .labels(labels)
@@ -352,12 +356,28 @@ public class TitusDeployDescription extends AbstractTitusCredentialsDescription
     this.entryPoint = entryPoint;
   }
 
+  public List<String> getEntryPointList() {
+    return entryPointList;
+  }
+
+  public void setEntryPointList(List<String> entryPointList) {
+    this.entryPointList = entryPointList;
+  }
+
   public String getCmd() {
     return cmd;
   }
 
   public void setCmd(String cmd) {
     this.cmd = cmd;
+  }
+
+  public List<String> getCmdList() {
+    return cmdList;
+  }
+
+  public void setCmdList(List<String> cmdList) {
+    this.cmdList = cmdList;
   }
 
   public String getIamProfile() {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroup.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroup.groovy
@@ -42,7 +42,9 @@ class TitusServerGroup implements ServerGroup, Serializable {
   final String type = TitusCloudProvider.ID
   final String cloudProvider = TitusCloudProvider.ID
   String entryPoint
+  List<String> entryPointList
   String cmd
+  List<String> cmdList
   String awsAccount
   String accountId
   String iamProfile
@@ -85,7 +87,9 @@ class TitusServerGroup implements ServerGroup, Serializable {
     image << [dockerImageVersion: job.version]
     image << [dockerImageDigest: job.digest]
     entryPoint = job.entryPoint
+    entryPointList = job.entryPointList
     cmd = job.cmd
+    cmdList = job.cmdList
     iamProfile = job.iamProfile
     resources.cpu = job.cpu
     resources.memory = job.memory


### PR DESCRIPTION
-- Accept entrypoint and command as an array and pass it along to titus.
-- Currently users cannot specify either entry point or cmd in exec form(Json Array Format) and can only give one string and this change will allow users to specify entry and cmd in multiple parts.