### PR TITLE
fix(aws): Copy IPv6 assignment in CopyLastAsgAtomicOperation

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -178,6 +178,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
             def networkInterface = launchTemplateData.networkInterfaces.find({it.deviceIndex == 0 })
             if (networkInterface != null) {
               securityGroups = networkInterface.groups
+              newDescription.associateIPv6Address = networkInterface.getIpv6AddressCount() > 0 ? true : false
             }
           }
 


### PR DESCRIPTION
A `cloneServerGroup` does not explicitly set `associateIPv6Address`. This PR sets `associateIPv6Address` based on the network interface of the source server group.
