### PR TITLE
fix(artifacts/helm): look up artifact credentials by supported type

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactController.java
@@ -69,7 +69,7 @@ public class ArtifactController {
   List<String> getNames(
       @PathVariable("accountName") String accountName, @RequestParam(value = "type") String type) {
     ArtifactCredentials credentials =
-        artifactCredentialsRepository.getCredentials(accountName, type);
+        artifactCredentialsRepository.getCredentialsForType(accountName, type);
     return credentials.getArtifactNames();
   }
 
@@ -79,7 +79,7 @@ public class ArtifactController {
       @RequestParam(value = "type") String type,
       @RequestParam(value = "artifactName") String artifactName) {
     ArtifactCredentials credentials =
-        artifactCredentialsRepository.getCredentials(accountName, type);
+        artifactCredentialsRepository.getCredentialsForType(accountName, type);
     return credentials.getArtifactVersions(artifactName);
   }
 }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactController.java
@@ -21,12 +21,14 @@ import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository
 import com.netflix.spinnaker.clouddriver.artifacts.ArtifactDownloader;
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.exceptions.MissingCredentialsException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
@@ -67,19 +69,24 @@ public class ArtifactController {
 
   @RequestMapping(method = RequestMethod.GET, value = "/account/{accountName}/names")
   List<String> getNames(
-      @PathVariable("accountName") String accountName, @RequestParam(value = "type") String type) {
+      @PathVariable("accountName") String accountName,
+      @RequestParam(value = "type") String artifactType) {
     ArtifactCredentials credentials =
-        artifactCredentialsRepository.getCredentialsForType(accountName, type);
+        artifactCredentialsRepository.getCredentialsForType(accountName, artifactType);
     return credentials.getArtifactNames();
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/account/{accountName}/versions")
   List<String> getVersions(
       @PathVariable("accountName") String accountName,
-      @RequestParam(value = "type") String type,
+      @RequestParam(value = "type") String artifactType,
       @RequestParam(value = "artifactName") String artifactName) {
     ArtifactCredentials credentials =
-        artifactCredentialsRepository.getCredentialsForType(accountName, type);
+        artifactCredentialsRepository.getCredentialsForType(accountName, artifactType);
     return credentials.getArtifactVersions(artifactName);
   }
+
+  @ExceptionHandler(MissingCredentialsException.class)
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  public void handleMissingCredentials() {}
 }

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactControllerSpec.java
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactControllerSpec.java
@@ -136,8 +136,9 @@ public class ArtifactControllerSpec {
 
     // We also don't expect to find an account that can support type artifacts-helm
     mvc.perform(
-            get("/artifacts/account/{accountName}/names", credentials.getName())
-                .param("type", HelmArtifactCredentials.CREDENTIALS_TYPE))
+            get("/artifacts/account/{accountName}/versions", credentials.getName())
+                .param("type", HelmArtifactCredentials.CREDENTIALS_TYPE)
+                .param("artifactName", artifactName))
         .andExpect(status().isNotFound());
   }
 }

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactControllerSpec.java
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactControllerSpec.java
@@ -19,18 +19,25 @@ package com.netflix.spinnaker.clouddriver.controllers;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.Main;
+import com.netflix.spinnaker.clouddriver.artifacts.helm.HelmArtifactCredentials;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.util.List;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -48,7 +55,8 @@ import org.springframework.web.context.WebApplicationContext;
     properties = {
       "redis.enabled = false",
       "sql.enabled = false",
-      "spring.application.name = clouddriver"
+      "spring.application.name = clouddriver",
+      "artifacts.helm.enabled = true"
     })
 public class ArtifactControllerSpec {
 
@@ -57,6 +65,8 @@ public class ArtifactControllerSpec {
   @Autowired private WebApplicationContext webApplicationContext;
 
   @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private CredentialsRepository<HelmArtifactCredentials> helmCredentials;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -77,5 +87,57 @@ public class ArtifactControllerSpec {
         .andDo(print())
         .andExpect(status().isBadRequest())
         .andExpect(content().string(is(emptyString())));
+  }
+
+  @Test
+  public void testArtifactNames() throws Exception {
+    List<String> names = ImmutableList.of("artifact1", "artifact2");
+    HelmArtifactCredentials credentials = Mockito.mock(HelmArtifactCredentials.class);
+    Mockito.when(credentials.getName()).thenReturn("my-account");
+    Mockito.when(credentials.getType()).thenReturn(HelmArtifactCredentials.CREDENTIALS_TYPE);
+    Mockito.when(credentials.handlesType("helm/chart")).thenReturn(true);
+    Mockito.when(credentials.getArtifactNames()).thenReturn(names);
+    helmCredentials.save(credentials);
+
+    mvc.perform(
+            get("/artifacts/account/{accountName}/names", credentials.getName())
+                .param("type", "helm/chart"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", Matchers.hasSize(2)))
+        .andExpect(jsonPath("$[0]", Matchers.is(names.get(0))))
+        .andExpect(jsonPath("$[1]", Matchers.is(names.get(1))));
+
+    // We also don't expect to find an account that can support type artifacts-helm
+    mvc.perform(
+            get("/artifacts/account/{accountName}/names", credentials.getName())
+                .param("type", HelmArtifactCredentials.CREDENTIALS_TYPE))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  public void testArtifactVersions() throws Exception {
+    final String artifactName = "my-artifact";
+    List<String> versions = ImmutableList.of("version1", "version2");
+    HelmArtifactCredentials credentials = Mockito.mock(HelmArtifactCredentials.class);
+    Mockito.when(credentials.getName()).thenReturn("my-account");
+    Mockito.when(credentials.getType()).thenReturn(HelmArtifactCredentials.CREDENTIALS_TYPE);
+    Mockito.when(credentials.handlesType("helm/chart")).thenReturn(true);
+    Mockito.when(credentials.getArtifactVersions(artifactName)).thenReturn(versions);
+    helmCredentials.save(credentials);
+
+    mvc.perform(
+            get("/artifacts/account/{accountName}/versions", credentials.getName())
+                .param("type", "helm/chart")
+                .param("artifactName", artifactName))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", Matchers.hasSize(2)))
+        .andExpect(jsonPath("$[0]", Matchers.is(versions.get(0))))
+        .andExpect(jsonPath("$[1]", Matchers.is(versions.get(1))));
+
+    // We also don't expect to find an account that can support type artifacts-helm
+    mvc.perform(
+            get("/artifacts/account/{accountName}/names", credentials.getName())
+                .param("type", HelmArtifactCredentials.CREDENTIALS_TYPE))
+        .andExpect(status().isNotFound());
   }
 }


### PR DESCRIPTION
There are 2 types for artifacts: the type of artifacts credentials (e.g. github, gitlab, helm) and the type of artifacts (helm/chart, git/repo). The two endpoints in `ArtifactController` are called from Deck - just for helm artifacts - and pass an artifact type.

This should fix https://github.com/spinnaker/spinnaker/issues/6349.