### PR TITLE
feat(kubernetes): Breaking, Update API versions

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -78,7 +78,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-exceptions"
   implementation "io.spinnaker.kork:kork-moniker"
   implementation "io.spinnaker.kork:kork-secrets"
-  implementation "io.kubernetes:client-java:7.0.0"
+  implementation "io.kubernetes:client-java:11.0.1"
   implementation "org.apache.commons:commons-lang3"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesApiVersion.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesApiVersion.java
@@ -34,8 +34,6 @@ public class KubernetesApiVersion {
   public static final KubernetesApiVersion NETWORKING_K8S_IO_V1BETA1 =
       new KubernetesApiVersion("networking.k8s.io/v1beta1");
   public static final KubernetesApiVersion APPS_V1 = new KubernetesApiVersion("apps/v1");
-  public static final KubernetesApiVersion APPS_V1BETA1 = new KubernetesApiVersion("apps/v1beta1");
-  public static final KubernetesApiVersion APPS_V1BETA2 = new KubernetesApiVersion("apps/v1beta2");
   public static final KubernetesApiVersion BATCH_V1 = new KubernetesApiVersion("batch/v1");
   public static final KubernetesApiVersion NONE = new KubernetesApiVersion("");
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesDaemonSetHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesDaemonSetHandler.java
@@ -17,15 +17,18 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.op.handler;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiVersion.APPS_V1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_CONTROLLER_PRIORITY;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.clouddriver.kubernetes.artifact.Replacer;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.InfrastructureCacheKey;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgentFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCoreCachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest.Status;
@@ -46,6 +49,9 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler
         CanUndoRollout,
         CanRollingRestart,
         ServerGroupHandler {
+
+  private static final ImmutableSet<KubernetesApiVersion> SUPPORTED_API_VERSIONS =
+      ImmutableSet.of(APPS_V1);
 
   @Nonnull
   @Override
@@ -91,6 +97,9 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler
 
   @Override
   public Status status(KubernetesManifest manifest) {
+    if (!SUPPORTED_API_VERSIONS.contains(manifest.getApiVersion())) {
+      throw new UnsupportedVersionException(manifest);
+    }
     V1DaemonSet v1DaemonSet = KubernetesCacheDataConverter.getResource(manifest, V1DaemonSet.class);
     return status(v1DaemonSet);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesDaemonSetHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesDaemonSetHandler.java
@@ -29,9 +29,9 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest.Status;
+import io.kubernetes.client.openapi.models.V1DaemonSet;
+import io.kubernetes.client.openapi.models.V1DaemonSetStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1beta2DaemonSet;
-import io.kubernetes.client.openapi.models.V1beta2DaemonSetStatus;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -91,9 +91,8 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    V1beta2DaemonSet v1beta2DaemonSet =
-        KubernetesCacheDataConverter.getResource(manifest, V1beta2DaemonSet.class);
-    return status(v1beta2DaemonSet);
+    V1DaemonSet v1DaemonSet = KubernetesCacheDataConverter.getResource(manifest, V1DaemonSet.class);
+    return status(v1DaemonSet);
   }
 
   @Override
@@ -104,8 +103,8 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler
     return result;
   }
 
-  private Status status(V1beta2DaemonSet daemonSet) {
-    V1beta2DaemonSetStatus status = daemonSet.getStatus();
+  private Status status(V1DaemonSet daemonSet) {
+    V1DaemonSetStatus status = daemonSet.getStatus();
     if (status == null) {
       return Status.noneReported();
     }
@@ -148,7 +147,7 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler
     return Status.defaultStatus();
   }
 
-  private boolean generationMatches(V1beta2DaemonSet daemonSet, V1beta2DaemonSetStatus status) {
+  private boolean generationMatches(V1DaemonSet daemonSet, V1DaemonSetStatus status) {
     Optional<Long> metadataGeneration =
         Optional.ofNullable(daemonSet.getMetadata()).map(V1ObjectMeta::getGeneration);
     Optional<Long> statusGeneration = Optional.ofNullable(status.getObservedGeneration());

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesDeploymentHandler.java
@@ -18,9 +18,6 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.op.handler;
 
 import static com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiVersion.APPS_V1;
-import static com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiVersion.APPS_V1BETA1;
-import static com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiVersion.APPS_V1BETA2;
-import static com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiVersion.EXTENSIONS_V1BETA1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_CONTROLLER_PRIORITY;
 
 import com.google.common.collect.ImmutableList;
@@ -57,7 +54,7 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
         ServerGroupManagerHandler {
 
   private static final ImmutableSet<KubernetesApiVersion> SUPPORTED_API_VERSIONS =
-      ImmutableSet.of(EXTENSIONS_V1BETA1, APPS_V1BETA1, APPS_V1BETA2, APPS_V1);
+      ImmutableSet.of(APPS_V1);
 
   @Override
   protected ImmutableList<Replacer> artifactReplacers() {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesEventHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesEventHandler.java
@@ -30,7 +30,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest.Status;
-import io.kubernetes.client.openapi.models.V1Event;
+import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.openapi.models.V1ObjectReference;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -86,13 +86,13 @@ public class KubernetesEventHandler extends KubernetesHandler {
                     ImmutablePair.of(
                         m,
                         involvedManifest(
-                            KubernetesCacheDataConverter.getResource(m, V1Event.class))))
+                            KubernetesCacheDataConverter.getResource(m, CoreV1Event.class))))
             .filter(p -> p.getRight() != null)
             .collect(
                 Collectors.toMap(ImmutablePair::getLeft, p -> ImmutableList.of(p.getRight()))));
   }
 
-  private KubernetesManifest involvedManifest(V1Event event) {
+  private KubernetesManifest involvedManifest(CoreV1Event event) {
     if (event == null) {
       return null;
     }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesReplicaSetHandler.java
@@ -18,8 +18,6 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.op.handler;
 
 import static com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiVersion.APPS_V1;
-import static com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiVersion.APPS_V1BETA2;
-import static com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiVersion.EXTENSIONS_V1BETA1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_CONTROLLER_PRIORITY;
 
 import com.google.common.collect.ImmutableList;
@@ -41,8 +39,6 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ReplicaSet;
 import io.kubernetes.client.openapi.models.V1ReplicaSetSpec;
 import io.kubernetes.client.openapi.models.V1ReplicaSetStatus;
-import io.kubernetes.client.openapi.models.V1beta1ReplicaSet;
-import io.kubernetes.client.openapi.models.V1beta2ReplicaSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,7 +51,7 @@ import org.springframework.stereotype.Component;
 public class KubernetesReplicaSetHandler extends KubernetesHandler
     implements CanResize, CanScale, HasPods, ServerGroupHandler {
   private static final ImmutableSet<KubernetesApiVersion> SUPPORTED_API_VERSIONS =
-      ImmutableSet.of(EXTENSIONS_V1BETA1, APPS_V1BETA2, APPS_V1);
+      ImmutableSet.of(APPS_V1);
 
   @Override
   protected ImmutableList<Replacer> artifactReplacers() {
@@ -163,29 +159,13 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
   }
 
   public static Map<String, String> getPodTemplateLabels(KubernetesManifest manifest) {
-    if (manifest.getApiVersion().equals(EXTENSIONS_V1BETA1)) {
-      V1beta1ReplicaSet v1beta1ReplicaSet =
-          KubernetesCacheDataConverter.getResource(manifest, V1beta1ReplicaSet.class);
-      return getPodTemplateLabels(v1beta1ReplicaSet);
-    } else if (manifest.getApiVersion().equals(APPS_V1BETA2)) {
-      V1beta2ReplicaSet v1beta2ReplicaSet =
-          KubernetesCacheDataConverter.getResource(manifest, V1beta2ReplicaSet.class);
-      return getPodTemplateLabels(v1beta2ReplicaSet);
-    } else if (manifest.getApiVersion().equals(APPS_V1)) {
+    if (manifest.getApiVersion().equals(APPS_V1)) {
       V1ReplicaSet v1ReplicaSet =
           KubernetesCacheDataConverter.getResource(manifest, V1ReplicaSet.class);
       return getPodTemplateLabels(v1ReplicaSet);
     } else {
       throw new UnsupportedVersionException(manifest);
     }
-  }
-
-  private static Map<String, String> getPodTemplateLabels(V1beta1ReplicaSet replicaSet) {
-    return replicaSet.getSpec().getTemplate().getMetadata().getLabels();
-  }
-
-  private static Map<String, String> getPodTemplateLabels(V1beta2ReplicaSet replicaSet) {
-    return replicaSet.getSpec().getTemplate().getMetadata().getLabels();
   }
 
   private static Map<String, String> getPodTemplateLabels(V1ReplicaSet replicaSet) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesStatefulSetHandler.java
@@ -31,9 +31,9 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest.Status;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1beta2RollingUpdateStatefulSetStrategy;
-import io.kubernetes.client.openapi.models.V1beta2StatefulSet;
-import io.kubernetes.client.openapi.models.V1beta2StatefulSetStatus;
+import io.kubernetes.client.openapi.models.V1RollingUpdateStatefulSetStrategy;
+import io.kubernetes.client.openapi.models.V1StatefulSet;
+import io.kubernetes.client.openapi.models.V1StatefulSetStatus;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -97,9 +97,9 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    V1beta2StatefulSet v1beta2StatefulSet =
-        KubernetesCacheDataConverter.getResource(manifest, V1beta2StatefulSet.class);
-    return status(v1beta2StatefulSet);
+    V1StatefulSet v1StatefulSet =
+        KubernetesCacheDataConverter.getResource(manifest, V1StatefulSet.class);
+    return status(v1StatefulSet);
   }
 
   public static String serviceName(KubernetesManifest manifest) {
@@ -116,12 +116,12 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
     return result;
   }
 
-  private Status status(V1beta2StatefulSet statefulSet) {
+  private Status status(V1StatefulSet statefulSet) {
     if (statefulSet.getSpec().getUpdateStrategy().getType().equalsIgnoreCase("ondelete")) {
       return Status.defaultStatus();
     }
 
-    V1beta2StatefulSetStatus status = statefulSet.getStatus();
+    V1StatefulSetStatus status = statefulSet.getStatus();
     if (status == null) {
       return Status.noneReported();
     }
@@ -143,7 +143,7 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
     }
 
     String updateType = statefulSet.getSpec().getUpdateStrategy().getType();
-    V1beta2RollingUpdateStatefulSetStrategy rollingUpdate =
+    V1RollingUpdateStatefulSetStrategy rollingUpdate =
         statefulSet.getSpec().getUpdateStrategy().getRollingUpdate();
 
     Integer updated = status.getUpdatedReplicas();
@@ -170,8 +170,7 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
     return Status.defaultStatus();
   }
 
-  private boolean generationMatches(
-      V1beta2StatefulSet statefulSet, V1beta2StatefulSetStatus status) {
+  private boolean generationMatches(V1StatefulSet statefulSet, V1StatefulSetStatus status) {
     Optional<Long> metadataGeneration =
         Optional.ofNullable(statefulSet.getMetadata()).map(V1ObjectMeta::getGeneration);
     Optional<Long> statusGeneration = Optional.ofNullable(status.getObservedGeneration());

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.apache.commons.lang.WordUtils;
+import org.apache.commons.text.WordUtils;
 
 @ParametersAreNonnullByDefault
 public abstract class AbstractKubernetesEnableDisableManifestOperation

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.Getter;
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KeysSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KeysSpec.groovy
@@ -57,9 +57,9 @@ class KeysSpec extends Specification {
 
     where:
     kind                       | apiVersion                              | account | namespace   | name      || key
-    KubernetesKind.REPLICA_SET | KubernetesApiVersion.EXTENSIONS_V1BETA1 | "ac"    | "namespace" | "v1-v000" || "kubernetes.v2:infrastructure:replicaSet:ac:namespace:v1-v000"
+    KubernetesKind.REPLICA_SET | KubernetesApiVersion.APPS_V1            | "ac"    | "namespace" | "v1-v000" || "kubernetes.v2:infrastructure:replicaSet:ac:namespace:v1-v000"
     KubernetesKind.SERVICE     | KubernetesApiVersion.V1                 | "ac"    | "namespace" | "v1"      || "kubernetes.v2:infrastructure:service:ac:namespace:v1"
-    KubernetesKind.DEPLOYMENT  | KubernetesApiVersion.APPS_V1BETA1       | "ac"    | "namespace" | "v1"      || "kubernetes.v2:infrastructure:deployment:ac:namespace:v1"
+    KubernetesKind.DEPLOYMENT  | KubernetesApiVersion.APPS_V1            | "ac"    | "namespace" | "v1"      || "kubernetes.v2:infrastructure:deployment:ac:namespace:v1"
   }
 
   @Unroll
@@ -115,11 +115,12 @@ class KeysSpec extends Specification {
     parsedInfrastructureKey.name == name
 
     where:
-    kind                       | version                                 | account   | namespace   | name
-    KubernetesKind.DEPLOYMENT  | KubernetesApiVersion.APPS_V1BETA1       | "ac"      | "name"      | "nameer"
-    KubernetesKind.REPLICA_SET | KubernetesApiVersion.EXTENSIONS_V1BETA1 | ""        | ""          | ""
-    KubernetesKind.SERVICE     | KubernetesApiVersion.V1                 | "account" | "namespace" | ""
-    KubernetesKind.INGRESS     | KubernetesApiVersion.EXTENSIONS_V1BETA1 | "ac"      | ""          | "nameer"
+    kind                       | version                                   | account   | namespace   | name
+    KubernetesKind.DEPLOYMENT  | KubernetesApiVersion.APPS_V1              | "ac"      | "name"      | "nameer"
+    KubernetesKind.REPLICA_SET | KubernetesApiVersion.APPS_V1              | ""        | ""          | ""
+    KubernetesKind.SERVICE     | KubernetesApiVersion.V1                   | "account" | "namespace" | ""
+    KubernetesKind.INGRESS     | KubernetesApiVersion.EXTENSIONS_V1BETA1   | "ac"      | ""          | "nameer"
+    KubernetesKind.INGRESS     | KubernetesApiVersion.NETWORKING_K8S_IO_V1 | "ac"      | ""          | "nameer"
   }
 
   def "correctly unpacks resource names containing a ';' character"() {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesApiVersionSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesApiVersionSpec.groovy
@@ -69,6 +69,6 @@ class KubernetesApiVersionSpec extends Specification {
     ""                       | KubernetesApiGroup.NONE
     "test.api.group"         | KubernetesApiGroup.NONE
     "test.api.group/version" | KubernetesApiGroup.fromString("test.api.group")
-    "apps/v1beta1"           | KubernetesApiGroup.APPS
+    "apps/v1"                | KubernetesApiGroup.APPS
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesDeploymentHandlerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesDeploymentHandlerSpec.groovy
@@ -39,7 +39,7 @@ class KubernetesDeploymentHandlerSpec extends Specification {
   def ACCOUNT = "my-account"
 
   def BASIC_DEPLOYMENT = """
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/daemonset/base-on-delete.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/daemonset/base-on-delete.yml
@@ -1,5 +1,5 @@
 # Base daemonset with update strategy set to OnDelete
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   generation: 2

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/daemonset/base.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/daemonset/base.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   generation: 2

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/deployment/base-no-replicas.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/deployment/base-no-replicas.yml
@@ -1,5 +1,5 @@
 # Deployment with spec of 0 replicas
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   generation: 3

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/deployment/base.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/deployment/base.yml
@@ -1,5 +1,5 @@
 # Base deployment spec
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   generation: 3

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/replicaset/base-no-replicas.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/replicaset/base-no-replicas.yml
@@ -1,5 +1,5 @@
 # Base replicaset with no desired replicas
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   creationTimestamp: "2020-01-30T16:34:22Z"

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/replicaset/base.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/replicaset/base.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   creationTimestamp: "2020-01-30T16:34:22Z"


### PR DESCRIPTION
This change makes Spinnaker incompatible with Kubernetes prior to 1.14.

The reason for this change is to enable the now General Available
Ingress API. This was added in Kubernetes 1.19. To make this change the
client library had to be updated. Since 1.16 removed a bunch of APIs
that change now affects us, and a few of the old APIs got removed.

As far as I can tell the oldest supported version of Kubernetes is now
1.14. It was released in 2019, almost two years ago to date. It's been
End of Life since December 2019.

BREAKING CHANGE: This breaks Kubernetes prior to 1.14.
