### PR TITLE
feat(cfn): prefer templateURL over templateBody if provided

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeployCloudFormationDescription.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeployCloudFormationDescription.java
@@ -29,6 +29,7 @@ public class DeployCloudFormationDescription extends AbstractAmazonCredentialsDe
 
   private String stackName;
   private String templateBody;
+  private String templateURL;
   private String roleARN;
   private Map<String, String> parameters = new HashMap<>();
   private Map<String, String> tags = new HashMap<>();


### PR DESCRIPTION
The `templateBody` field has a size limit of 51200 bytes; larger CFN templates need to be hosted in S3. This PR updates the CloudFormation deploy task to use `templateURL` if provided in the task input.

There will be a subsequent PR on orca to send `templateURL` if the given template artifact has a reference starting with `s3://`.

Corresponding PR: https://github.com/spinnaker/orca/pull/4079