### PR TITLE
feat(cats): Support for overriding the full cache eviction protection on a per-provider basis

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/SqlProviderRegistry.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/SqlProviderRegistry.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.NamedCacheFactory
 import com.netflix.spinnaker.cats.provider.Provider
 import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.cats.provider.ProviderCacheConfiguration
 import com.netflix.spinnaker.cats.provider.ProviderRegistry
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.contracts.ExperimentalContracts
@@ -17,7 +18,11 @@ class SqlProviderRegistry(
 
   init {
     providerList.forEach {
-      providerCaches[it.providerName] = SqlProviderCache(cacheFactory.getCache(it.providerName))
+      if (it is ProviderCacheConfiguration) {
+        providerCaches[it.providerName] = SqlProviderCache(cacheFactory.getCache(it.providerName, it))
+      } else {
+        providerCaches[it.providerName] = SqlProviderCache(cacheFactory.getCache(it.providerName))
+      }
     }
   }
 

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNamedCacheFactory.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNamedCacheFactory.kt
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.cats.sql.cache
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.NamedCacheFactory
 import com.netflix.spinnaker.cats.cache.WriteableCache
+import com.netflix.spinnaker.cats.provider.ProviderCacheConfiguration
 import com.netflix.spinnaker.config.SqlConstraints
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
@@ -25,6 +26,11 @@ class SqlNamedCacheFactory(
 
   @ExperimentalContracts
   override fun getCache(name: String): WriteableCache {
+    return getCache(name, DefaultProviderCacheConfiguration())
+  }
+
+  @ExperimentalContracts
+  override fun getCache(name: String, providerCacheConfiguration: ProviderCacheConfiguration): WriteableCache {
     return SqlCache(
       name,
       jooq,
@@ -35,7 +41,10 @@ class SqlNamedCacheFactory(
       prefix,
       cacheMetrics,
       dynamicConfigService,
-      sqlConstraints
+      sqlConstraints,
+      providerCacheConfiguration
     )
   }
+
+  class DefaultProviderCacheConfiguration : ProviderCacheConfiguration
 }

--- a/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/PostgreSqlCacheSpec.groovy
+++ b/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/PostgreSqlCacheSpec.groovy
@@ -57,7 +57,8 @@ class PostgreSqlCacheSpec extends SqlCacheSpec {
       "test",
       Mock(SqlCacheMetrics),
       dynamicConfigService,
-      new SqlConstraintsInitializer().getDefaultSqlConstraints(SQLDialect.POSTGRES)
+      new SqlConstraintsInitializer().getDefaultSqlConstraints(SQLDialect.POSTGRES),
+      new StaticProviderCacheConfiguration(supportsFullEviction: false)
     )
   }
 

--- a/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/SqlProviderCacheSpec.groovy
+++ b/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/SqlProviderCacheSpec.groovy
@@ -10,6 +10,7 @@ import com.netflix.spinnaker.cats.cache.WriteableCache
 import com.netflix.spinnaker.cats.provider.ProviderCacheSpec
 import com.netflix.spinnaker.cats.sql.cache.SpectatorSqlCacheMetrics
 import com.netflix.spinnaker.cats.sql.cache.SqlCache
+import com.netflix.spinnaker.cats.sql.cache.SqlNamedCacheFactory
 import com.netflix.spinnaker.config.SqlConstraintsInitializer
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
@@ -70,7 +71,8 @@ class SqlProviderCacheSpec extends ProviderCacheSpec {
       "test",
       sqlMetrics,
       dynamicConfigService,
-      new SqlConstraintsInitializer().getDefaultSqlConstraints(SQLDialect.MYSQL)
+      new SqlConstraintsInitializer().getDefaultSqlConstraints(SQLDialect.MYSQL),
+      new SqlNamedCacheFactory.DefaultProviderCacheConfiguration()
     )
 
     return new SqlProviderCache(backingStore)

--- a/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/StaticProviderCacheConfiguration.groovy
+++ b/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/StaticProviderCacheConfiguration.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.cats.cache;
+package com.netflix.spinnaker.cats.sql
 
 import com.netflix.spinnaker.cats.provider.ProviderCacheConfiguration;
 
-/** Produces writeable caches by name. */
-public interface NamedCacheFactory {
-  WriteableCache getCache(String name);
+class StaticProviderCacheConfiguration implements ProviderCacheConfiguration {
+  boolean supportsFullEviction = false
 
-  default WriteableCache getCache(
-      String name, ProviderCacheConfiguration providerCacheConfiguration) {
-    // not all caches support per-provider configuration
-    return getCache(name);
+  @Override
+  boolean supportsFullEviction() {
+    return supportsFullEviction
   }
 }

--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/cats/provider/ProviderCacheConfiguration.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/cats/provider/ProviderCacheConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.cats.provider;
+
+/** Allows cache configuration to be overridden per-provider. */
+public interface ProviderCacheConfiguration {
+  /**
+   * By default a safe guard exists preventing removal of the last cached resource, even if it no
+   * longer exists in the underlying provider.
+   *
+   * <p>This allows a provider to opt out of this safe guard and allow full cache eviction.
+   *
+   * @return true if provider cache should support full eviction, false otherwise.
+   */
+  default boolean supportsFullEviction() {
+    return false;
+  }
+}


### PR DESCRIPTION
Allows for a provider to opt out of the default protection and allow a previously populated
collection to be emptied.
