### PR TITLE
fix(aws): Ensure that the cleanup agents are scheduled

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
@@ -229,7 +229,8 @@ public class ProviderHelpers {
       AmazonClientProvider amazonClientProvider,
       AwsCleanupProvider awsCleanupProvider,
       AwsConfiguration.DeployDefaults deployDefaults,
-      AwsConfigurationProperties awsConfigurationProperties) {
+      AwsConfigurationProperties awsConfigurationProperties,
+      boolean hasPreviouslyScheduledCleanupAgents) {
     Set<String> scheduledAccounts = ProviderUtils.getScheduledAccounts(awsCleanupProvider);
     List<Agent> newlyAddedAgents = new ArrayList<>();
     if (!scheduledAccounts.contains(credentials.getName())) {
@@ -241,7 +242,8 @@ public class ProviderHelpers {
         }
       }
     }
-    if (awsCleanupProvider.getAgentScheduler() == null) {
+
+    if (!hasPreviouslyScheduledCleanupAgents) {
       if (awsConfigurationProperties.getCleanup().getAlarms().getEnabled()) {
         newlyAddedAgents.add(
             new CleanupAlarmsAgent(

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsLifecycleHandler.java
@@ -82,6 +82,7 @@ public class AmazonCredentialsLifecycleHandler
   protected Set<String> publicRegions = new HashSet<>();
   protected Set<String> awsInfraRegions = new HashSet<>();
   protected boolean reservationReportCachingAgentScheduled = false;
+  protected boolean hasPreviouslyScheduledCleanupAgents = false;
 
   @Override
   public void credentialsAdded(@NotNull NetflixAmazonCredentials credentials) {
@@ -201,9 +202,17 @@ public class AmazonCredentialsLifecycleHandler
             amazonClientProvider,
             awsCleanupProvider,
             deployDefaults,
-            awsConfigurationProperties);
+            awsConfigurationProperties,
+            hasPreviouslyScheduledCleanupAgents);
 
     awsCleanupProvider.addAgents(newlyAddedAgents);
+
+    log.info(
+        "The following cleanup agents have been added: {} (awsCleanupProvider.getAgentScheduler: {})",
+        newlyAddedAgents,
+        awsCleanupProvider.getAgentScheduler());
+
+    hasPreviouslyScheduledCleanupAgents = true;
   }
 
   private void scheduleReservationReportCachingAgent() {


### PR DESCRIPTION
Due to (potential) changes in bean ordering, `awsCleanupProvider.getAgentScheduler()`
may not always belonger null.

In these cases, `CleanupAlarmsAgent` and `CleanupDetachedInstancesAgent` would
not be added to the `AwsCleanupProvider`.
