### PR TITLE
Adding integration tests for AWS EC2 provider

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -46,3 +46,5 @@ jobs:
       run: ./gradlew --build-cache :clouddriver-ecs:integrationTest
     - name: Artifacts Integration Tests
       run: ./gradlew --build-cache :clouddriver-artifacts:integrationTest
+    - name: AWS EC2 Provider Integration Tests
+      run: ./gradlew --build-cache :clouddriver-aws:integrationTest

--- a/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver-aws/clouddriver-aws.gradle
@@ -1,3 +1,20 @@
+plugins {
+  id 'com.adarshr.test-logger' version '2.1.0'
+}
+
+sourceSets {
+  integration {
+    java.srcDirs = ["src/integration/java"]
+    resources.srcDirs = ["src/integration/resources"]
+    compileClasspath += main.output + test.output
+  }
+}
+
+configurations {
+  integrationImplementation.extendsFrom testImplementation
+  integrationRuntime.extendsFrom testRuntime
+}
+
 dependencies {
   implementation project(":cats:cats-core")
   implementation project(":clouddriver-api")
@@ -48,4 +65,29 @@ dependencies {
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "org.springframework:spring-test"
+
+  integrationImplementation project(":clouddriver-web")
+  integrationImplementation "org.springframework:spring-test"
+  integrationImplementation sourceSets.test.output
+  integrationImplementation sourceSets.main.output
+  integrationImplementation ("io.rest-assured:rest-assured:4.0.0") {
+    exclude group: "org.codehaus.groovy", module: "groovy" // use kork's version
+  }
+}
+
+task integrationTest(type: Test) {
+  description = "Runs AWS EC2 provider integration tests."
+  group = 'verification'
+
+  environment "PROJECT_ROOT", project.rootDir.toString()
+  useJUnitPlatform()
+
+  testClassesDirs = sourceSets.integration.output.classesDirs
+  classpath = sourceSets.integration.runtimeClasspath
+  shouldRunAfter test
+
+  testlogger {
+    theme 'mocha'
+    showFailedStandardStreams true
+  }
 }

--- a/clouddriver-aws/src/integration/README.md
+++ b/clouddriver-aws/src/integration/README.md
@@ -1,0 +1,29 @@
+# AWS EC2 Integration tests
+
+## Running the tests
+
+To manually run the gradle task:
+```bash
+$> ./gradlew :clouddriver-aws:integrationTest
+```
+
+## Guidance for modifying this package
+
+### When to add a new test
+
+Existing or new AWS EC2 provider features of significant scope should include integration tests.
+
+Examples of qualifying changes include (but are not limited to):
+* Changes to validations
+* New or significant changes to an existing atomic operation
+* Addition of new AWS launch templates features
+* Addition of new AWS Autoscaling features
+* Complex refactoring of code areas not included in integration tests
+
+### Changing existing tests
+
+In general, existing test cases should function as-is after new contributions to ensure existing features continue to function as expected.
+Possible exceptions to this guidance may include:
+
+* Updates to internal implementation details (required `@Beans`, etc.) that don't effect operation success or API response content
+* Adding and asserting on *new* data in a `clouddriver` API response

--- a/clouddriver-aws/src/integration/java/com/netflix/spinnaker/clouddriver/aws/AwsTestConfiguration.java
+++ b/clouddriver-aws/src/integration/java/com/netflix/spinnaker/clouddriver/aws/AwsTestConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
+import com.netflix.spinnaker.credentials.CompositeCredentialsRepository;
+import com.netflix.spinnaker.credentials.definition.CredentialsParser;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.TestPropertySource;
+
+@TestConfiguration
+@TestPropertySource(properties = {"spring.config.location = classpath:clouddriver.yml"})
+public class AwsTestConfiguration {
+
+  @Value("${aws.primaryAccount}")
+  private String AWS_ACCOUNT_NAME;
+
+  @Bean
+  @Primary
+  public CompositeCredentialsRepository<AccountCredentials> compositeCredentialsRepository() {
+    NetflixAmazonCredentials awsCreds = TestCredential.named(AWS_ACCOUNT_NAME);
+    CompositeCredentialsRepository<AccountCredentials> repo =
+        mock(CompositeCredentialsRepository.class);
+    when(repo.getCredentials(eq(AWS_ACCOUNT_NAME), eq("aws"))).thenReturn(awsCreds);
+    when(repo.getFirstCredentialsWithName(AWS_ACCOUNT_NAME)).thenReturn(awsCreds);
+    return repo;
+  }
+
+  @Bean
+  @Primary
+  public CredentialsParser amazonCredentialsParser() {
+    CredentialsParser parser = mock(CredentialsParser.class, withSettings().verboseLogging());
+    when(parser.parse(any()))
+        .thenAnswer(
+            (Answer<NetflixAmazonCredentials>)
+                invocation -> {
+                  CredentialsConfig.Account account =
+                      invocation.getArgument(0, CredentialsConfig.Account.class);
+                  return TestCredential.named(account.getName());
+                });
+    return parser;
+  }
+}

--- a/clouddriver-aws/src/integration/java/com/netflix/spinnaker/clouddriver/aws/test/CreateServerGroupLaunchConfigEnabledSpec.java
+++ b/clouddriver-aws/src/integration/java/com/netflix/spinnaker/clouddriver/aws/test/CreateServerGroupLaunchConfigEnabledSpec.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.autoscaling.AmazonAutoScaling;
+import com.amazonaws.services.autoscaling.model.CreateAutoScalingGroupRequest;
+import com.amazonaws.services.autoscaling.model.CreateLaunchConfigurationRequest;
+import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest;
+import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsResult;
+import com.amazonaws.services.autoscaling.model.DescribeLaunchConfigurationsRequest;
+import com.amazonaws.services.autoscaling.model.DescribeLaunchConfigurationsResult;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.DescribeAddressesResult;
+import com.amazonaws.services.ec2.model.DescribeImagesRequest;
+import com.amazonaws.services.ec2.model.DescribeImagesResult;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.ec2.model.DescribeKeyPairsResult;
+import com.amazonaws.services.ec2.model.DescribeSecurityGroupsRequest;
+import com.amazonaws.services.ec2.model.DescribeSecurityGroupsResult;
+import com.amazonaws.services.ec2.model.DescribeSubnetsResult;
+import com.amazonaws.services.ec2.model.DescribeVpcClassicLinkResult;
+import com.amazonaws.services.ec2.model.DescribeVpcsResult;
+import com.amazonaws.services.ec2.model.Image;
+import com.amazonaws.services.ec2.model.SecurityGroup;
+import com.amazonaws.services.ec2.model.Subnet;
+import com.amazonaws.services.ec2.model.Tag;
+import com.netflix.spinnaker.clouddriver.aws.AwsBaseSpec;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.utils.TestUtils;
+import io.restassured.http.ContentType;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * Test class with launch configuration settings enabled in clouddriver.yml, for CreateServerGroup
+ * operation.
+ */
+public class CreateServerGroupLaunchConfigEnabledSpec extends AwsBaseSpec {
+
+  @Value("${aws.features.launch-templates:#{null}}")
+  Boolean AWS_LAUNCH_TEMPLATES;
+
+  private final String EXPECTED_SERVER_GROUP_NAME = "myAwsApp-myStack-v000";
+  private final String EXPECTED_LAUNCH_CONFIG_NAME =
+      EXPECTED_SERVER_GROUP_NAME + "-"; // partial name without the timestamp part
+  private final String EXPECTED_DEPLOY_WITH_LC_MSG_FMT =
+      "Deploying ASG %s with launch configuration %s";
+
+  private AmazonAutoScaling mockAutoScaling = mock(AmazonAutoScaling.class);
+  private AmazonEC2 mockEc2 = mock(AmazonEC2.class);
+
+  @BeforeEach
+  public void setup() {
+
+    // mock EC2 responses
+    when(mockRegionScopedProvider.getAmazonEC2()).thenReturn(mockEc2);
+    when(mockAwsProvider.getAmazonEC2(
+            any(NetflixAmazonCredentials.class), anyString(), anyBoolean()))
+        .thenReturn(mockEc2);
+
+    when(mockEc2.describeSecurityGroups(any(DescribeSecurityGroupsRequest.class)))
+        .thenReturn(
+            new DescribeSecurityGroupsResult()
+                .withSecurityGroups(
+                    new SecurityGroup().withGroupId("sg-123").withGroupName("myAwsApp")));
+    when(mockEc2.describeVpcClassicLink()).thenReturn(new DescribeVpcClassicLinkResult());
+    when(mockEc2.describeAddresses()).thenReturn(new DescribeAddressesResult());
+    when(mockEc2.describeVpcs()).thenReturn(new DescribeVpcsResult());
+    when(mockEc2.describeKeyPairs()).thenReturn(new DescribeKeyPairsResult());
+    when(mockEc2.describeInstances(any(DescribeInstancesRequest.class)))
+        .thenReturn(new DescribeInstancesResult());
+    when(mockEc2.describeImages(any(DescribeImagesRequest.class)))
+        .thenReturn(new DescribeImagesResult().withImages(new Image().withImageId("ami-12345")));
+    when(mockEc2.describeSubnets())
+        .thenReturn(
+            new DescribeSubnetsResult()
+                .withSubnets(
+                    Arrays.asList(
+                        new Subnet()
+                            .withSubnetId("subnetId1")
+                            .withAvailabilityZone("us-west-1a")
+                            .withTags(
+                                new Tag()
+                                    .withKey("immutable_metadata")
+                                    .withValue(
+                                        "{\"purpose\": \"internal\", \"target\": \"ec2\" }")),
+                        new Subnet()
+                            .withSubnetId("subnetId2")
+                            .withAvailabilityZone("us-west-2a"))));
+
+    // mock autoscaling response
+    when(mockAwsProvider.getAutoScaling(any(NetflixAmazonCredentials.class), anyString()))
+        .thenReturn(mockAutoScaling);
+    when(mockAwsProvider.getAutoScaling(
+            any(NetflixAmazonCredentials.class), anyString(), anyBoolean()))
+        .thenReturn(mockAutoScaling);
+
+    when(mockAutoScaling.describeAutoScalingGroups(any(DescribeAutoScalingGroupsRequest.class)))
+        .thenReturn(new DescribeAutoScalingGroupsResult());
+    when(mockAutoScaling.describeLaunchConfigurations(
+            any(DescribeLaunchConfigurationsRequest.class)))
+        .thenReturn(new DescribeLaunchConfigurationsResult());
+  }
+
+  @DisplayName("Assert AWS is enabled and launch template features are disabled")
+  @Test
+  public void configTest() {
+    assertTrue(AWS_ENABLED);
+    assertEquals("aws-account1", AWS_ACCOUNT_NAME);
+    assertNull(AWS_LAUNCH_TEMPLATES); // assert that launch template config is absent / disabled
+  }
+
+  @DisplayName(
+      "Given request with launch configuration and default settings with EC2 on-demand, "
+          + "successfully submit createServerGroup operation with requested configuration")
+  @Test
+  public void createServerGroup_defaultSettings_expect_launchConfiguration()
+      throws InterruptedException {
+    // given
+    Map<String, Object> requestBody =
+        TestUtils.loadJson(PATH_PREFIX + "createServerGroup-basic.json")
+            .withValue("tags", Map.of("testPurpose", "testing default settings"))
+            .asMap();
+
+    // when, then
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    final String taskHistory = getTaskUpdatesAfterCompletion(taskId);
+    assertTrue(
+        taskHistory.contains(
+            String.format(
+                EXPECTED_DEPLOY_WITH_LC_MSG_FMT,
+                EXPECTED_SERVER_GROUP_NAME,
+                EXPECTED_LAUNCH_CONFIG_NAME)));
+    assertTrue(taskHistory.contains(EXPECTED_DEPLOY_SUCCESS_MSG));
+
+    // capture and assert arguments
+    ArgumentCaptor<CreateLaunchConfigurationRequest> createLaunchConfigArgs =
+        ArgumentCaptor.forClass(CreateLaunchConfigurationRequest.class);
+    verify(mockAutoScaling).createLaunchConfiguration(createLaunchConfigArgs.capture());
+    CreateLaunchConfigurationRequest createLcReq = createLaunchConfigArgs.getValue();
+
+    assertTrue(createLcReq.getLaunchConfigurationName().contains(EXPECTED_LAUNCH_CONFIG_NAME));
+    assertEquals("ami-12345", createLcReq.getImageId());
+    assertEquals("c3.large", createLcReq.getInstanceType());
+    assertEquals(1, createLcReq.getSecurityGroups().size());
+    assertEquals("sg-123", createLcReq.getSecurityGroups().get(0));
+
+    ArgumentCaptor<CreateAutoScalingGroupRequest> createAsgArgs =
+        ArgumentCaptor.forClass(CreateAutoScalingGroupRequest.class);
+    verify(mockAutoScaling).createAutoScalingGroup(createAsgArgs.capture());
+    CreateAutoScalingGroupRequest createAsgReq = createAsgArgs.getValue();
+
+    assertTrue(createAsgReq.getLaunchConfigurationName().contains(EXPECTED_LAUNCH_CONFIG_NAME));
+    assertEquals(1, createAsgReq.getTags().size());
+    assertEquals("testPurpose", createAsgReq.getTags().get(0).getKey());
+    assertEquals("testing default settings", createAsgReq.getTags().get(0).getValue());
+  }
+
+  @DisplayName(
+      "Given request with launch configuration and default settings with Ec2 Spot, "
+          + "successfully submit createServerGroup operation with requested configuration")
+  @Test
+  public void createServerGroup_lcAndSpot_expect_launchConfiguration() throws InterruptedException {
+    // given
+    Map<String, Object> requestBody =
+        TestUtils.loadJson(PATH_PREFIX + "createServerGroup-basic.json")
+            .withValue("spotPrice", "1.5")
+            .withValue("securityGroup", new String[] {"myAwsApp"})
+            .withValue("setLaunchTemplate", false)
+            .withValue("tags", Map.of("testPurpose", "testing default settings for spot"))
+            .asMap();
+
+    // when, then
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    final String taskHistory = getTaskUpdatesAfterCompletion(taskId);
+    assertTrue(
+        taskHistory.contains(
+            String.format(
+                EXPECTED_DEPLOY_WITH_LC_MSG_FMT,
+                EXPECTED_SERVER_GROUP_NAME,
+                EXPECTED_LAUNCH_CONFIG_NAME)));
+    assertTrue(taskHistory.contains(EXPECTED_DEPLOY_SUCCESS_MSG));
+
+    // capture and assert arguments
+    ArgumentCaptor<CreateLaunchConfigurationRequest> createLaunchConfigArgs =
+        ArgumentCaptor.forClass(CreateLaunchConfigurationRequest.class);
+    verify(mockAutoScaling).createLaunchConfiguration(createLaunchConfigArgs.capture());
+    CreateLaunchConfigurationRequest createLcReq = createLaunchConfigArgs.getValue();
+
+    assertTrue(createLcReq.getLaunchConfigurationName().contains(EXPECTED_LAUNCH_CONFIG_NAME));
+    assertEquals("ami-12345", createLcReq.getImageId());
+    assertEquals("c3.large", createLcReq.getInstanceType());
+    assertEquals("1.5", createLcReq.getSpotPrice());
+    assertEquals(1, createLcReq.getSecurityGroups().size());
+    assertEquals("sg-123", createLcReq.getSecurityGroups().get(0));
+
+    ArgumentCaptor<CreateAutoScalingGroupRequest> createAsgArgs =
+        ArgumentCaptor.forClass(CreateAutoScalingGroupRequest.class);
+    verify(mockAutoScaling).createAutoScalingGroup(createAsgArgs.capture());
+    CreateAutoScalingGroupRequest createAsgReq = createAsgArgs.getValue();
+
+    assertTrue(createAsgReq.getLaunchConfigurationName().contains(EXPECTED_LAUNCH_CONFIG_NAME));
+    assertEquals(1, createAsgReq.getTags().size());
+    assertEquals("testPurpose", createAsgReq.getTags().get(0).getKey());
+    assertEquals("testing default settings for spot", createAsgReq.getTags().get(0).getValue());
+  }
+}

--- a/clouddriver-aws/src/integration/java/com/netflix/spinnaker/clouddriver/aws/test/CreateServerGroupLaunchTemplatesEnabledSpec.java
+++ b/clouddriver-aws/src/integration/java/com/netflix/spinnaker/clouddriver/aws/test/CreateServerGroupLaunchTemplatesEnabledSpec.java
@@ -1,0 +1,502 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.autoscaling.AmazonAutoScaling;
+import com.amazonaws.services.autoscaling.model.CreateAutoScalingGroupRequest;
+import com.amazonaws.services.autoscaling.model.CreateLaunchConfigurationRequest;
+import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest;
+import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsResult;
+import com.amazonaws.services.autoscaling.model.LaunchTemplateSpecification;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.CreateLaunchTemplateRequest;
+import com.amazonaws.services.ec2.model.CreateLaunchTemplateResult;
+import com.amazonaws.services.ec2.model.DescribeAddressesResult;
+import com.amazonaws.services.ec2.model.DescribeImagesRequest;
+import com.amazonaws.services.ec2.model.DescribeImagesResult;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.ec2.model.DescribeKeyPairsResult;
+import com.amazonaws.services.ec2.model.DescribeLaunchTemplatesRequest;
+import com.amazonaws.services.ec2.model.DescribeLaunchTemplatesResult;
+import com.amazonaws.services.ec2.model.DescribeSecurityGroupsRequest;
+import com.amazonaws.services.ec2.model.DescribeSecurityGroupsResult;
+import com.amazonaws.services.ec2.model.DescribeSubnetsResult;
+import com.amazonaws.services.ec2.model.DescribeVpcClassicLinkResult;
+import com.amazonaws.services.ec2.model.DescribeVpcsResult;
+import com.amazonaws.services.ec2.model.Image;
+import com.amazonaws.services.ec2.model.LaunchTemplate;
+import com.amazonaws.services.ec2.model.SecurityGroup;
+import com.amazonaws.services.ec2.model.Subnet;
+import com.amazonaws.services.ec2.model.Tag;
+import com.amazonaws.services.ec2.model.VirtualizationType;
+import com.netflix.spinnaker.clouddriver.aws.AwsBaseSpec;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.utils.TestUtils;
+import io.restassured.http.ContentType;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Test class with launch template settings enabled in clouddriver.yml, for CreateServerGroup
+ * operation.
+ */
+@ActiveProfiles("launch-templates")
+public class CreateServerGroupLaunchTemplatesEnabledSpec extends AwsBaseSpec {
+  @Value("${aws.features.launch-templates.enabled}")
+  private Boolean AWS_LAUNCH_TEMPLATES_ENABLED;
+
+  @Value("${aws.features.launch-templates.allowed-applications}")
+  private String AWS_LAUNCH_TEMPLATES_ALLOWED_APPS;
+
+  @Value("${aws.features.launch-templates.excluded-applications}")
+  private String AWS_LAUNCH_TEMPLATES_EXCLUDED_APPS;
+
+  private final String EXPECTED_SERVER_GROUP_NAME = "myAwsApp-myStack-v000";
+  private final String EXPECTED_LAUNCH_TEMPLATE_ID = "lt-1";
+  private final LaunchTemplateSpecification EXPECTED_LAUNCH_TEMPLATE_SPEC =
+      new LaunchTemplateSpecification().withLaunchTemplateId("lt-1").withVersion("1");
+  private final String EXPECTED_DEPLOY_WITH_LT_MSG_FMT = "Deploying ASG %s with launch template %s";
+
+  private final String EXPECTED_DEPLOY_WITH_LC_MSG_FMT =
+      "Deploying ASG %s with launch configuration %s";
+  private final String EXPECTED_LAUNCH_CONFIG_NAME =
+      "myAwsApp-myStack-v000-"; // partial name without the timestamp part
+
+  private AmazonAutoScaling mockAutoScaling = mock(AmazonAutoScaling.class);
+  private AmazonEC2 mockEc2 = mock(AmazonEC2.class);
+
+  @BeforeEach
+  public void setup() {
+    // mock EC2 responses
+    when(mockRegionScopedProvider.getAmazonEC2()).thenReturn(mockEc2);
+    when(mockAwsProvider.getAmazonEC2(
+            any(NetflixAmazonCredentials.class), anyString(), anyBoolean()))
+        .thenReturn(mockEc2);
+
+    when(mockEc2.describeSecurityGroups(any(DescribeSecurityGroupsRequest.class)))
+        .thenReturn(
+            new DescribeSecurityGroupsResult()
+                .withSecurityGroups(
+                    new SecurityGroup().withGroupId("sg-123").withGroupName("myAwsApp")));
+    when(mockEc2.describeVpcClassicLink()).thenReturn(new DescribeVpcClassicLinkResult());
+    when(mockEc2.describeAddresses()).thenReturn(new DescribeAddressesResult());
+    when(mockEc2.describeVpcs()).thenReturn(new DescribeVpcsResult());
+    when(mockEc2.describeKeyPairs()).thenReturn(new DescribeKeyPairsResult());
+    when(mockEc2.describeInstances(any(DescribeInstancesRequest.class)))
+        .thenReturn(new DescribeInstancesResult());
+    when(mockEc2.describeImages(any(DescribeImagesRequest.class)))
+        .thenReturn(new DescribeImagesResult().withImages(new Image().withImageId("ami-12345")));
+    when(mockEc2.describeSubnets())
+        .thenReturn(
+            new DescribeSubnetsResult()
+                .withSubnets(
+                    Arrays.asList(
+                        new Subnet()
+                            .withSubnetId("subnetId1")
+                            .withAvailabilityZone("us-west-1a")
+                            .withTags(
+                                new Tag()
+                                    .withKey("immutable_metadata")
+                                    .withValue(
+                                        "{\"purpose\": \"internal\", \"target\": \"ec2\" }")),
+                        new Subnet()
+                            .withSubnetId("subnetId2")
+                            .withAvailabilityZone("us-west-2a"))));
+
+    when(mockEc2.describeLaunchTemplates(any(DescribeLaunchTemplatesRequest.class)))
+        .thenReturn(
+            new DescribeLaunchTemplatesResult()
+                .withLaunchTemplates(
+                    Arrays.asList(
+                        new LaunchTemplate()
+                            .withLaunchTemplateId("lt-1")
+                            .withLatestVersionNumber(1L)
+                            .withDefaultVersionNumber(0L),
+                        new LaunchTemplate()
+                            .withLaunchTemplateId("lt-2")
+                            .withLatestVersionNumber(1L)
+                            .withDefaultVersionNumber(0L))));
+
+    when(mockEc2.createLaunchTemplate(any(CreateLaunchTemplateRequest.class)))
+        .thenReturn(
+            new CreateLaunchTemplateResult()
+                .withLaunchTemplate(
+                    new LaunchTemplate().withLaunchTemplateId("lt-1").withLatestVersionNumber(1L)));
+
+    // mock autoscaling response
+    when(mockAwsProvider.getAutoScaling(any(NetflixAmazonCredentials.class), anyString()))
+        .thenReturn(mockAutoScaling);
+    when(mockAwsProvider.getAutoScaling(
+            any(NetflixAmazonCredentials.class), anyString(), anyBoolean()))
+        .thenReturn(mockAutoScaling);
+    when(mockAutoScaling.describeAutoScalingGroups(any(DescribeAutoScalingGroupsRequest.class)))
+        .thenReturn(new DescribeAutoScalingGroupsResult());
+  }
+
+  @DisplayName("Assert AWS and launch template features are enabled")
+  @Test
+  public void configTest() {
+    assertTrue(AWS_ENABLED);
+    assertEquals("aws-account1", AWS_ACCOUNT_NAME);
+
+    assertTrue(AWS_LAUNCH_TEMPLATES_ENABLED);
+    assertEquals("myAwsApp:aws-account1:us-west-1", AWS_LAUNCH_TEMPLATES_ALLOWED_APPS);
+    assertEquals("myExcludedApp:aws-account1:us-west-1", AWS_LAUNCH_TEMPLATES_EXCLUDED_APPS);
+  }
+
+  @DisplayName(
+      "Given request for server group with launch template features, "
+          + "successfully submit createServerGroup operation with launch template")
+  @Test
+  public void createServerGroup_ltFeatures_used_expect_launchTemplate()
+      throws InterruptedException {
+    // given
+    Map<String, Object> requestBody =
+        TestUtils.loadJson(PATH_PREFIX + "createServerGroup-basic.json")
+            .withValue("setLaunchTemplate", true)
+            .withValue("requireIMDSv2", true)
+            .withValue("associateIPv6Address", true)
+            .withValue("unlimitedCpuCredits", true)
+            .withValue("instanceType", "t3.medium")
+            .withValue("securityGroup", new String[] {"myAwsApp"})
+            .withValue(
+                "tags", Map.of("testPurpose", "testing server group with launch template features"))
+            .asMap();
+
+    // when, then
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    final String taskHistory = getTaskUpdatesAfterCompletion(taskId);
+    assertTrue(
+        taskHistory.contains(
+            String.format(
+                EXPECTED_DEPLOY_WITH_LT_MSG_FMT,
+                EXPECTED_SERVER_GROUP_NAME,
+                EXPECTED_LAUNCH_TEMPLATE_ID)));
+    assertTrue(taskHistory.contains(EXPECTED_DEPLOY_SUCCESS_MSG));
+
+    // capture and assert arguments
+    ArgumentCaptor<CreateLaunchTemplateRequest> createLaunchTemplateArgs =
+        ArgumentCaptor.forClass(CreateLaunchTemplateRequest.class);
+    verify(mockEc2).createLaunchTemplate(createLaunchTemplateArgs.capture());
+    CreateLaunchTemplateRequest createLtReq = createLaunchTemplateArgs.getValue();
+
+    assertTrue(createLtReq.getLaunchTemplateName().contains("myAwsApp-myStack-v000-"));
+    assertEquals("ami-12345", createLtReq.getLaunchTemplateData().getImageId());
+    assertEquals("t3.medium", createLtReq.getLaunchTemplateData().getInstanceType());
+    assertEquals(
+        1, createLtReq.getLaunchTemplateData().getNetworkInterfaces().get(0).getGroups().size());
+    assertEquals(
+        "sg-123",
+        createLtReq.getLaunchTemplateData().getNetworkInterfaces().get(0).getGroups().get(0));
+
+    assertEquals(
+        "unlimited", createLtReq.getLaunchTemplateData().getCreditSpecification().getCpuCredits());
+    assertEquals(
+        "required", createLtReq.getLaunchTemplateData().getMetadataOptions().getHttpTokens());
+    assertEquals(
+        1, createLtReq.getLaunchTemplateData().getNetworkInterfaces().get(0).getIpv6AddressCount());
+
+    assertNull(createLtReq.getLaunchTemplateData().getInstanceMarketOptions());
+    assertNull(createLtReq.getLaunchTemplateData().getPlacement());
+    assertTrue(createLtReq.getLaunchTemplateData().getLicenseSpecifications().isEmpty());
+
+    ArgumentCaptor<CreateAutoScalingGroupRequest> createAsgArgs =
+        ArgumentCaptor.forClass(CreateAutoScalingGroupRequest.class);
+    verify(mockAutoScaling).createAutoScalingGroup(createAsgArgs.capture());
+    CreateAutoScalingGroupRequest createAsgReq = createAsgArgs.getValue();
+
+    assertEquals(EXPECTED_LAUNCH_TEMPLATE_SPEC, createAsgReq.getLaunchTemplate());
+    assertEquals(1, createAsgReq.getTags().size());
+    assertEquals("testPurpose", createAsgReq.getTags().get(0).getKey());
+    assertEquals(
+        "testing server group with launch template features",
+        createAsgReq.getTags().get(0).getValue());
+  }
+
+  @DisplayName(
+      "Given request for server group with launch template, and EC2 Spot, "
+          + "successfully submit createServerGroup operation with launch template")
+  @Test
+  public void createServerGroup_ltAndSpot_expect_launchTemplate() throws InterruptedException {
+    // given
+    Map<String, Object> requestBody =
+        TestUtils.loadJson(PATH_PREFIX + "createServerGroup-basic.json")
+            .withValue("setLaunchTemplate", true)
+            .withValue("spotPrice", "1.5")
+            .withValue("securityGroup", new String[] {"myAwsApp"})
+            .withValue("instanceType", "t3.medium")
+            .asMap();
+
+    // when, then
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    final String taskHistory = getTaskUpdatesAfterCompletion(taskId);
+    assertTrue(
+        taskHistory.contains(
+            String.format(
+                EXPECTED_DEPLOY_WITH_LT_MSG_FMT,
+                EXPECTED_SERVER_GROUP_NAME,
+                EXPECTED_LAUNCH_TEMPLATE_ID)));
+    assertTrue(taskHistory.contains(EXPECTED_DEPLOY_SUCCESS_MSG));
+
+    // capture and assert arguments
+    ArgumentCaptor<CreateLaunchTemplateRequest> createLaunchTemplateArgs =
+        ArgumentCaptor.forClass(CreateLaunchTemplateRequest.class);
+    verify(mockEc2).createLaunchTemplate(createLaunchTemplateArgs.capture());
+    CreateLaunchTemplateRequest createLtReq = createLaunchTemplateArgs.getValue();
+
+    assertTrue(createLtReq.getLaunchTemplateName().contains("myAwsApp-myStack-v000-"));
+    assertEquals("ami-12345", createLtReq.getLaunchTemplateData().getImageId());
+    assertEquals("t3.medium", createLtReq.getLaunchTemplateData().getInstanceType());
+    assertEquals(
+        "spot", createLtReq.getLaunchTemplateData().getInstanceMarketOptions().getMarketType());
+    assertEquals(
+        "1.5",
+        createLtReq
+            .getLaunchTemplateData()
+            .getInstanceMarketOptions()
+            .getSpotOptions()
+            .getMaxPrice());
+    assertEquals(
+        "standard",
+        createLtReq
+            .getLaunchTemplateData()
+            .getCreditSpecification()
+            .getCpuCredits()); // default for t3 type
+
+    ArgumentCaptor<CreateAutoScalingGroupRequest> createAsgArgs =
+        ArgumentCaptor.forClass(CreateAutoScalingGroupRequest.class);
+    verify(mockAutoScaling).createAutoScalingGroup(createAsgArgs.capture());
+    CreateAutoScalingGroupRequest createAsgReq = createAsgArgs.getValue();
+
+    assertEquals(EXPECTED_LAUNCH_TEMPLATE_SPEC, createAsgReq.getLaunchTemplate());
+  }
+
+  @DisplayName("Given request with incompatible AMI and instance type, fail with accurate message")
+  @Test
+  public void createServerGroup_incompatible_ami_and_instanceType_expect_exception()
+      throws InterruptedException {
+    // given
+    Map<String, Object> requestBody =
+        TestUtils.loadJson(PATH_PREFIX + "createServerGroup-basic.json")
+            .withValue("setLaunchTemplate", true)
+            .withValue("spotPrice", "1.5")
+            .withValue("securityGroup", new String[] {"myAwsApp"})
+            .withValue("instanceType", "t3.medium")
+            .asMap();
+    when(mockEc2.describeImages(any(DescribeImagesRequest.class)))
+        .thenReturn(
+            new DescribeImagesResult()
+                .withImages(
+                    new Image()
+                        .withImageId("img-1")
+                        .withName("test-image")
+                        .withVirtualizationType(VirtualizationType.Paravirtual)));
+
+    // when, then
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    final String taskHistory = getTaskUpdatesAfterCompletion(taskId);
+    assertTrue(
+        taskHistory.contains(
+            "Orchestration failed: DeployAtomicOperation | IllegalArgumentException: [Instance type t3.medium does not support virtualization type paravirtual. Please select a different image or instance type.]"));
+  }
+
+  @DisplayName(
+      "Given request with setLaunchTemplate disabled, "
+          + "successfully submit createServerGroup operation with launch configuration")
+  @Test
+  public void createServerGroup_setLaunchTemplateDisabled_expect_launchConfiguration()
+      throws InterruptedException {
+    // given
+    Map<String, Object> requestBody =
+        TestUtils.loadJson(PATH_PREFIX + "createServerGroup-basic.json")
+            .withValue("setLaunchTemplate", false)
+            .asMap();
+
+    // when, then
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    final String taskHistory = getTaskUpdatesAfterCompletion(taskId);
+    assertTrue(
+        taskHistory.contains(
+            String.format(
+                EXPECTED_DEPLOY_WITH_LC_MSG_FMT,
+                EXPECTED_SERVER_GROUP_NAME,
+                EXPECTED_LAUNCH_CONFIG_NAME)));
+    assertTrue(
+        taskHistory.contains(
+            String.format(EXPECTED_SERVER_GROUP_NAME, EXPECTED_SERVER_GROUP_NAME)));
+
+    // capture and assert arguments
+    ArgumentCaptor<CreateLaunchConfigurationRequest> createLaunchConfigArgs =
+        ArgumentCaptor.forClass(CreateLaunchConfigurationRequest.class);
+    verify(mockAutoScaling).createLaunchConfiguration(createLaunchConfigArgs.capture());
+    CreateLaunchConfigurationRequest createLcReq = createLaunchConfigArgs.getValue();
+
+    assertTrue(createLcReq.getLaunchConfigurationName().contains(EXPECTED_LAUNCH_CONFIG_NAME));
+    assertEquals(1, createLcReq.getSecurityGroups().size());
+    assertEquals("sg-123", createLcReq.getSecurityGroups().get(0));
+    assertEquals("ami-12345", createLcReq.getImageId());
+    assertEquals("c3.large", createLcReq.getInstanceType());
+
+    ArgumentCaptor<CreateAutoScalingGroupRequest> createAsgArgs =
+        ArgumentCaptor.forClass(CreateAutoScalingGroupRequest.class);
+    verify(mockAutoScaling).createAutoScalingGroup(createAsgArgs.capture());
+    CreateAutoScalingGroupRequest createAsgReq = createAsgArgs.getValue();
+
+    assertTrue(createAsgReq.getLaunchConfigurationName().contains(EXPECTED_LAUNCH_CONFIG_NAME));
+  }
+
+  @DisplayName(
+      "Given request with setLaunchTemplate enabled for an excluded application, "
+          + "successfully submit createServerGroup operation with launch configuration")
+  @Test
+  public void createServerGroup_ltEnabled_and_excludedApp_expect_launchConfiguration()
+      throws InterruptedException {
+    // given
+    Map<String, Object> requestBody =
+        TestUtils.loadJson(PATH_PREFIX + "createServerGroup-basic.json")
+            .withValue("application", "myExcludedApp")
+            .withValue("instanceType", "c3.small")
+            .withValue("setLaunchTemplate", false)
+            .asMap();
+    when(mockEc2.describeSecurityGroups(any(DescribeSecurityGroupsRequest.class)))
+        .thenReturn(
+            new DescribeSecurityGroupsResult()
+                .withSecurityGroups(
+                    new SecurityGroup().withGroupId("sg-123").withGroupName("myExcludedApp")));
+
+    // when, then
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    final String expectedSgName = "myExcludedApp-myStack-v000";
+    final String expectedLcName =
+        expectedSgName + "-"; // partial launch config name without the timestamp
+    final String taskHistory = getTaskUpdatesAfterCompletion(taskId);
+    assertTrue(
+        taskHistory.contains(
+            String.format(EXPECTED_DEPLOY_WITH_LC_MSG_FMT, expectedSgName, expectedLcName)));
+    assertTrue(taskHistory.contains(EXPECTED_DEPLOY_SUCCESS_MSG));
+
+    // capture and assert arguments
+    ArgumentCaptor<CreateLaunchConfigurationRequest> createLaunchConfigArgs =
+        ArgumentCaptor.forClass(CreateLaunchConfigurationRequest.class);
+    verify(mockAutoScaling).createLaunchConfiguration(createLaunchConfigArgs.capture());
+    CreateLaunchConfigurationRequest createLcReq = createLaunchConfigArgs.getValue();
+
+    assertTrue(createLcReq.getLaunchConfigurationName().contains(expectedLcName));
+    assertEquals(1, createLcReq.getSecurityGroups().size());
+    assertEquals("sg-123", createLcReq.getSecurityGroups().get(0));
+    assertEquals("ami-12345", createLcReq.getImageId());
+    assertEquals("c3.small", createLcReq.getInstanceType());
+
+    ArgumentCaptor<CreateAutoScalingGroupRequest> createAsgArgs =
+        ArgumentCaptor.forClass(CreateAutoScalingGroupRequest.class);
+    verify(mockAutoScaling).createAutoScalingGroup(createAsgArgs.capture());
+    CreateAutoScalingGroupRequest createAsgReq = createAsgArgs.getValue();
+
+    assertTrue(createAsgReq.getLaunchConfigurationName().contains(expectedLcName));
+  }
+}

--- a/clouddriver-aws/src/integration/java/com/netflix/spinnaker/clouddriver/aws/test/CreateServerGroupSpec.java
+++ b/clouddriver-aws/src/integration/java/com/netflix/spinnaker/clouddriver/aws/test/CreateServerGroupSpec.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.autoscaling.AmazonAutoScaling;
+import com.amazonaws.services.autoscaling.model.AlreadyExistsException;
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
+import com.amazonaws.services.autoscaling.model.CreateAutoScalingGroupRequest;
+import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest;
+import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsResult;
+import com.amazonaws.services.autoscaling.model.LaunchTemplateSpecification;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.CreateLaunchTemplateRequest;
+import com.amazonaws.services.ec2.model.CreateLaunchTemplateResult;
+import com.amazonaws.services.ec2.model.DescribeAddressesResult;
+import com.amazonaws.services.ec2.model.DescribeImagesRequest;
+import com.amazonaws.services.ec2.model.DescribeImagesResult;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.ec2.model.DescribeKeyPairsResult;
+import com.amazonaws.services.ec2.model.DescribeSecurityGroupsRequest;
+import com.amazonaws.services.ec2.model.DescribeSecurityGroupsResult;
+import com.amazonaws.services.ec2.model.DescribeSubnetsResult;
+import com.amazonaws.services.ec2.model.DescribeVpcClassicLinkResult;
+import com.amazonaws.services.ec2.model.DescribeVpcsResult;
+import com.amazonaws.services.ec2.model.Image;
+import com.amazonaws.services.ec2.model.LaunchTemplate;
+import com.amazonaws.services.ec2.model.SecurityGroup;
+import com.amazonaws.services.ec2.model.Subnet;
+import com.amazonaws.services.ec2.model.Tag;
+import com.netflix.spinnaker.clouddriver.aws.AwsBaseSpec;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.utils.TestUtils;
+import io.restassured.http.ContentType;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Test class for general test cases related to CreateServerGroup operation. Note: launch template
+ * settings are enabled in clouddriver.yml
+ */
+@ActiveProfiles("launch-templates")
+public class CreateServerGroupSpec extends AwsBaseSpec {
+  private AmazonAutoScaling mockAutoScaling = mock(AmazonAutoScaling.class);
+  private AmazonEC2 mockEc2 = mock(AmazonEC2.class);
+
+  @BeforeEach
+  public void setup() {
+    // mock EC2 responses
+    when(mockRegionScopedProvider.getAmazonEC2()).thenReturn(mockEc2);
+    when(mockAwsProvider.getAmazonEC2(
+            any(NetflixAmazonCredentials.class), anyString(), anyBoolean()))
+        .thenReturn(mockEc2);
+
+    when(mockEc2.describeSecurityGroups(any(DescribeSecurityGroupsRequest.class)))
+        .thenReturn(
+            new DescribeSecurityGroupsResult()
+                .withSecurityGroups(
+                    new SecurityGroup().withGroupId("sg-123").withGroupName("myAwsApp")));
+    when(mockEc2.describeVpcClassicLink()).thenReturn(new DescribeVpcClassicLinkResult());
+    when(mockEc2.describeAddresses()).thenReturn(new DescribeAddressesResult());
+    when(mockEc2.describeVpcs()).thenReturn(new DescribeVpcsResult());
+    when(mockEc2.describeKeyPairs()).thenReturn(new DescribeKeyPairsResult());
+    when(mockEc2.describeInstances(any(DescribeInstancesRequest.class)))
+        .thenReturn(new DescribeInstancesResult());
+    when(mockEc2.describeImages(any(DescribeImagesRequest.class)))
+        .thenReturn(new DescribeImagesResult().withImages(new Image().withImageId("ami-12345")));
+    when(mockEc2.describeSubnets())
+        .thenReturn(
+            new DescribeSubnetsResult()
+                .withSubnets(
+                    Arrays.asList(
+                        new Subnet()
+                            .withSubnetId("subnetId1")
+                            .withAvailabilityZone("us-west-1a")
+                            .withTags(
+                                new Tag()
+                                    .withKey("immutable_metadata")
+                                    .withValue(
+                                        "{\"purpose\": \"internal\", \"target\": \"ec2\" }")),
+                        new Subnet()
+                            .withSubnetId("subnetId2")
+                            .withAvailabilityZone("us-west-2a"))));
+
+    when(mockEc2.createLaunchTemplate(any(CreateLaunchTemplateRequest.class)))
+        .thenReturn(
+            new CreateLaunchTemplateResult()
+                .withLaunchTemplate(
+                    new LaunchTemplate().withLaunchTemplateId("lt-1").withLatestVersionNumber(1L)));
+
+    // mock autoscaling response
+    when(mockAwsProvider.getAutoScaling(any(NetflixAmazonCredentials.class), anyString()))
+        .thenReturn(mockAutoScaling);
+    when(mockAwsProvider.getAutoScaling(
+            any(NetflixAmazonCredentials.class), anyString(), anyBoolean()))
+        .thenReturn(mockAutoScaling);
+    when(mockAutoScaling.describeAutoScalingGroups(any(DescribeAutoScalingGroupsRequest.class)))
+        .thenReturn(new DescribeAutoScalingGroupsResult());
+  }
+
+  @DisplayName("Given invalid requests, successfully validate with error messages")
+  @Test
+  public void createServerGroup_invalidRequests_expect_validationFailure() {
+    final String invalidReqDir = "/description_validator_test_inputs/";
+    final String pattern = PATH_PREFIX + invalidReqDir + "createServerGroup-*.json";
+    TestUtils.loadResourcesFromDir(pattern).stream()
+        .forEach(
+            ti -> {
+              final String testFileName = ti.getFilename();
+              System.out.println("\nRunning tests for " + invalidReqDir + testFileName);
+
+              // given
+              Map<String, Object> requestBody = TestUtils.loadJson(ti).asMap();
+
+              // when, then
+              final String expectedValidationMsg =
+                  StringUtils.substringAfterLast(testFileName, "-").split(".json")[0];
+
+              given()
+                  .contentType(ContentType.JSON)
+                  .body(requestBody)
+                  .when()
+                  .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+                  .then()
+                  .statusCode(400)
+                  .contentType(ContentType.JSON)
+                  .assertThat()
+                  .body("message", Matchers.equalTo("Validation Failed"))
+                  .body("errors.size()", Matchers.equalTo(1))
+                  .body("errors[0]", Matchers.equalTo(expectedValidationMsg));
+            });
+  }
+
+  @DisplayName("Given request with subnet type, successfully submit deployment to subnet IDs")
+  @Test
+  public void createServerGroup_subnetType_expect_deploymentToSubnetIds()
+      throws InterruptedException {
+    // given
+    Map<String, Object> requestBody =
+        TestUtils.loadJson(PATH_PREFIX + "createServerGroup-basic.json")
+            .withValue("setLaunchTemplate", false)
+            .withValue("subnetType", "internal")
+            .asMap();
+
+    // when, then
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    final String taskHistory = getTaskUpdatesAfterCompletion(taskId);
+    assertTrue(taskHistory.contains(EXPECTED_DEPLOY_SUCCESS_MSG));
+    assertTrue(taskHistory.contains("Deploying to subnetIds: subnetId1"));
+
+    // capture and assert arguments
+    ArgumentCaptor<CreateAutoScalingGroupRequest> createAsgArgs =
+        ArgumentCaptor.forClass(CreateAutoScalingGroupRequest.class);
+    verify(mockAutoScaling).createAutoScalingGroup(createAsgArgs.capture());
+    CreateAutoScalingGroupRequest createAsgReq = createAsgArgs.getValue();
+
+    assertEquals("subnetId1", createAsgReq.getVPCZoneIdentifier());
+    assertTrue(createAsgReq.getAvailabilityZones().isEmpty());
+  }
+
+  @DisplayName("Given request with invalid subnet type, fail with accurate message")
+  @Test
+  public void createServerGroup_invalid_subnetType_expect_error() throws InterruptedException {
+    // given
+    Map<String, Object> requestBody =
+        TestUtils.loadJson(PATH_PREFIX + "createServerGroup-basic.json")
+            .withValue("subnetType", "unknown")
+            .asMap();
+
+    // when, then
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    final String taskHistory = getTaskUpdatesAfterCompletion(taskId);
+    assertTrue(
+        taskHistory.contains(
+            "Orchestration failed: DeployAtomicOperation | RuntimeException: [No suitable subnet was found for internal subnet purpose 'unknown'!]"));
+  }
+
+  @DisplayName(
+      "Given request without subnet type, successfully submit deployment to availability zones")
+  @Test
+  public void createServerGroup_noSubnetType_expect_deploymentToAZs() throws InterruptedException {
+    // given
+    Map<String, Object> requestBody =
+        TestUtils.loadJson(PATH_PREFIX + "createServerGroup-basic.json").asMap();
+
+    // when, then
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    final String taskHistory = getTaskUpdatesAfterCompletion(taskId);
+    assertTrue(taskHistory.contains(EXPECTED_DEPLOY_SUCCESS_MSG));
+    assertTrue(
+        taskHistory.contains(
+            String.format("Deploying to availabilityZones: [us-west-1a, us-west-1c]")));
+
+    // capture and assert arguments
+    ArgumentCaptor<CreateAutoScalingGroupRequest> createAsgArgs =
+        ArgumentCaptor.forClass(CreateAutoScalingGroupRequest.class);
+    verify(mockAutoScaling).createAutoScalingGroup(createAsgArgs.capture());
+    CreateAutoScalingGroupRequest createAsgReq = createAsgArgs.getValue();
+
+    assertEquals(Arrays.asList("us-west-1a", "us-west-1c"), createAsgReq.getAvailabilityZones());
+    assertNull(createAsgReq.getVPCZoneIdentifier());
+  }
+
+  @DisplayName(
+      "Given request to create server group that already exists "
+          + "and creation time not in safety window, fail with accurate message")
+  @Test
+  public void createServerGroup_alreadyExists_notInSafetyWindow_expect_exception()
+      throws InterruptedException {
+    // given
+    final String expectedServerGroupName = "myAwsApp-myStack-v100";
+    Map<String, Object> requestBody =
+        TestUtils.loadJson(PATH_PREFIX + "createServerGroup-basic.json")
+            .withValue("sequence", "100")
+            .withValue("setLaunchTemplate", true)
+            .asMap();
+
+    // when - create myAwsApp-myStack-v100 first and verify
+    String taskId1 =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    String taskHistory1 = getTaskUpdatesAfterCompletion(taskId1);
+    System.out.println(taskHistory1);
+    System.out.println(taskHistory1.contains(EXPECTED_DEPLOY_SUCCESS_MSG));
+    assertTrue(taskHistory1.contains(EXPECTED_DEPLOY_SUCCESS_MSG));
+
+    // when
+    final Date notWithinOneHour = Date.from(Instant.now().minus(2, ChronoUnit.HOURS));
+    when(mockAutoScaling.createAutoScalingGroup(any(CreateAutoScalingGroupRequest.class)))
+        .thenThrow(AlreadyExistsException.class);
+    when(mockAutoScaling.describeAutoScalingGroups(
+            new DescribeAutoScalingGroupsRequest()
+                .withAutoScalingGroupNames(expectedServerGroupName)))
+        .thenReturn(
+            new DescribeAutoScalingGroupsResult()
+                .withAutoScalingGroups(
+                    Arrays.asList(
+                        new AutoScalingGroup()
+                            .withAutoScalingGroupName(expectedServerGroupName)
+                            .withHealthCheckType("EC2")
+                            .withLaunchTemplate(
+                                new LaunchTemplateSpecification()
+                                    .withLaunchTemplateId("lt-1")
+                                    .withVersion("1"))
+                            .withAvailabilityZones(Arrays.asList("us-west-1a", "us-west-1c"))
+                            .withCreatedTime(notWithinOneHour))));
+
+    // then, try to create myAwsApp-myStack-v100 again
+    String taskId2 =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    String taskHistory2 = getTaskUpdatesAfterCompletion(taskId2);
+    assertTrue(
+        taskHistory2.contains(
+            expectedServerGroupName
+                + " already exists and appears to be valid, but falls outside of safety window for idempotent deploy (1 hour)"));
+    assertTrue(
+        taskHistory2.contains(
+            "Orchestration failed: DeployAtomicOperation | AlreadyExistsException"));
+  }
+
+  @DisplayName(
+      "Given request to create server group that already exists "
+          + "and creation time not in safety window, fail with accurate message")
+  @Test
+  public void createServerGroup_alreadyExists_inSafetyWindow_expect_success()
+      throws InterruptedException {
+    // given
+    final String expectedServerGroupName = "myAwsApp-myStack-v200";
+    Map<String, Object> requestBody =
+        TestUtils.loadJson(PATH_PREFIX + "createServerGroup-basic.json")
+            .withValue("sequence", "200")
+            .withValue("setLaunchTemplate", true)
+            .asMap();
+
+    // when - create myAwsApp-myStack-v200 first and verify
+    String taskId1 =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    String taskHistory1 = getTaskUpdatesAfterCompletion(taskId1);
+    assertTrue(taskHistory1.contains(EXPECTED_DEPLOY_SUCCESS_MSG));
+
+    // when
+    final Date withinOneHour = Date.from(Instant.now().minus(2, ChronoUnit.MINUTES));
+    when(mockAutoScaling.createAutoScalingGroup(any(CreateAutoScalingGroupRequest.class)))
+        .thenThrow(AlreadyExistsException.class);
+    when(mockAutoScaling.describeAutoScalingGroups(
+            new DescribeAutoScalingGroupsRequest()
+                .withAutoScalingGroupNames(expectedServerGroupName)))
+        .thenReturn(
+            new DescribeAutoScalingGroupsResult()
+                .withAutoScalingGroups(
+                    Arrays.asList(
+                        new AutoScalingGroup()
+                            .withAutoScalingGroupName(expectedServerGroupName)
+                            .withHealthCheckType("EC2")
+                            .withLaunchTemplate(
+                                new LaunchTemplateSpecification()
+                                    .withLaunchTemplateId("lt-1")
+                                    .withVersion("1"))
+                            .withAvailabilityZones(Arrays.asList("us-west-1a", "us-west-1c"))
+                            .withCreatedTime(withinOneHour))));
+
+    // then, try to create myAwsApp-myStack-v200 again
+    String taskId2 =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    String taskHistory2 = getTaskUpdatesAfterCompletion(taskId2);
+    assertTrue(taskHistory2.contains(EXPECTED_DEPLOY_SUCCESS_MSG));
+  }
+
+  @DisplayName(
+      "Given request to create server group with monitoring enabled, "
+          + "successfully submit create server group operation")
+  @Test
+  public void createServerGroup_metrics_monitoring_enabled_expect_success()
+      throws InterruptedException {
+    // given
+    Map<String, Object> requestBody =
+        TestUtils.loadJson(PATH_PREFIX + "createServerGroup-basic.json")
+            .withValue("instanceMonitoring", true)
+            .withValue("enabledMetrics", new String[] {"GroupMinSize", "GroupMaxSize"})
+            .withValue("securityGroup", new String[] {"myAwsApp"})
+            .asMap();
+
+    // when, then
+    String taskId =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post(getBaseUrl() + CREATE_SERVER_GROUP_OP_PATH)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("resourceUri", containsString("/task/"))
+            .extract()
+            .path("id");
+
+    // then
+    final String taskHistory = getTaskUpdatesAfterCompletion(taskId);
+    assertTrue(taskHistory.contains("Enabling metrics collection for:"));
+  }
+}

--- a/clouddriver-aws/src/integration/java/com/netflix/spinnaker/clouddriver/aws/utils/TestUtils.java
+++ b/clouddriver-aws/src/integration/java/com/netflix/spinnaker/clouddriver/aws/utils/TestUtils.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.utils;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Splitter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.ResourcePatternUtils;
+
+public class TestUtils {
+
+  public static List<Resource> loadResourcesFromDir(String path) {
+    try {
+      return Arrays.asList(
+          ResourcePatternUtils.getResourcePatternResolver(new DefaultResourceLoader())
+              .getResources(path));
+    } catch (IOException ex) {
+      throw new RuntimeException("Failed to load resources from directory " + path, ex);
+    }
+  }
+
+  public static TestResourceFile loadJson(Resource resource) {
+    try (InputStream is = resource.getInputStream()) {
+      ObjectMapper objectMapper = new ObjectMapper();
+      JsonNode jsonNode = objectMapper.readTree(is);
+      List<Map<String, Object>> content;
+
+      if (jsonNode.isArray()) {
+        content = objectMapper.convertValue(jsonNode, new TypeReference<>() {});
+      } else {
+        content =
+            Collections.singletonList(
+                objectMapper.convertValue(jsonNode, new TypeReference<>() {}));
+      }
+      return new TestResourceFile(content);
+    } catch (IOException ex) {
+      throw new RuntimeException(
+          "Failed to load test input from file " + resource.getFilename(), ex);
+    }
+  }
+
+  public static TestResourceFile loadJson(String path) {
+    ResourceLoader resourceLoader = new DefaultResourceLoader();
+    return loadJson(resourceLoader.getResource(path));
+  }
+
+  public static class TestResourceFile {
+    private final List<Map<String, Object>> content;
+
+    public TestResourceFile(List<Map<String, Object>> content) {
+      this.content = content;
+    }
+
+    public List<Map<String, Object>> asList() {
+      return content;
+    }
+
+    public Map<String, Object> asMap() {
+      return content.get(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    public TestResourceFile withValue(String path, Object value) {
+      List<String> parts = Splitter.on('.').splitToList(path);
+
+      for (Map<String, Object> entry : content) {
+        for (int i = 0; i < parts.size(); i++) {
+          if (parts.get(i).matches("^.*\\[[0-9]*]$")) {
+            String key = parts.get(i).substring(0, parts.get(i).indexOf('['));
+            int index =
+                Integer.parseInt(
+                    parts
+                        .get(i)
+                        .substring(parts.get(i).indexOf('[') + 1, parts.get(i).indexOf(']')));
+            List<Map<String, Object>> list = (List<Map<String, Object>>) entry.get(key);
+            if (i == parts.size() - 1) {
+              list.add(index, (Map<String, Object>) value);
+              break;
+            }
+            entry = list.get(index);
+          } else if (i == parts.size() - 1) {
+            entry.put(parts.get(i), value);
+            break;
+          } else if (!entry.containsKey(parts.get(i))) {
+            entry.put(parts.get(i), new HashMap<>());
+            entry = (Map<String, Object>) entry.get(parts.get(i));
+          } else {
+            entry = (Map<String, Object>) entry.get(parts.get(i));
+          }
+        }
+      }
+
+      return this;
+    }
+  }
+}

--- a/clouddriver-aws/src/integration/resources/clouddriver.yml
+++ b/clouddriver-aws/src/integration/resources/clouddriver.yml
@@ -1,0 +1,51 @@
+spring:
+  application:
+    name: clouddriver
+
+aws:
+  enabled: true
+  primaryAccount: aws-account1
+  accounts:
+    - name: aws-account1
+      requiredGroupMembership: []
+      providerVersion: V1
+      permissions: {}
+      accountId: '123456789012'
+      regions:
+        - name: us-west-1
+      assumeRole: role/SpinnakerManaged
+  bakeryDefaults:
+    baseImages: []
+  defaultKeyPairTemplate: '{{name}}-keypair'
+  defaultRegions:
+    - name: us-west-1
+  defaults:
+    iamRole: BaseIAMRole
+
+redis:
+  enabled: false
+  cache:
+    enabled: false
+  scheduler:
+    enabled: false
+  taskRepository:
+    enabled: false
+
+services:
+  fiat:
+    baseUrl: http://fiat.net
+  front50:
+    baseUrl: http://front50.net
+
+---
+
+spring:
+  profiles: launch-templates
+
+aws:
+  enabled: true
+  features:
+    launch-templates:
+      enabled: true
+      allowed-applications: "myAwsApp:aws-account1:us-west-1"
+      excluded-applications: "myExcludedApp:aws-account1:us-west-1"

--- a/clouddriver-aws/src/integration/resources/testinputs/createServerGroup-basic.json
+++ b/clouddriver-aws/src/integration/resources/testinputs/createServerGroup-basic.json
@@ -1,0 +1,24 @@
+{
+  "type":"createServerGroup",
+  "account": "aws_account",
+  "amiName": "ami-12345",
+  "stack": "myStack",
+  "application": "myAwsApp",
+  "availabilityZones": {
+    "us-west-1": [
+      "us-west-1a",
+      "us-west-1c"
+    ]
+  },
+  "capacity": {
+    "desired": 1,
+    "max": 1,
+    "min": 1
+  },
+  "cloudProvider": "aws",
+  "credentials": "aws-account1",
+  "healthCheckType":"EC2",
+  "iamRole":"BaseInstanceProfile",
+  "instanceType":"c3.large",
+  "legacyUdf": false
+}

--- a/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-Region not configured.json
+++ b/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-Region not configured.json
@@ -1,0 +1,22 @@
+{
+  "type":"createServerGroup",
+  "account": "aws_account",
+  "amiName": "ami-12345",
+  "stack": "myStack",
+  "application": "myAwsApp",
+  "availabilityZones": {
+    "us-west-2": ["us-west-2a"]
+  },
+  "capacity": {
+    "desired": 1,
+    "max": 1,
+    "min": 1
+  },
+  "cloudProvider": "aws",
+  "credentials": "aws-account1",
+  "healthCheckType":"EC2",
+  "iamRole":"BaseInstanceProfile",
+  "legacyUdf": false,
+  "setLaunchTemplate": true,
+  "instanceType":"c3.small"
+}

--- a/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-basicAmazonDeployDescription.amiName.empty.json
+++ b/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-basicAmazonDeployDescription.amiName.empty.json
@@ -1,0 +1,23 @@
+{
+  "type":"createServerGroup",
+  "account": "aws_account",
+  "stack": "myStack",
+  "application": "myAwsApp",
+  "availabilityZones": {
+    "us-west-1": [
+      "us-west-1a",
+      "us-west-1c"
+    ]
+  },
+  "capacity": {
+    "desired": 1,
+    "max": 1,
+    "min": 1
+  },
+  "cloudProvider": "aws",
+  "credentials": "aws-account1",
+  "healthCheckType":"EC2",
+  "iamRole":"BaseInstanceProfile",
+  "legacyUdf": false,
+  "instanceType": "m5.medium"
+}

--- a/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-basicAmazonDeployDescription.application.empty.json
+++ b/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-basicAmazonDeployDescription.application.empty.json
@@ -1,0 +1,23 @@
+{
+  "type":"createServerGroup",
+  "account": "aws_account",
+  "amiName": "ami-12345",
+  "stack": "myStack",
+  "availabilityZones": {
+    "us-west-1": [
+      "us-west-1a",
+      "us-west-1c"
+    ]
+  },
+  "capacity": {
+    "desired": 1,
+    "max": 1,
+    "min": 1
+  },
+  "cloudProvider": "aws",
+  "credentials": "aws-account1",
+  "healthCheckType":"EC2",
+  "iamRole":"BaseInstanceProfile",
+  "instanceType":"c3.small",
+  "legacyUdf": false
+}

--- a/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-basicAmazonDeployDescription.availabilityZones.empty.json
+++ b/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-basicAmazonDeployDescription.availabilityZones.empty.json
@@ -1,0 +1,19 @@
+{
+  "type":"createServerGroup",
+  "account": "aws_account",
+  "amiName": "ami-12345",
+  "stack": "myStack",
+  "application": "myAwsApp",
+  "capacity": {
+    "desired": 1,
+    "max": 1,
+    "min": 1
+  },
+  "cloudProvider": "aws",
+  "credentials": "aws-account1",
+  "healthCheckType":"EC2",
+  "iamRole":"BaseInstanceProfile",
+  "instanceType":"t2.small",
+  "legacyUdf": false,
+  "subnetType": "internal"
+}

--- a/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-basicAmazonDeployDescription.instanceType.empty.json
+++ b/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-basicAmazonDeployDescription.instanceType.empty.json
@@ -1,0 +1,23 @@
+{
+  "type":"createServerGroup",
+  "account": "aws_account",
+  "amiName": "ami-12345",
+  "stack": "myStack",
+  "application": "myAwsApp",
+  "availabilityZones": {
+    "us-west-1": [
+      "us-west-1a",
+      "us-west-1c"
+    ]
+  },
+  "capacity": {
+    "desired": 1,
+    "max": 1,
+    "min": 1
+  },
+  "cloudProvider": "aws",
+  "credentials": "aws-account1",
+  "healthCheckType":"EC2",
+  "iamRole":"BaseInstanceProfile",
+  "legacyUdf": false
+}

--- a/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-burstingOff-basicAmazonDeployDescription.bursting.not.supported.by.instanceType.json
+++ b/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-burstingOff-basicAmazonDeployDescription.bursting.not.supported.by.instanceType.json
@@ -1,0 +1,26 @@
+{
+  "type":"createServerGroup",
+  "account": "aws_account",
+  "amiName": "ami-12345",
+  "stack": "myStack",
+  "application": "myAwsApp",
+  "availabilityZones": {
+    "us-west-1": [
+      "us-west-1a",
+      "us-west-1c"
+    ]
+  },
+  "capacity": {
+    "desired": 1,
+    "max": 1,
+    "min": 1
+  },
+  "cloudProvider": "aws",
+  "credentials": "aws-account1",
+  "healthCheckType":"EC2",
+  "iamRole":"BaseInstanceProfile",
+  "legacyUdf": false,
+  "setLaunchTemplate": true,
+  "instanceType":"c3.small",
+  "unlimitedCpuCredits": false
+}

--- a/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-burstingOn-basicAmazonDeployDescription.bursting.not.supported.by.instanceType.json
+++ b/clouddriver-aws/src/integration/resources/testinputs/description_validator_test_inputs/createServerGroup-burstingOn-basicAmazonDeployDescription.bursting.not.supported.by.instanceType.json
@@ -1,0 +1,26 @@
+{
+  "type":"createServerGroup",
+  "account": "aws_account",
+  "amiName": "ami-12345",
+  "stack": "myStack",
+  "application": "myAwsApp",
+  "availabilityZones": {
+    "us-west-1": [
+      "us-west-1a",
+      "us-west-1c"
+    ]
+  },
+  "capacity": {
+    "desired": 1,
+    "max": 1,
+    "min": 1
+  },
+  "cloudProvider": "aws",
+  "credentials": "aws-account1",
+  "healthCheckType":"EC2",
+  "iamRole":"BaseInstanceProfile",
+  "legacyUdf": false,
+  "setLaunchTemplate": true,
+  "instanceType":"c3.small",
+  "unlimitedCpuCredits": true
+}


### PR DESCRIPTION
* Adding integration tests for AWS EC2 provider for CreateServerGroup operation (with launch configuration / launch template settings enabled)
* Adding AWS provider integration tests to Github workflow


#### Sample integ test run:
Look for `AWS EC2 Provider Integration Tests` in https://github.com/pdk27/clouddriver/runs/2090227653?check_suite_focus=true

#### Successful run (shows tests summary):
![image](https://user-images.githubusercontent.com/3614196/110863151-d920d180-8285-11eb-964b-2339831e9ed4.png)
