### PR TITLE
feat(cloudfoundry): add support for manifest processes

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Processes.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Processes.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client;
 
+import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClientUtils.collectPages;
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClientUtils.safelyCall;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.api.ProcessesService;
@@ -24,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessSta
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ScaleProcess;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.UpdateProcess;
 import groovy.util.logging.Slf4j;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,14 @@ import lombok.RequiredArgsConstructor;
 public class Processes {
 
   private final ProcessesService api;
+
+  public List<Process> getAllProcessesByAppId(String appGuid) {
+    if (appGuid == null || appGuid.isEmpty()) {
+      throw new IllegalArgumentException(
+          "An application guid must be provided in order to return processes by app.");
+    }
+    return collectPages("processes", page -> api.getProcesses(page, appGuid));
+  }
 
   public void scaleProcess(
       String guid,

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ProcessesService.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ProcessesService.java
@@ -16,8 +16,11 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.api;
 
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.*;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Pagination;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Process;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessResources;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ScaleProcess;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.UpdateProcess;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.*;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ProcessesService.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ProcessesService.java
@@ -16,15 +16,17 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.api;
 
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.*;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Process;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessResources;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ScaleProcess;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.UpdateProcess;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.*;
 
 public interface ProcessesService {
+
+  @GET("/v3/processes")
+  Call<Pagination<Process>> getProcesses(
+      @Query("page") Integer page, @Query("app_guids") String appGuids);
 
   @POST("/v3/processes/{guid}/actions/scale")
   Call<ResponseBody> scaleProcess(@Path("guid") String guid, @Body ScaleProcess scaleProcess);

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/ProcessRequest.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/ProcessRequest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Pivotal, Inc.
+ * Copyright 2021 Armory, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,32 +17,20 @@
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3;
 
 import javax.annotation.Nullable;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
-public class Process {
-  private String type;
-  private String guid;
-  private int instances;
-  private int memoryInMb;
-  private int diskInMb;
-
-  @Nullable private HealthCheck healthCheck;
-
-  @Data
-  public static class HealthCheck {
-    @Nullable private String type;
-
-    @Nullable private HealthCheckData data;
-  }
-
-  @Data
-  public static class HealthCheckData {
-
-    @Nullable private String endpoint;
-
-    @Nullable private Integer timeout;
-
-    @Nullable private Integer invocationTimeout;
-  }
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProcessRequest {
+  @Nullable private String type;
+  @Nullable private String command;
+  @Nullable private String diskQuota;
+  @Nullable private String healthCheckType;
+  @Nullable private String healthCheckHttpEndpoint;
+  @Nullable private Integer healthCheckInvocationTimeout;
+  @Nullable private Integer instances;
+  @Nullable private String memory;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryOperation;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.artifacts.CloudFoundryArtifactCredentials;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Docker;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessRequest;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeployCloudFoundryServerGroupDescription;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops.DeployCloudFoundryServerGroupAtomicOperation;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.security.CloudFoundryCredentials;
@@ -181,6 +182,7 @@ public class DeployCloudFoundryServerGroupAtomicOperationConverter
               attrs.setEnv(app.getEnv());
               attrs.setStack(app.getStack());
               attrs.setCommand(app.getCommand());
+              attrs.setProcesses(app.getProcesses());
               return attrs;
             })
         .get();
@@ -213,5 +215,7 @@ public class DeployCloudFoundryServerGroupAtomicOperationConverter
     @Nullable private String stack;
 
     @Nullable private String command;
+
+    private List<ProcessRequest> processes = Collections.emptyList();
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServerGroupDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServerGroupDescription.java
@@ -19,8 +19,10 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Docker;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessRequest;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -69,5 +71,7 @@ public class DeployCloudFoundryServerGroupDescription
     @Nullable private String stack;
 
     @Nullable private String command;
+
+    private List<ProcessRequest> processes = Collections.emptyList();
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -485,15 +485,7 @@ public class DeployCloudFoundryServerGroupAtomicOperation
       List<Process> processes = client.getProcesses().getAllProcessesByAppId(serverGroupId);
 
       for (ProcessRequest req : description.getApplicationAttributes().getProcesses()) {
-        String processGuid =
-            processes.stream()
-                .filter(p -> p.getType().equalsIgnoreCase(req.getType()))
-                .map(p -> p.getGuid())
-                .findFirst()
-                .orElseThrow(
-                    () ->
-                        new CloudFoundryApiException(
-                            "Unable to find a process with type: " + req.getType()));
+        String processGuid = getProcessGuidByType(processes, req.getType());
 
         Integer pMemoryAmount = convertToMb("memory", req.getMemory());
         Integer pDiskSizeAmount = convertToMb("disk quota", req.getDiskQuota());
@@ -522,15 +514,7 @@ public class DeployCloudFoundryServerGroupAtomicOperation
       List<Process> processes = client.getProcesses().getAllProcessesByAppId(serverGroupId);
 
       for (ProcessRequest req : description.getApplicationAttributes().getProcesses()) {
-        String processGuid =
-            processes.stream()
-                .filter(p -> p.getType().equalsIgnoreCase(req.getType()))
-                .map(p -> p.getGuid())
-                .findFirst()
-                .orElseThrow(
-                    () ->
-                        new CloudFoundryApiException(
-                            "Unable to find a process with type: " + req.getType()));
+        String processGuid = getProcessGuidByType(processes, req.getType());
 
         client
             .getProcesses()
@@ -562,5 +546,15 @@ public class DeployCloudFoundryServerGroupAtomicOperation
 
     throw new IllegalArgumentException(
         "Invalid size for application " + field + " = '" + size + "'");
+  }
+
+  // Helper method for filtering and returning a process guid by type
+  private String getProcessGuidByType(List<Process> processes, String type) {
+    return processes.stream()
+        .filter(p -> p.getType().equalsIgnoreCase(type))
+        .map(p -> p.getGuid())
+        .findFirst()
+        .orElseThrow(
+            () -> new CloudFoundryApiException("Unable to find a process with type: " + type));
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.clouddriver.cloudfoundry.artifacts.ArtifactCredenti
 import com.netflix.spinnaker.clouddriver.cloudfoundry.cache.CacheRepository;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.MockCloudFoundryClient;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessRequest;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeployCloudFoundryServerGroupDescription;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryOrganization;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
@@ -174,7 +175,8 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
                 .setServices(List.of("service1"))
                 .setRoutes(List.of("www.example.com/foo"))
                 .setEnv(Map.of("token", "ASDF"))
-                .setCommand("some-command"));
+                .setCommand("some-command")
+                .setProcesses(emptyList()));
   }
 
   @Test
@@ -187,7 +189,8 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
                 .setInstances(1)
                 .setMemory("1024")
                 .setDiskQuota("1024")
-                .setBuildpacks(List.of("buildpack1")));
+                .setBuildpacks(List.of("buildpack1"))
+                .setProcesses(emptyList()));
   }
 
   @Test
@@ -200,7 +203,8 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
                 .setInstances(1)
                 .setMemory("1024")
                 .setDiskQuota("1024")
-                .setBuildpacks(Collections.emptyList()));
+                .setBuildpacks(Collections.emptyList())
+                .setProcesses(emptyList()));
   }
 
   @Test
@@ -213,7 +217,8 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
                 .setInstances(1)
                 .setMemory("1024")
                 .setDiskQuota("1024")
-                .setBuildpacks(Collections.emptyList()));
+                .setBuildpacks(Collections.emptyList())
+                .setProcesses(emptyList()));
   }
 
   @Test
@@ -244,5 +249,28 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
     assertThat(result.getApplicationArtifact().getArtifactAccount())
         .isEqualTo("destinationAccount");
     assertThat(result.getApplicationArtifact().getUuid()).isEqualTo("servergroup-id");
+  }
+
+  @Test
+  void convertDescriptionWithProcesses() {
+    final Map input =
+        Map.of(
+            "applications",
+            List.of(
+                Map.of(
+                    "processes",
+                    List.of(
+                        new ProcessRequest().setType("web").setInstances(2).setMemory("800M")))));
+
+    assertThat(converter.convertManifest(input))
+        .isEqualToComparingFieldByFieldRecursively(
+            new DeployCloudFoundryServerGroupDescription.ApplicationAttributes()
+                .setInstances(1)
+                .setMemory("1024")
+                .setDiskQuota("1024")
+                .setBuildpacks(Collections.emptyList())
+                .setProcesses(
+                    List.of(
+                        new ProcessRequest().setType("web").setInstances(2).setMemory("800M"))));
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
@@ -192,8 +192,8 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
     inOrder.verify(apps).buildCompleted(any());
     inOrder.verify(apps).findDropletGuidFromBuildId(any());
     inOrder.verify(apps).setCurrentDroplet(any(), any());
-    inOrder.verify(processes).scaleProcess(any(), any(), any(), any());
     inOrder.verify(processes).updateProcess("serverGroupId", null, "http", "/health");
+    inOrder.verify(processes).scaleProcess(any(), any(), any(), any());
     inOrder.verify(apps, calls.get()).startApplication("serverGroupId");
   }
 
@@ -207,8 +207,8 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
     inOrder.verify(apps).createPackage(any());
     inOrder.verify(cloudFoundryClient.getServiceInstances()).createServiceBinding(any());
     inOrder.verify(apps).createBuild(any());
-    inOrder.verify(processes).scaleProcess("serverGroupId", 7, 1024, 2048);
     inOrder.verify(processes).updateProcess("serverGroupId", null, "http", "/health");
+    inOrder.verify(processes).scaleProcess("serverGroupId", 7, 1024, 2048);
     inOrder.verify(apps, calls.get()).startApplication("serverGroupId");
   }
 


### PR DESCRIPTION
This features supports processes which can be defined in cloud foundry manifests. For more information about processes see [here](https://docs.cloudfoundry.org/devguide/multiple-processes.html#about-processes). Buildpacks typically define the processes for an application however a Procfile can also be used to define these processes and their starting commands. See [here](https://docs.cloudfoundry.org/devguide/multiple-processes.html#push-with-multiple-processes) for more information regarding Procfiles and processes. 