### PR TITLE
fix(aws): updateLaunchTemplate wasn't including security groups from the previous version

### DIFF
--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyServerGroupLaunchTemplateAtomicOperation.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyServerGroupLaunchTemplateAtomicOperation.java
@@ -58,6 +58,11 @@ public class ModifyServerGroupLaunchTemplateAtomicOperation
   }
 
   public static class LaunchTemplateException extends IntegrationException {
+    public LaunchTemplateException(String message) {
+      super(message);
+      setRetryable(true);
+    }
+
     public LaunchTemplateException(String message, Throwable cause) {
       super(message, cause);
       setRetryable(true);


### PR DESCRIPTION
There are two cases where we want to include previous version groups
1. The securityGroupsAppendOnly is explicitly set to true
2. The securityGroupsAppendOnly is not set to false and the payload doesn't include any security groups

Also includes a fixup around imageId resolution to fix an IDE warning (deferencing and Optional without
checking if it was present) that resulted in deleting some unused code.