### PR TITLE
feat(core): Tag `orchestrations`, `operations` and `tasks` metrics with `cloudProvider`

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
@@ -28,13 +28,12 @@ import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEventHand
 import com.netflix.spinnaker.kork.api.exceptions.ExceptionSummary
 import com.netflix.spinnaker.kork.web.context.RequestContextProvider
 import com.netflix.spinnaker.kork.web.exceptions.ExceptionSummaryService
-import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.transform.Canonical
 import groovy.util.logging.Slf4j
-import org.slf4j.MDC
 import org.springframework.context.ApplicationContext
 
 import javax.annotation.Nonnull
+import javax.annotation.Nullable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
@@ -88,11 +87,12 @@ class DefaultOrchestrationProcessor implements OrchestrationProcessor {
   }
 
   @Override
-  Task process(List<AtomicOperation> atomicOperations, String clientRequestId) {
-
-    def orchestrationsId = registry.createId('orchestrations')
-    def atomicOperationId = registry.createId('operations')
-    def tasksId = registry.createId('tasks')
+  Task process(@Nullable String cloudProvider,
+               @Nonnull List<AtomicOperation> atomicOperations,
+               @Nonnull String clientRequestId) {
+    def orchestrationsId = registry.createId('orchestrations').withTag("cloudProvider", cloudProvider ?: "unknown")
+    def atomicOperationId = registry.createId('operations').withTag("cloudProvider", cloudProvider ?: "unknown")
+    def tasksId = registry.createId('tasks').withTag("cloudProvider", cloudProvider ?: "unknown")
 
     // Get the task (either an existing one, or a new one). If the task already exists, `shouldExecute` will be false
     // if the task is in a failed state and the failure is not retryable.

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/OrchestrationProcessor.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/OrchestrationProcessor.java
@@ -15,6 +15,8 @@ package com.netflix.spinnaker.clouddriver.orchestration;
 
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Implementations of this interface should perform orchestration of operations in a workflow. Often
@@ -27,5 +29,13 @@ public interface OrchestrationProcessor {
    * @param key a unique key, used to de-dupe orchestration requests
    * @return a list of results
    */
-  Task process(List<AtomicOperation> atomicOperations, String key);
+  Task process(
+      @Nullable String cloudProvider,
+      @Nonnull List<AtomicOperation> atomicOperations,
+      @Nonnull String key);
+
+  @Deprecated
+  default Task process(@Nonnull List<AtomicOperation> atomicOperations, @Nonnull String key) {
+    return process(null, atomicOperations, key);
+  }
 }

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessorSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessorSpec.groovy
@@ -176,7 +176,7 @@ class DefaultOrchestrationProcessorSpec extends Specification {
   }
 
   private void submitAndWait(AtomicOperation atomicOp) {
-    processor.process([atomicOp], taskKey)
+    processor.process("cloudProvider", [atomicOp], taskKey)
     processor.executorService.shutdown()
     processor.executorService.awaitTermination(5, TimeUnit.SECONDS)
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleAutoscalingPolicyAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleAutoscalingPolicyAtomicOperation.groovy
@@ -189,7 +189,7 @@ class DeleteGoogleAutoscalingPolicyAtomicOperation extends GoogleAtomicOperation
       templateOpMap.instanceMetadata.remove(GCEUtil.AUTOSCALING_POLICY)
       def converter = atomicOperationsRegistry.getAtomicOperationConverter('modifyGoogleServerGroupInstanceTemplateDescription', 'gce')
       AtomicOperation templateOp = converter.convertOperation(templateOpMap)
-      orchestrationProcessor.process([templateOp], UUID.randomUUID().toString())
+      orchestrationProcessor.process('gce', [templateOp], UUID.randomUUID().toString())
     }
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
@@ -391,7 +391,7 @@ class UpsertGoogleAutoscalingPolicyAtomicOperation extends GoogleAtomicOperation
     if (templateOpMap.instanceMetadata) {
       def converter = atomicOperationsRegistry.getAtomicOperationConverter('modifyGoogleServerGroupInstanceTemplateDescription', 'gce')
       AtomicOperation templateOp = converter.convertOperation(templateOpMap)
-      orchestrationProcessor.process([templateOp], UUID.randomUUID().toString())
+      orchestrationProcessor.process('gce', [templateOp], UUID.randomUUID().toString())
     }
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
@@ -595,7 +595,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
 
       def converter = atomicOperationsRegistry.getAtomicOperationConverter('modifyGoogleServerGroupInstanceTemplateDescription', 'gce')
       AtomicOperation templateOp = converter.convertOperation(templateOpMap)
-      orchestrationProcessor.process([templateOp], UUID.randomUUID().toString())
+      orchestrationProcessor.process('gce', [templateOp], UUID.randomUUID().toString())
     }
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleInternalHttpLoadBalancerAtomicOperation.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleInternalHttpLoadBalancerAtomicOperation.java
@@ -1039,7 +1039,7 @@ public class UpsertGoogleInternalHttpLoadBalancerAtomicOperation
                 "modifyGoogleServerGroupInstanceTemplateDescription", "gce");
         AtomicOperation templateOp = converter.convertOperation(templateOpMap);
         orchestrationProcessor.process(
-            new ArrayList<>(Arrays.asList(templateOp)), UUID.randomUUID().toString());
+            "gce", new ArrayList<>(Arrays.asList(templateOp)), UUID.randomUUID().toString());
       }
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
@@ -68,7 +68,7 @@ class OperationsController {
     @RequestParam(value = "clientRequestId", required = false) String clientRequestId,
     @RequestBody List<Map<String, Map>> requestBody) {
     List<AtomicOperation> atomicOperations = operationsService.collectAtomicOperations(requestBody)
-    return start(atomicOperations, clientRequestId)
+    return start(null, atomicOperations, clientRequestId)
   }
 
   /**
@@ -81,7 +81,7 @@ class OperationsController {
     @RequestParam(value = "clientRequestId", required = false) String clientRequestId,
     @RequestBody Map requestBody) {
     List<AtomicOperation> atomicOperations = operationsService.collectAtomicOperations([[(name): requestBody]])
-    return start(atomicOperations, clientRequestId)
+    return start(null, atomicOperations, clientRequestId)
   }
 
   @PostMapping("/{cloudProvider}/ops")
@@ -90,7 +90,7 @@ class OperationsController {
     @RequestParam(value = "clientRequestId", required = false) String clientRequestId,
     @RequestBody List<Map<String, Map>> requestBody) {
     List<AtomicOperation> atomicOperations = operationsService.collectAtomicOperations(cloudProvider, requestBody)
-    return start(atomicOperations, clientRequestId)
+    return start(cloudProvider, atomicOperations, clientRequestId)
   }
 
   @PostMapping("/{cloudProvider}/ops/{name}")
@@ -100,7 +100,7 @@ class OperationsController {
     @RequestParam(value = "clientRequestId", required = false) String clientRequestId,
     @RequestBody Map requestBody) {
     List<AtomicOperation> atomicOperations = operationsService.collectAtomicOperations(cloudProvider, [[(name): requestBody]])
-    return start(atomicOperations, clientRequestId)
+    return start(cloudProvider, atomicOperations, clientRequestId)
   }
 
   @GetMapping("/task/{id}")
@@ -140,7 +140,7 @@ class OperationsController {
     if (atomicOperations.isEmpty()) {
       throw new NotFoundException("No saga was found for this task id: $id - can't resume")
     }
-    
+
     return start(atomicOperations, t.requestId)
   }
 
@@ -163,10 +163,12 @@ class OperationsController {
     }
   }
 
-  private StartOperationResult start(@Nonnull List<AtomicOperation> atomicOperations, @Nullable String id) {
+  private StartOperationResult start(@Nullable String cloudProvider,
+                                     @Nonnull List<AtomicOperation> atomicOperations,
+                                     @Nullable String id) {
     Task task =
       orchestrationProcessor.process(
-        atomicOperations, Optional.ofNullable(id).orElse(UUID.randomUUID().toString()));
+        cloudProvider, atomicOperations, Optional.ofNullable(id).orElse(UUID.randomUUID().toString()));
     return new StartOperationResult(task.getId());
   }
 


### PR DESCRIPTION
The tag will be `unknown` in the event that a `cloudProvider` is not available (not all operations
are cloud-specific).

This is step one to being able to clasify and better report the cause for failed operations in
`clouddriver`.
