### PR TITLE
feat(s3): add signerOverride config option

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactAccount.java
@@ -33,6 +33,7 @@ public class S3ArtifactAccount implements ArtifactAccount {
   private final String region;
   private final String awsAccessKeyId;
   private final String awsSecretAccessKey;
+  private final String signerOverride;
 
   @Builder
   @ConstructorBinding
@@ -43,12 +44,14 @@ public class S3ArtifactAccount implements ArtifactAccount {
       String apiRegion,
       String region,
       String awsAccessKeyId,
-      String awsSecretAccessKey) {
+      String awsSecretAccessKey,
+      String signerOverride) {
     this.name = Strings.nullToEmpty(name);
     this.apiEndpoint = Strings.nullToEmpty(apiEndpoint);
     this.apiRegion = Strings.nullToEmpty(apiRegion);
     this.region = Strings.nullToEmpty(region);
     this.awsAccessKeyId = Strings.nullToEmpty(awsAccessKeyId);
     this.awsSecretAccessKey = Strings.nullToEmpty(awsSecretAccessKey);
+    this.signerOverride = Strings.nullToEmpty(signerOverride);
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactCredentials.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.s3;
 
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.PredefinedClientConfigurations;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
@@ -42,6 +44,7 @@ public class S3ArtifactCredentials implements ArtifactCredentials {
   private final String region;
   private final String awsAccessKeyId;
   private final String awsSecretAccessKey;
+  private final String signerOverride;
 
   S3ArtifactCredentials(S3ArtifactAccount account) throws IllegalArgumentException {
     name = account.getName();
@@ -50,11 +53,16 @@ public class S3ArtifactCredentials implements ArtifactCredentials {
     region = account.getRegion();
     awsAccessKeyId = account.getAwsAccessKeyId();
     awsSecretAccessKey = account.getAwsSecretAccessKey();
+    signerOverride = account.getSignerOverride();
   }
 
   private AmazonS3 getS3Client() {
     AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
-
+    if (!signerOverride.isEmpty()) {
+      ClientConfiguration configuration = PredefinedClientConfigurations.defaultConfig();
+      configuration.setSignerOverride(signerOverride);
+      builder.setClientConfiguration(configuration);
+    }
     if (!apiEndpoint.isEmpty()) {
       AwsClientBuilder.EndpointConfiguration endpoint =
           new AwsClientBuilder.EndpointConfiguration(apiEndpoint, apiRegion);


### PR DESCRIPTION
Allow users to override the S3 signer algorithm if they can't use the default. They can set the AWS client to use a different algorithm in their profile yaml:
```artifacts:
  s3:
    enabled: true
    accounts:
    - name: s3
      signerOverride: S3SignerType
```
The AWS SDK validates the algorithm passed in and will throw an exception if the user tries to configure one that doesn't exist:
```
Caused by: java.lang.IllegalArgumentException: unknown signer type: NotARealType
        at com.amazonaws.auth.SignerFactory.createSigner(SignerFactory.java:131) ~[aws-java-sdk-core-1.11.934.jar:na]
        at com.amazonaws.auth.SignerFactory.getSignerByTypeAndService(SignerFactory.java:104) ~[aws-java-sdk-core-1.11.934.jar:na]
        at com.amazonaws.AmazonWebServiceClient.computeSignerByServiceRegion(AmazonWebServiceClient.java:459) ~[aws-java-sdk-core-1.11.934.jar:na]
        at com.amazonaws.AmazonWebServiceClient.computeSignerByURI(AmazonWebServiceClient.java:430) ~[aws-java-sdk-core-1.11.934.jar:na]
        at com.amazonaws.AmazonWebServiceClient.setEndpoint(AmazonWebServiceClient.java:318) ~[aws-java-sdk-core-1.11.934.jar:na]
        at com.amazonaws.services.s3.AmazonS3Client.setEndpoint(AmazonS3Client.java:750) ~[aws-java-sdk-s3-1.11.934.jar:na]
        at com.amazonaws.services.s3.AmazonS3Client.init(AmazonS3Client.java:731) ~[aws-java-sdk-s3-1.11.934.jar:na]
        at com.amazonaws.services.s3.AmazonS3Client.<init>(AmazonS3Client.java:653) ~[aws-java-sdk-s3-1.11.934.jar:na]
        at com.amazonaws.services.s3.AmazonS3Client.<init>(AmazonS3Client.java:629) ~[aws-java-sdk-s3-1.11.934.jar:na]
        at com.amazonaws.services.s3.AmazonS3Client.<init>(AmazonS3Client.java:607) ~[aws-java-sdk-s3-1.11.934.jar:na]
...
```