### PR TITLE
fix(entitytags): include required module

### DIFF
--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -23,6 +23,7 @@ dependencies {
   implementation project(":clouddriver-api")
   implementation project(":clouddriver-artifacts")
   implementation project(":clouddriver-core")
+  implementation project(":clouddriver-elasticsearch")
   implementation project(":clouddriver-security")
   implementation project(":clouddriver-sql")
 
@@ -57,8 +58,6 @@ dependencies {
   if (!gradle.hasProperty("excludeSpringConfigServer")) {
     runtimeOnly project(":clouddriver-configserver")
   }
-
-  testImplementation project(":clouddriver-elasticsearch")
 
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "org.spockframework:spock-core"


### PR DESCRIPTION
The removal of the AWS integration with Entity Tags as part of #4923 mean that the required modules for core Entity Tags functions was not included in the `clouddriver` build.

This change changes the dependency on `clouddriver-elasticsearch` in `clouddriver-web` from test only to implementation. This ensure that the ES module is included in the build.

Fixes spinnaker/spinnaker#6331
