### PR TITLE
fix(aws): User input in cloneServerGroup is being overidden

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -170,6 +170,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
           instanceMonitoring = launchTemplateData.monitoring?.enabled
           spotPrice = launchTemplateData.instanceMarketOptions?.spotOptions?.maxPrice
           newDescription.requireIMDSv2 = description.requireIMDSv2 != null ? description.requireIMDSv2 : launchTemplateData.metadataOptions?.httpTokens == "required"
+          newDescription.associateIPv6Address = description.associateIPv6Address 
           if (!launchTemplateData.networkInterfaces?.empty && launchTemplateData.networkInterfaces*.associatePublicIpAddress?.any()) {
             associatePublicIpAddress = true
           }
@@ -178,7 +179,9 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
             def networkInterface = launchTemplateData.networkInterfaces.find({it.deviceIndex == 0 })
             if (networkInterface != null) {
               securityGroups = networkInterface.groups
-              newDescription.associateIPv6Address = networkInterface.getIpv6AddressCount() > 0 ? true : false
+              if (description.associateIPv6Address == null) {
+                newDescription.associateIPv6Address = networkInterface.getIpv6AddressCount() > 0 ? true : false
+              }
             }
           }
 


### PR DESCRIPTION
**Steps to reproduce:** 
- previous ASG has an ipv6 address
- user sets `associateIPv6Address` to `false` in the UI, then clones the ASG manually
- new ASG still has an IPv6 address

**Cause:**
The `CopyLastAsgAtomicOperation` is only looking at the network interfaces, not the presence of the user-supplied flag (`assocaiteIPv6Address`). This causes the ipv6 to be copied from the network interface even if the user says otherwise.

**Solution**
Copy `associateIPv6Address` to the new asg description. If it is not explicitly `true` or `false` (aka not supplied by the user), then look to the network interface to copy the previous setting. 