### PR TITLE
feat(cfn): prefer templateURL over templateBody if provided

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitJobExecutor.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitJobExecutor.java
@@ -114,8 +114,15 @@ public class GitJobExecutor {
       throws IOException {
 
     List<String> command =
-        Arrays.asList(
-            gitExecutable, "archive", "--format", "tgz", "--output", outputFile.toString(), branch);
+        new ArrayList<>(
+            Arrays.asList(
+                gitExecutable,
+                "archive",
+                "--format",
+                "tgz",
+                "--output",
+                outputFile.toString(),
+                branch));
     if (!StringUtils.isEmpty(subDir)) {
       command.add(subDir);
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeployCloudFormationDescription.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeployCloudFormationDescription.java
@@ -29,6 +29,7 @@ public class DeployCloudFormationDescription extends AbstractAmazonCredentialsDe
 
   private String stackName;
   private String templateBody;
+  private String templateURL;
   private String roleARN;
   private Map<String, String> parameters = new HashMap<>();
   private Map<String, String> tags = new HashMap<>();

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeployCloudFormationAtomicOperation.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeployCloudFormationAtomicOperation.java
@@ -60,8 +60,9 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
     AmazonCloudFormation amazonCloudFormation =
         amazonClientProvider.getAmazonCloudFormation(
             description.getCredentials(), description.getRegion());
-    String template = description.getTemplateBody();
-    validateTemplate(amazonCloudFormation, template);
+    String templateURL = description.getTemplateURL();
+    String templateBody = description.getTemplateBody();
+    validateTemplate(amazonCloudFormation, templateURL, templateBody);
     String roleARN = description.getRoleARN();
     List<Parameter> parameters =
         description.getParameters().entrySet().stream()
@@ -85,7 +86,8 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
       stackId =
           createChangeSet(
               amazonCloudFormation,
-              template,
+              templateURL,
+              templateBody,
               roleARN,
               parameters,
               tags,
@@ -97,7 +99,8 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
         stackId =
             updateStack(
                 amazonCloudFormation,
-                template,
+                templateURL,
+                templateBody,
                 roleARN,
                 parameters,
                 tags,
@@ -107,7 +110,8 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
         stackId =
             createStack(
                 amazonCloudFormation,
-                template,
+                templateURL,
+                templateBody,
                 roleARN,
                 parameters,
                 tags,
@@ -119,7 +123,8 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
 
   private String createStack(
       AmazonCloudFormation amazonCloudFormation,
-      String template,
+      String templateURL,
+      String templateBody,
       String roleARN,
       List<Parameter> parameters,
       List<Tag> tags,
@@ -131,8 +136,14 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
             .withStackName(description.getStackName())
             .withParameters(parameters)
             .withTags(tags)
-            .withTemplateBody(template)
             .withCapabilities(capabilities);
+
+    if (StringUtils.hasText(templateURL)) {
+      createStackRequest.setTemplateURL(templateURL);
+    } else {
+      createStackRequest.setTemplateBody(templateBody);
+    }
+
     if (StringUtils.hasText(roleARN)) {
       createStackRequest.setRoleARN(roleARN);
     }
@@ -143,7 +154,8 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
 
   private String updateStack(
       AmazonCloudFormation amazonCloudFormation,
-      String template,
+      String templateURL,
+      String templateBody,
       String roleARN,
       List<Parameter> parameters,
       List<Tag> tags,
@@ -155,8 +167,14 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
             .withStackName(description.getStackName())
             .withParameters(parameters)
             .withTags(tags)
-            .withTemplateBody(template)
             .withCapabilities(capabilities);
+
+    if (StringUtils.hasText(templateURL)) {
+      updateStackRequest.setTemplateURL(templateURL);
+    } else {
+      updateStackRequest.setTemplateBody(templateBody);
+    }
+
     if (StringUtils.hasText(roleARN)) {
       updateStackRequest.setRoleARN(roleARN);
     }
@@ -177,7 +195,8 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
 
   private String createChangeSet(
       AmazonCloudFormation amazonCloudFormation,
-      String template,
+      String templateURL,
+      String templateBody,
       String roleARN,
       List<Parameter> parameters,
       List<Tag> tags,
@@ -191,14 +210,21 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
             .withChangeSetName(description.getChangeSetName())
             .withParameters(parameters)
             .withTags(tags)
-            .withTemplateBody(template)
             .withCapabilities(capabilities)
             .withChangeSetType(changeSetType)
             .withIncludeNestedStacks(
                 awsConfigurationProperties.getCloudformation().getChangeSetsIncludeNestedStacks());
+
+    if (StringUtils.hasText(templateURL)) {
+      createChangeSetRequest.setTemplateURL(templateURL);
+    } else {
+      createChangeSetRequest.setTemplateBody(templateBody);
+    }
+
     if (StringUtils.hasText(roleARN)) {
       createChangeSetRequest.setRoleARN(roleARN);
     }
+
     task.updateStatus(BASE_PHASE, "Uploading CloudFormation ChangeSet");
     try {
       CreateChangeSetResult createChangeSetResult =
@@ -232,10 +258,19 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
         .getStackId();
   }
 
-  private void validateTemplate(AmazonCloudFormation amazonCloudFormation, String template) {
+  private void validateTemplate(AmazonCloudFormation amazonCloudFormation,
+    String templateURL,
+    String templateBody) {
     try {
-      amazonCloudFormation.validateTemplate(
-          new ValidateTemplateRequest().withTemplateBody(template));
+      ValidateTemplateRequest validateTemplateRequest = new ValidateTemplateRequest();
+
+      if (StringUtils.hasText(templateURL)) {
+        validateTemplateRequest.setTemplateURL(templateURL);
+      } else {
+        validateTemplateRequest.setTemplateBody(templateBody);
+      }
+
+      amazonCloudFormation.validateTemplate(validateTemplateRequest);
     } catch (AmazonCloudFormationException e) {
       log.error("Error validating cloudformation template", e);
       throw e;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Routes.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Routes.java
@@ -49,7 +49,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Routes {
   private static final Pattern VALID_ROUTE_REGEX =
-      Pattern.compile("^([a-zA-Z0-9_-]+)\\.([a-zA-Z0-9_.-]+)(:[0-9]+)?([/a-zA-Z0-9_-]+)?$");
+      Pattern.compile("^([a-zA-Z0-9_-]+)\\.([a-zA-Z0-9_.-]+)(:[0-9]+)?([/a-zA-Z0-9_.-]+)?$");
 
   private final String account;
   private final RouteService api;

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/RoutesTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/RoutesTest.java
@@ -60,11 +60,11 @@ class RoutesTest {
 
     Routes routes =
         new Routes("pws", routeService, null, domains, spaces, 500, ForkJoinPool.commonPool());
-    RouteId routeId = routes.toRouteId("demo1-prod.apps.calabasas.cf-app.com/path");
+    RouteId routeId = routes.toRouteId("demo1-prod.apps.calabasas.cf-app.com/path/v1.0");
     assertThat(routeId).isNotNull();
     assertThat(routeId.getHost()).isEqualTo("demo1-prod");
     assertThat(routeId.getDomainGuid()).isEqualTo("domainGuid");
-    assertThat(routeId.getPath()).isEqualTo("/path");
+    assertThat(routeId.getPath()).isEqualTo("/path/v1.0");
   }
 
   @Test


### PR DESCRIPTION
The `templateBody` field has a size limit of 51200 bytes; larger CFN templates need to be hosted in S3. This PR updates the CloudFormation deploy task to use `templateURL` if provided in the task input.

There will be a subsequent PR on orca to send `templateURL` if the given template artifact has a reference starting with `s3://`.
