### PR TITLE
feat(kubernetes): remove kubernetes.jobs.append-suffix flag and logic…

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/job/KubernetesRunJobOperationConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/job/KubernetesRunJobOperationConverter.java
@@ -30,7 +30,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsConverter;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @KubernetesOperation(RUN_JOB)
@@ -38,21 +37,16 @@ import org.springframework.stereotype.Component;
 public class KubernetesRunJobOperationConverter
     extends AbstractAtomicOperationsCredentialsConverter<KubernetesNamedAccountCredentials> {
   private final ResourceVersioner resourceVersioner;
-  private final boolean appendSuffix;
 
   @Autowired
-  public KubernetesRunJobOperationConverter(
-      ResourceVersioner resourceVersioner,
-      @Value("${kubernetes.jobs.append-suffix:false}") boolean appendSuffix) {
+  public KubernetesRunJobOperationConverter(ResourceVersioner resourceVersioner) {
     this.resourceVersioner = resourceVersioner;
-    this.appendSuffix = appendSuffix;
   }
 
   @Override
   public AtomicOperation<KubernetesRunJobDeploymentResult> convertOperation(
       Map<String, Object> input) {
-    return new KubernetesRunJobOperation(
-        convertDescription(input), resourceVersioner, appendSuffix);
+    return new KubernetesRunJobOperation(convertDescription(input), resourceVersioner);
   }
 
   @Override

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
@@ -50,8 +50,6 @@ import com.netflix.spinnaker.moniker.Namer;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
@@ -74,50 +72,28 @@ final class KubernetesRunJobOperationTest {
   @Test
   void deploysJobWithName() {
     KubernetesRunJobOperationDescription runJobDescription = baseJobDescription("job.yml");
-    OperationResult result = operate(runJobDescription, false);
+    OperationResult result = operate(runJobDescription);
 
     assertThat(result.getManifestNamesByNamespace()).containsOnlyKeys(NAMESPACE);
     assertThat(result.getManifestNamesByNamespace().get(NAMESPACE))
         .containsExactlyInAnyOrder(DEPLOYED_JOB);
   }
 
-  @Test
-  void deploysJobWithNameAndAddsSuffix() {
-    KubernetesRunJobOperationDescription runJobDescription = baseJobDescription("job.yml");
-    OperationResult result = operate(runJobDescription, true);
-
-    assertThat(result.getManifestNamesByNamespace()).containsOnlyKeys(NAMESPACE);
-    assertThat(result.getManifestNamesByNamespace().get(NAMESPACE)).hasSize(1);
-    String job =
-        Iterators.getOnlyElement(result.getManifestNamesByNamespace().get(NAMESPACE).iterator());
-    assertThat(job).startsWith(DEPLOYED_JOB);
-    String suffix = job.substring(DEPLOYED_JOB.length());
-    assertThat(suffix).startsWith("-");
-    // We're asserting that at least 4 characters are added after the hyphen; rather than
-    // overspecify the test by looking up exactly how many are added, we're just making sure that a
-    // reasonable number to guarantee randomness are added.
-    assertThat(suffix.length()).isGreaterThanOrEqualTo(5);
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void deploysJobWithGenerateName(boolean appendSuffix) {
+  void deploysJobWithGenerateName() {
     KubernetesRunJobOperationDescription runJobDescription =
         baseJobDescription("job-generate-name.yml");
-    OperationResult result = operate(runJobDescription, appendSuffix);
+    OperationResult result = operate(runJobDescription);
 
     assertThat(result.getManifestNamesByNamespace()).containsOnlyKeys(NAMESPACE);
     assertThat(result.getManifestNamesByNamespace().get(NAMESPACE))
         .containsExactlyInAnyOrder(DEPLOYED_JOB + GENERATE_SUFFIX);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void overridesNamespace(boolean appendSuffix) {
+  void overridesNamespace() {
     String overrideNamespace = "override-namespace";
     KubernetesRunJobOperationDescription runJobDescription =
         baseJobDescription("job.yml").setNamespace(overrideNamespace);
-    OperationResult result = operate(runJobDescription, appendSuffix);
+    OperationResult result = operate(runJobDescription);
 
     assertThat(result.getManifestNamesByNamespace()).containsOnlyKeys(overrideNamespace);
     assertThat(result.getManifestNamesByNamespace().get(overrideNamespace)).hasSize(1);
@@ -192,8 +168,7 @@ final class KubernetesRunJobOperationTest {
     return credentialsMock;
   }
 
-  private static OperationResult operate(
-      KubernetesRunJobOperationDescription description, boolean appendSuffix) {
+  private static OperationResult operate(KubernetesRunJobOperationDescription description) {
     ArtifactProvider artifactProvider = mock(ArtifactProvider.class);
     when(artifactProvider.getArtifacts(
             any(KubernetesKind.class),
@@ -202,7 +177,7 @@ final class KubernetesRunJobOperationTest {
             any(KubernetesCredentials.class)))
         .thenReturn(ImmutableList.of());
     ResourceVersioner resourceVersioner = new ResourceVersioner(artifactProvider);
-    return new KubernetesRunJobOperation(description, resourceVersioner, appendSuffix)
+    return new KubernetesRunJobOperation(description, resourceVersioner)
         .operate(ImmutableList.of());
   }
 }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
@@ -79,6 +79,7 @@ final class KubernetesRunJobOperationTest {
         .containsExactlyInAnyOrder(DEPLOYED_JOB);
   }
 
+  @Test
   void deploysJobWithGenerateName() {
     KubernetesRunJobOperationDescription runJobDescription =
         baseJobDescription("job-generate-name.yml");
@@ -89,6 +90,7 @@ final class KubernetesRunJobOperationTest {
         .containsExactlyInAnyOrder(DEPLOYED_JOB + GENERATE_SUFFIX);
   }
 
+  @Test
   void overridesNamespace() {
     String overrideNamespace = "override-namespace";
     KubernetesRunJobOperationDescription runJobDescription =


### PR DESCRIPTION
… to append a suffix to jobs

This is a follow-up to
https://spinnaker.io/community/releases/versions/1-22-0-changelog#breaking-change-suffix-no-longer-added-to-jobs-created-by-kuber
and simplifies the code enough to facilitate documentation of the behavior at
https://spinnaker.io/guides/user/kubernetes-v2/run-job-manifest/#cleaning-up-old-jobs.

Documentation PR [here](https://github.com/spinnaker/spinnaker.github.io/pull/2155)