### PR TITLE
fix(aws/ALB): Check emptiness to distinguish ALB/ELB

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/DeregisterInstancesFromLoadBalancerAtomicOperationConverter.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/DeregisterInstancesFromLoadBalancerAtomicOperationConverter.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.ops.DeregisterInstancesFromT
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -33,7 +34,8 @@ import org.springframework.stereotype.Component;
 public class DeregisterInstancesFromLoadBalancerAtomicOperationConverter
     extends AbstractAtomicOperationsCredentialsSupport {
   private Boolean isClassic(Map input) {
-    return !input.containsKey("targetGroupNames");
+    return !input.containsKey("targetGroupNames")
+        || getObjectMapper().convertValue(input.get("targetGroupNames"), List.class).isEmpty();
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/RegisterInstancesWithLoadBalancerAtomicOperationConverter.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/RegisterInstancesWithLoadBalancerAtomicOperationConverter.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.ops.RegisterInstancesWithTar
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -33,7 +34,8 @@ import org.springframework.stereotype.Component;
 class RegisterInstancesWithLoadBalancerAtomicOperationConverter
     extends AbstractAtomicOperationsCredentialsSupport {
   private Boolean isClassic(Map input) {
-    return !input.containsKey("targetGroupNames");
+    return !input.containsKey("targetGroupNames")
+        || getObjectMapper().convertValue(input.get("targetGroupNames"), List.class).isEmpty();
   }
 
   @Override


### PR DESCRIPTION
Previously only the `existence` of a `targetGroupNames` is check to determine ALB/ELB. With this MR, it's adding extra checks on the value. It checks whether the value is empty or not

Fixes https://github.com/spinnaker/spinnaker/issues/6352