### PR TITLE
feat(docker): for a V2Schema add inspectDigest to inspect docker metadata

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
@@ -49,6 +49,8 @@ class DockerRegistryConfigurationProperties {
     int paginateSize
     // Track digest changes. This is _not_ recommended as it consumes a high QPM, and most registries are flaky.
     boolean trackDigests
+    // inspect digests
+    boolean inspectDigests
     // Sort tags by creation date.
     boolean sortTagsByDate
     boolean insecureRegistry

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
@@ -167,7 +167,6 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware, Age
             digestContent = credentials.client.getDigestContent(repository, digest)
           } catch (Exception e) {
             log.warn("Error retrieving config digest for $tagKey; digest and tag will not be cached: $e.message")
-            return
           }
         }
 

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
@@ -141,6 +141,7 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware, Age
         def tagKey = Keys.getTaggedImageKey(accountName, repository, tag)
         def imageIdKey = Keys.getImageIdKey(DockerRegistryProviderUtils.imageId(registry, repository, tag))
         def digest = null
+        def digestContent = null
         def creationDate = null
 
         if (credentials.trackDigests) {
@@ -160,6 +161,16 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware, Age
           }
         }
 
+        if (credentials.inspectDigests) {
+          try {
+            digest = credentials.client.getConfigDigest(repository, tag)
+            digestContent = credentials.client.getDigestContent(repository, digest)
+          } catch (Exception e) {
+            log.warn("Error retrieving config digest for $tagKey; digest and tag will not be cached: $e.message")
+            return
+          }
+        }
+
         if (credentials.sortTagsByDate) {
           try {
             creationDate = credentials.client.getCreationDate(repository, tag)
@@ -174,6 +185,9 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware, Age
         tagData.attributes.put("account", accountName)
         tagData.attributes.put("digest", digest)
         tagData.attributes.put("date", creationDate)
+        if (digestContent?.config != null) {
+          tagData.attributes.put("labels", digestContent.config.Labels)
+        }
         cachedTags.put(tagKey, tagData)
 
         def idData = new DefaultCacheDataBuilder()

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentials.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentials.groovy
@@ -23,12 +23,14 @@ class DockerRegistryCredentials {
   private List<String> repositories
   private final boolean reloadRepositories
   private final boolean trackDigests
+  private final boolean inspectDigests
   private final boolean sortTagsByDate
   private List<String> skip
 
-  DockerRegistryCredentials(DockerRegistryClient client, List<String> repositories, boolean trackDigests, List<String> skip, boolean sortTagsByDate) {
+  DockerRegistryCredentials(DockerRegistryClient client, List<String> repositories, boolean trackDigests, boolean inspectDigests, List<String> skip, boolean sortTagsByDate) {
     this.client = client
     this.trackDigests = trackDigests
+    this.inspectDigests = inspectDigests
     this.skip = skip
     if (!repositories) {
       this.reloadRepositories = true
@@ -50,6 +52,10 @@ class DockerRegistryCredentials {
 
   boolean getTrackDigests() {
     return trackDigests
+  }
+
+  boolean getInspectDigests() {
+    return inspectDigests
   }
 
   boolean getSortTagsByDate() {

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
@@ -76,6 +76,7 @@ class DockerRegistryCredentialsInitializer {
           .clientTimeoutMillis(managedAccount.clientTimeoutMillis)
           .paginateSize(managedAccount.paginateSize)
           .trackDigests(managedAccount.trackDigests)
+          .inspectDigests(managedAccount.inspectDigests)
           .sortTagsByDate(managedAccount.sortTagsByDate)
           .insecureRegistry(managedAccount.insecureRegistry)
           .repositories(managedAccount.repositories)

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
@@ -47,6 +47,7 @@ class DockerRegistryNamedAccountCredentials extends AbstractAccountCredentials<D
     long clientTimeoutMillis
     int paginateSize
     boolean trackDigests
+    boolean inspectDigests
     boolean sortTagsByDate
     boolean insecureRegistry
     List<String> repositories
@@ -142,6 +143,11 @@ class DockerRegistryNamedAccountCredentials extends AbstractAccountCredentials<D
       return this
     }
 
+    Builder inspectDigests(boolean inspectDigests) {
+      this.inspectDigests = inspectDigests
+      return this
+    }
+
     Builder sortTagsByDate(boolean sortTagsByDate) {
       this.sortTagsByDate = sortTagsByDate
       return this
@@ -195,6 +201,7 @@ class DockerRegistryNamedAccountCredentials extends AbstractAccountCredentials<D
                                                        clientTimeoutMillis,
                                                        paginateSize,
                                                        trackDigests,
+                                                       inspectDigests,
                                                        sortTagsByDate,
                                                        catalogFile,
                                                        repositoriesRegex,
@@ -220,6 +227,7 @@ class DockerRegistryNamedAccountCredentials extends AbstractAccountCredentials<D
                                         long clientTimeoutMillis,
                                         int paginateSize,
                                         boolean trackDigests,
+                                        boolean inspectDigests,
                                         boolean sortTagsByDate,
                                         String catalogFile,
                                         String repositoriesRegex,
@@ -242,6 +250,7 @@ class DockerRegistryNamedAccountCredentials extends AbstractAccountCredentials<D
          clientTimeoutMillis,
          paginateSize,
          trackDigests,
+         inspectDigests,
          sortTagsByDate,
          catalogFile,
          repositoriesRegex,
@@ -267,6 +276,7 @@ class DockerRegistryNamedAccountCredentials extends AbstractAccountCredentials<D
                                         long clientTimeoutMillis,
                                         int paginateSize,
                                         boolean trackDigests,
+                                        boolean inspectDigests,
                                         boolean sortTagsByDate,
                                         String catalogFile,
                                         String repositoriesRegex,
@@ -323,6 +333,7 @@ class DockerRegistryNamedAccountCredentials extends AbstractAccountCredentials<D
     this.email = email
     this.repositoriesRegex = repositoriesRegex
     this.trackDigests = trackDigests
+    this.inspectDigests = inspectDigests
     this.sortTagsByDate = sortTagsByDate
     this.insecureRegistry = insecureRegistry;
     this.skip = skip ?: []
@@ -338,6 +349,10 @@ class DockerRegistryNamedAccountCredentials extends AbstractAccountCredentials<D
   @Override
   String getName() {
     return accountName
+  }
+
+  String getRegistry() {
+    return registry
   }
 
   @JsonIgnore
@@ -369,6 +384,14 @@ class DockerRegistryNamedAccountCredentials extends AbstractAccountCredentials<D
     return "$address/v2"
   }
 
+  boolean getTrackDigests(){
+    return trackDigests
+  }
+
+  boolean getInspectDigests(){
+    return inspectDigests
+  }
+
   @Override
   String getCloudProvider() {
     return CLOUD_PROVIDER
@@ -391,7 +414,7 @@ class DockerRegistryNamedAccountCredentials extends AbstractAccountCredentials<D
         .okClientProvider(dockerOkClientProvider)
         .build()
 
-      return new DockerRegistryCredentials(client, repositories, trackDigests, skip, sortTagsByDate)
+      return new DockerRegistryCredentials(client, repositories, trackDigests,  inspectDigests, skip, sortTagsByDate)
     } catch (RetrofitError e) {
       if (e.response?.status == 404) {
         throw new DockerRegistryConfigException("No repositories specified for ${name}, and the provided endpoint ${address} does not support /_catalog.")
@@ -415,6 +438,7 @@ class DockerRegistryNamedAccountCredentials extends AbstractAccountCredentials<D
   final File passwordFile
   final String email
   final boolean trackDigests
+  final boolean inspectDigests
   final boolean sortTagsByDate
   final int cacheThreads
   final long cacheIntervalSeconds

--- a/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClientSpec.groovy
+++ b/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClientSpec.groovy
@@ -53,54 +53,54 @@ class DockerRegistryClientSpec extends Specification {
     Response catalogResponse = new Response("/v2/_catalog/",200, "nothing", Collections.EMPTY_LIST, catalogTypedInput)
     getCatalog(_,_,_) >> catalogResponse
 
-    String schemaJson = "{\n" +
-      "   \"schemaVersion\": 2,\n" +
-      "   \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n" +
-      "   \"config\": {\n" +
-      "      \"mediaType\": \"application/vnd.docker.container.image.v1+json\",\n" +
-      "      \"size\": 4405,\n" +
-      "      \"digest\": \"sha256:fa8d22f4899110fdecf7ae344a8129fb6175ed5294ffe9ca3fb09dfca5252c93\"\n" +
-      "   },\n" +
-      "   \"layers\": [\n" +
-      "      {\n" +
-      "         \"mediaType\": \"application/vnd.docker.image.rootfs.diff.tar.gzip\",\n" +
-      "         \"size\": 3310095,\n" +
-      "         \"digest\": \"sha256:1ace22715a341b6ad81b784da18f2efbcea18ff7b4b4edf4f467f193b7de3750\"\n" +
-      "      }\n" +
-      "   ]\n" +
-      "}"
+    String schemaJson = '''{
+         "schemaVersion": 2,
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "config": {
+            "mediaType": "application/vnd.docker.container.image.v1+json",
+            "size": 4405,
+            "digest": "sha256:fa8d22f4899110fdecf7ae344a8129fb6175ed5294ffe9ca3fb09dfca5252c93"
+         },
+         "layers": [
+            {
+               "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+               "size": 3310095,
+               "digest": "sha256:1ace22715a341b6ad81b784da18f2efbcea18ff7b4b4edf4f467f193b7de3750"
+            }
+         ]
+      }'''
     TypedInput schemaV2Input = new TypedByteArray("application/json", schemaJson.getBytes())
     Response schemaV2Response = new Response("/v2/{name}/manifests/{reference}",200, "nothing", Collections.EMPTY_LIST, schemaV2Input)
     getSchemaV2Manifest(_,_,_,_) >> schemaV2Response
 
-    String configDigestContentJson = "{ \n" +
-      "  \"architecture\": \"amd64\",\n" +
-      "  \"config\": {\n" +
-      "    \"Hostname\": \"\",\n" +
-      "    \"Env\": [\n" +
-      "      \"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"\n" +
-      "    ],\n" +
-      "    \"Cmd\": [\n" +
-      "      \"/opt/app/server\"\n" +
-      "    ],\n" +
-      "    \"Image\": \"sha256:3862e8f6f860c732be3fe0c0545330f9573a09cf906a78b06a329e09f9dc7191\",\n" +
-      "    \"Volumes\": null,\n" +
-      "    \"WorkingDir\": \"\",\n" +
-      "    \"Entrypoint\": null,\n" +
-      "    \"OnBuild\": null,\n" +
-      "    \"Labels\": {\n" +
-      "      \"branch\": \"main\",\n" +
-      "      \"buildNumber\": \"1\",\n" +
-      "      \"commitId\": \"b48e2cf960de545597411c99ec969e47a7635ba3\",\n" +
-      "      \"jobName\": \"test\"\n" +
-      "    }\n" +
-      "  },\n" +
-      "  \"container\": \"fc1607ce29cfa58cc6cad846b911ec0c4de76d426de2b528a126e715615286bc\",\n" +
-      "  \"created\": \"2021-02-16T19:18:50.176616541Z\",\n" +
-      "  \"docker_version\": \"19.03.6-ce\",\n" +
-      "  \"os\": \"linux\",\n" +
-      "  \"rootfs\": {}\n" +
-      "}"
+    String configDigestContentJson = '''{
+        "architecture": "amd64",
+        "config": {
+          "Hostname": "",
+          "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          ],
+          "Cmd": [
+            "/opt/app/server"
+          ],
+          "Image": "sha256:3862e8f6f860c732be3fe0c0545330f9573a09cf906a78b06a329e09f9dc7191",
+          "Volumes": null,
+          "WorkingDir": "",
+          "Entrypoint": null,
+          "OnBuild": null,
+          "Labels": {
+            "branch": "main",
+            "buildNumber": "1",
+            "commitId": "b48e2cf960de545597411c99ec969e47a7635ba3",
+            "jobName": "test"
+          }
+        },
+        "container": "fc1607ce29cfa58cc6cad846b911ec0c4de76d426de2b528a126e715615286bc",
+        "created": "2021-02-16T19:18:50.176616541Z",
+        "docker_version": "19.03.6-ce",
+        "os": "linux",
+        "rootfs": {}
+      }'''
     TypedInput configDigestContentInput = new TypedByteArray("application/json", configDigestContentJson.getBytes())
     Response contentDigestResponse = new Response("/v2/{repository}/blobs/{digest}",200, "nothing", Collections.EMPTY_LIST, configDigestContentInput)
     getDigestContent(_,_,_,_) >> contentDigestResponse

--- a/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClientSpec.groovy
+++ b/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClientSpec.groovy
@@ -52,6 +52,58 @@ class DockerRegistryClientSpec extends Specification {
     TypedInput catalogTypedInput = new TypedByteArray("application/json", json.getBytes())
     Response catalogResponse = new Response("/v2/_catalog/",200, "nothing", Collections.EMPTY_LIST, catalogTypedInput)
     getCatalog(_,_,_) >> catalogResponse
+
+    String schemaJson = "{\n" +
+      "   \"schemaVersion\": 2,\n" +
+      "   \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n" +
+      "   \"config\": {\n" +
+      "      \"mediaType\": \"application/vnd.docker.container.image.v1+json\",\n" +
+      "      \"size\": 4405,\n" +
+      "      \"digest\": \"sha256:fa8d22f4899110fdecf7ae344a8129fb6175ed5294ffe9ca3fb09dfca5252c93\"\n" +
+      "   },\n" +
+      "   \"layers\": [\n" +
+      "      {\n" +
+      "         \"mediaType\": \"application/vnd.docker.image.rootfs.diff.tar.gzip\",\n" +
+      "         \"size\": 3310095,\n" +
+      "         \"digest\": \"sha256:1ace22715a341b6ad81b784da18f2efbcea18ff7b4b4edf4f467f193b7de3750\"\n" +
+      "      }\n" +
+      "   ]\n" +
+      "}"
+    TypedInput schemaV2Input = new TypedByteArray("application/json", schemaJson.getBytes())
+    Response schemaV2Response = new Response("/v2/{name}/manifests/{reference}",200, "nothing", Collections.EMPTY_LIST, schemaV2Input)
+    getSchemaV2Manifest(_,_,_,_) >> schemaV2Response
+
+    String configDigestContentJson = "{ \n" +
+      "  \"architecture\": \"amd64\",\n" +
+      "  \"config\": {\n" +
+      "    \"Hostname\": \"\",\n" +
+      "    \"Env\": [\n" +
+      "      \"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"\n" +
+      "    ],\n" +
+      "    \"Cmd\": [\n" +
+      "      \"/opt/app/server\"\n" +
+      "    ],\n" +
+      "    \"Image\": \"sha256:3862e8f6f860c732be3fe0c0545330f9573a09cf906a78b06a329e09f9dc7191\",\n" +
+      "    \"Volumes\": null,\n" +
+      "    \"WorkingDir\": \"\",\n" +
+      "    \"Entrypoint\": null,\n" +
+      "    \"OnBuild\": null,\n" +
+      "    \"Labels\": {\n" +
+      "      \"branch\": \"main\",\n" +
+      "      \"buildNumber\": \"1\",\n" +
+      "      \"commitId\": \"b48e2cf960de545597411c99ec969e47a7635ba3\",\n" +
+      "      \"jobName\": \"test\"\n" +
+      "    }\n" +
+      "  },\n" +
+      "  \"container\": \"fc1607ce29cfa58cc6cad846b911ec0c4de76d426de2b528a126e715615286bc\",\n" +
+      "  \"created\": \"2021-02-16T19:18:50.176616541Z\",\n" +
+      "  \"docker_version\": \"19.03.6-ce\",\n" +
+      "  \"os\": \"linux\",\n" +
+      "  \"rootfs\": {}\n" +
+      "}"
+    TypedInput configDigestContentInput = new TypedByteArray("application/json", configDigestContentJson.getBytes())
+    Response contentDigestResponse = new Response("/v2/{repository}/blobs/{digest}",200, "nothing", Collections.EMPTY_LIST, configDigestContentInput)
+    getDigestContent(_,_,_,_) >> contentDigestResponse
   }
 
   def setupSpec() {
@@ -112,4 +164,22 @@ class DockerRegistryClientSpec extends Specification {
     filtered < original
   }
 
+  void "DockerRegistryClient should be able to fetch digest."() {
+    when:
+    client = new DockerRegistryClient("https://index.docker.io",100,"","",stubbedRegistryService, dockerBearerTokenService)
+    def result = client.getConfigDigest(REPOSITORY1, "tag")
+
+    then:
+    result == "sha256:fa8d22f4899110fdecf7ae344a8129fb6175ed5294ffe9ca3fb09dfca5252c93"
+  }
+
+  void "DockerRegistryClient should be able to fetch the config layer."() {
+    when:
+    client = new DockerRegistryClient("https://index.docker.io",100,"","",stubbedRegistryService, dockerBearerTokenService)
+    def results = client.getDigestContent(REPOSITORY1, "digest")
+
+    then:
+    results?.config?.Labels != null
+    results?.config?.Labels?.commitId == "b48e2cf960de545597411c99ec969e47a7635ba3"
+  }
 }

--- a/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupControllerSpec.groovy
+++ b/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupControllerSpec.groovy
@@ -16,13 +16,65 @@
 
 package com.netflix.spinnaker.clouddriver.docker.registry.controllers
 
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.CacheFilter
+import com.netflix.spinnaker.clouddriver.docker.registry.DockerRegistryCloudProvider
+import com.netflix.spinnaker.clouddriver.docker.registry.cache.Keys
+import com.netflix.spinnaker.clouddriver.docker.registry.security.DockerRegistryNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import spock.lang.Specification
 
 class DockerRegistryImageLookupControllerSpec extends Specification {
-  def "GenerateArtifact"() {
-    setup:
-    DockerRegistryImageLookupController dockerRegistryImageLookupController = new DockerRegistryImageLookupController();
+  DockerRegistryImageLookupController dockerRegistryImageLookupController
 
+  Set<CacheData> resultData = [
+    new CacheData(){
+      @Override
+      String getId() { Keys.getTaggedImageKey("test-account", "test-repo", "1.0") }
+
+      @Override
+      int getTtlSeconds() { return 0 }
+
+      @Override
+      Map<String, Collection<String>> getRelationships() { return null }
+
+      @Override
+      Map<String, Object> getAttributes() {
+        return [
+          "account": "test-account",
+          "digest": "test-digest",
+          "labels": [
+            "commitId":    "test-commit",
+            "buildNumber": "1",
+            "branch":      "test-branch",
+            "jobName":     "test-job"
+          ]
+        ]
+      }
+    }
+  ]
+
+  def accountCredentials = Stub(DockerRegistryNamedAccountCredentials) {
+    getCloudProvider() >> DockerRegistryCloudProvider.DOCKER_REGISTRY
+    getTrackDigests() >> true
+    getRegistry() >> "test-registry"
+  }
+
+  def setup() {
+    dockerRegistryImageLookupController = new DockerRegistryImageLookupController(
+      accountCredentialsProvider: Stub(AccountCredentialsProvider){
+        getAll() >> [accountCredentials]
+        getCredentials(*_) >> accountCredentials
+      },
+      cacheView: Stub(Cache) {
+        filterIdentifiers(_,_) >> ["someID"]
+        getAll(*_) >> resultData
+      }
+    )
+  }
+
+  def "GenerateArtifact"() {
     when:
     def result = dockerRegistryImageLookupController.generateArtifact("foo.registry", "my/app", "mytag")
 
@@ -32,5 +84,79 @@ class DockerRegistryImageLookupControllerSpec extends Specification {
     result.reference         == "foo.registry/my/app:mytag"
     result.type              == "docker"
     result.metadata.registry == "foo.registry"
+  }
+
+  void "When finding images with includeDetails == false"() {
+    when:
+    def result = dockerRegistryImageLookupController.find(new DockerRegistryImageLookupController.LookupOptions(includeDetails: false))
+
+    then:
+    result.size() == 1
+    result[0].account       == "test-account"
+    result[0].digest        == "test-digest"
+    result[0].commitId      == null
+    result[0].buildNumber   == null
+    result[0].artifact.type == "docker"
+    result[0].artifact.metadata.registry == "test-registry"
+  }
+
+  void "When finding images with includeDetails == true"() {
+    when:
+    def result = dockerRegistryImageLookupController.find(new DockerRegistryImageLookupController.LookupOptions(includeDetails: true))
+
+    then:
+    result.size() == 1
+    result[0].account       == "test-account"
+    result[0].digest        == "test-digest"
+    result[0].commitId      == "test-commit"
+    result[0].branch        == "test-branch"
+    result[0].buildNumber   == "1"
+    result[0].artifact.type == "docker"
+    result[0].artifact.metadata.registry == "test-registry"
+    result[0].artifact.metadata.labels != null
+    result[0].artifact.metadata.labels.jobName == "test-job"
+  }
+
+  void "When finding images with no metadata and includeDetails == true"() {
+    setup:
+    def noLabelResultData = [
+      new CacheData(){
+        @Override
+        String getId() { Keys.getTaggedImageKey("test-account", "test-repo", "1.0") }
+
+        @Override
+        int getTtlSeconds() { return 0 }
+
+        @Override
+        Map<String, Collection<String>> getRelationships() { return null }
+
+        @Override
+        Map<String, Object> getAttributes() { return ["account": "test-account", "digest": "test-digest"] }
+      }
+    ]
+
+    dockerRegistryImageLookupController = new DockerRegistryImageLookupController(
+      accountCredentialsProvider: Stub(AccountCredentialsProvider){
+        getAll() >> [accountCredentials]
+        getCredentials(*_) >> accountCredentials
+      },
+      cacheView: Stub(Cache) {
+        filterIdentifiers(_,_) >> ["someID"]
+        getAll(*_) >> noLabelResultData
+      }
+    )
+
+    when:
+    def result = dockerRegistryImageLookupController.find(new DockerRegistryImageLookupController.LookupOptions(includeDetails: true))
+
+    then:
+    result.size() == 1
+    result[0].account       == "test-account"
+    result[0].digest        == "test-digest"
+    result[0].commitId      == null
+    result[0].buildNumber   == null
+    result[0].artifact.type == "docker"
+    result[0].artifact.metadata.registry == "test-registry"
+    result[0].artifact.metadata.labels == null
   }
 }


### PR DESCRIPTION
- inspectDigest config flag allows the docker agent to fetch the config layer for a manifest with V2Schema
- looks under `config.Labels` for extra information regarding `buildNumber`, `commitId`, `branch`, and `jobName` that results in creating a docker artifact
- when the `/find` endpoint from the DockerController is called with `includeDetails=true` parameters, includes `commitId`, `buildNumbe`r and other metadata related to the created artifact in the response
