### PR TITLE
fix(kube/test): Separate namespaces for accounts in tests

### DIFF
--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/BaseTest.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/BaseTest.java
@@ -44,7 +44,7 @@ public abstract class BaseTest {
   public static final KubernetesCluster kubeCluster;
 
   static {
-    kubeCluster = KubernetesCluster.getInstance(ACCOUNT1_NAME);
+    kubeCluster = KubernetesCluster.getInstance();
     kubeCluster.start();
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
   }

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/InfrastructureIT.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/InfrastructureIT.java
@@ -36,6 +36,8 @@ public class InfrastructureIT extends BaseTest {
 
   private static final int CACHE_TIMEOUT_MIN = 5;
   private static final String DEPLOYMENT_1_NAME = "deployment1";
+  private static final String NETWORK_POLICY_1_NAME = "default-deny-ingress";
+  private static final String NETWORK_POLICY_2_NAME = "default-deny-ingress-second";
   private static final String SERVICE_1_NAME = "service1";
   private static String account1Ns;
   private static String account2Ns;
@@ -887,5 +889,419 @@ public class InfrastructureIT extends BaseTest {
             + " minutes for GET /applications/"
             + appName
             + "/rawResources to return valid data");
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given two kubernetes network policies\n"
+          + "When sending get securityGroups\n"
+          + "Then response should contain two lists with the security group for each\n===")
+  @Test
+  public void shouldListSecurityGroups() throws InterruptedException, IOException {
+    // ------------------------- given --------------------------
+
+    String appName = "getmanifest";
+    System.out.println("> Using namespace " + account1Ns + " and " + account2Ns);
+
+    KubeTestUtils.deployIfMissing(
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "networkPolicy",
+        NETWORK_POLICY_1_NAME,
+        appName,
+        kubeCluster);
+    KubeTestUtils.deployIfMissing(
+        baseUrl(),
+        ACCOUNT2_NAME,
+        account2Ns,
+        "networkPolicy",
+        NETWORK_POLICY_1_NAME,
+        appName,
+        kubeCluster);
+
+    KubeTestUtils.repeatUntilTrue(
+        () -> {
+          // ------------------------- when --------------------------
+          System.out.println("> Sending get securityGroups request");
+          Response resp = get(baseUrl() + "/securityGroups");
+
+          // ------------------------- then --------------------------
+          System.out.println(resp.asString());
+
+          resp.then().statusCode(200);
+          List<Object> list1 = resp.jsonPath().getList(ACCOUNT1_NAME + ".kubernetes." + account1Ns);
+          List<Object> list2 = resp.jsonPath().getList(ACCOUNT2_NAME + ".kubernetes." + account2Ns);
+          return list1 != null && !list1.isEmpty() && list2 != null && !list2.isEmpty();
+        },
+        CACHE_TIMEOUT_MIN,
+        TimeUnit.MINUTES,
+        "Waited "
+            + CACHE_TIMEOUT_MIN
+            + " minutes for GET /securityGroups"
+            + " to return valid data");
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given two kubernetes network policies for one account\n"
+          + "When sending get securityGroups/{account}\n"
+          + "Then response should contain a list with security groups of size 2\n===")
+  @Test
+  public void shouldListSecurityGroupsByAccount() throws InterruptedException, IOException {
+    // ------------------------- given --------------------------
+
+    String appName = "getmanifest";
+    System.out.println("> Using namespace " + account1Ns);
+
+    KubeTestUtils.deployIfMissing(
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "networkPolicy",
+        NETWORK_POLICY_1_NAME,
+        appName,
+        kubeCluster);
+    KubeTestUtils.deployIfMissing(
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "networkPolicy",
+        NETWORK_POLICY_2_NAME,
+        appName,
+        kubeCluster);
+
+    KubeTestUtils.repeatUntilTrue(
+        () -> {
+          // ------------------------- when --------------------------
+          System.out.println("> Sending get securityGroups request");
+          Response resp = get(baseUrl() + "/securityGroups/" + ACCOUNT1_NAME);
+
+          // ------------------------- then --------------------------
+          System.out.println(resp.asString());
+          if (resp.statusCode() == 404) {
+            return false;
+          }
+          resp.then().statusCode(200);
+          List<Object> securityGroupList = resp.jsonPath().getList("kubernetes." + account1Ns);
+          return securityGroupList != null && securityGroupList.size() == 2;
+        },
+        CACHE_TIMEOUT_MIN,
+        TimeUnit.MINUTES,
+        "Waited "
+            + CACHE_TIMEOUT_MIN
+            + " minutes for GET /securityGroups/"
+            + ACCOUNT1_NAME
+            + " to return valid data");
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given two kubernetes network policies for different namespaces\n"
+          + "When sending get securityGroups/{account}?region={region}\n"
+          + "Then response should contain a list with security groups of size 1\n===")
+  @Test
+  public void shouldListSecurityGroupsByAccountAndRegion()
+      throws InterruptedException, IOException {
+    // ------------------------- given --------------------------
+
+    String appName = "getmanifest";
+    System.out.println("> Using namespace " + account1Ns);
+
+    KubeTestUtils.deployIfMissing(
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "networkPolicy",
+        NETWORK_POLICY_1_NAME,
+        appName,
+        kubeCluster);
+    KubeTestUtils.deployIfMissing(
+        baseUrl(),
+        ACCOUNT2_NAME,
+        account2Ns,
+        "networkPolicy",
+        NETWORK_POLICY_2_NAME,
+        appName,
+        kubeCluster);
+
+    KubeTestUtils.repeatUntilTrue(
+        () -> {
+          // ------------------------- when --------------------------
+          System.out.println("> Sending get securityGroups request");
+          Response resp =
+              get(baseUrl() + "/securityGroups/" + ACCOUNT1_NAME + "?region=" + account1Ns);
+
+          // ------------------------- then --------------------------
+          System.out.println(resp.asString());
+          if (resp.statusCode() == 404) {
+            return false;
+          }
+          resp.then().statusCode(200);
+          List<Object> securityGroupList = resp.jsonPath().getList("kubernetes." + account1Ns);
+          return securityGroupList != null && securityGroupList.size() == 1;
+        },
+        CACHE_TIMEOUT_MIN,
+        TimeUnit.MINUTES,
+        "Waited "
+            + CACHE_TIMEOUT_MIN
+            + " minutes for GET /securityGroups/"
+            + ACCOUNT1_NAME
+            + "?region="
+            + account1Ns
+            + " to return valid data");
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given a kubernetes network policies for one account\n"
+          + "When sending get securityGroups/{account}/{cloudprovider}\n"
+          + "Then response should contain the securityGroup\n===")
+  @Test
+  public void shouldListSecurityGroupsByAccountAndCloudProvider()
+      throws InterruptedException, IOException {
+    // ------------------------- given --------------------------
+
+    String appName = "getmanifest";
+    System.out.println("> Using namespace " + account1Ns);
+
+    KubeTestUtils.deployIfMissing(
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "networkPolicy",
+        NETWORK_POLICY_1_NAME,
+        appName,
+        kubeCluster);
+    ;
+
+    KubeTestUtils.repeatUntilTrue(
+        () -> {
+          // ------------------------- when --------------------------
+          System.out.println("> Sending get securityGroups request");
+          Response resp = get(baseUrl() + "/securityGroups/" + ACCOUNT1_NAME + "/kubernetes");
+
+          // ------------------------- then --------------------------
+          System.out.println(resp.asString());
+          if (resp.statusCode() == 404) {
+            return false;
+          }
+          resp.then().statusCode(200);
+          List<Object> securityGroupList = resp.jsonPath().getList(account1Ns);
+          return securityGroupList != null && securityGroupList.size() > 0;
+        },
+        CACHE_TIMEOUT_MIN,
+        TimeUnit.MINUTES,
+        "Waited "
+            + CACHE_TIMEOUT_MIN
+            + " minutes for GET /securityGroups/"
+            + ACCOUNT1_NAME
+            + "/kubernetes"
+            + " to return valid data");
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given two kubernetes network policies for one account\n"
+          + "When sending get securityGroups/{account}/{cloudprovider}/{name}\n"
+          + "Then response should contain the security group specified in name\n===")
+  @Test
+  public void shouldListSecurityGroupsByAccountAndCloudProviderAndName()
+      throws InterruptedException, IOException {
+    // ------------------------- given --------------------------
+    String appName = "getmanifest";
+    System.out.println("> Using namespace " + account1Ns);
+
+    KubeTestUtils.deployIfMissing(
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "networkPolicy",
+        NETWORK_POLICY_1_NAME,
+        appName,
+        kubeCluster);
+    KubeTestUtils.deployIfMissing(
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "networkPolicy",
+        NETWORK_POLICY_2_NAME,
+        appName,
+        kubeCluster);
+
+    KubeTestUtils.repeatUntilTrue(
+        () -> {
+          // ------------------------- when --------------------------
+          System.out.println("> Sending get securityGroups request");
+          Response resp =
+              get(
+                  baseUrl()
+                      + "/securityGroups/"
+                      + ACCOUNT1_NAME
+                      + "/kubernetes/networkpolicy "
+                      + NETWORK_POLICY_1_NAME);
+
+          // ------------------------- then --------------------------
+          System.out.println(resp.asString());
+          if (resp.statusCode() == 404) {
+            return false;
+          }
+          resp.then().statusCode(200);
+          List<Object> securityGroupList = resp.jsonPath().getList(account1Ns);
+          return securityGroupList != null && securityGroupList.size() == 1;
+        },
+        CACHE_TIMEOUT_MIN,
+        TimeUnit.MINUTES,
+        "Waited "
+            + CACHE_TIMEOUT_MIN
+            + " minutes for GET /securityGroups/"
+            + ACCOUNT1_NAME
+            + "/kubernetes/networkpolicy "
+            + NETWORK_POLICY_1_NAME
+            + " to return valid data");
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given a kubernetes network policy for one account\n"
+          + "When sending get securityGroups/{account}/{cloudProvider}/{region}/{securityGroupNameOrId}\n"
+          + "Then response should contain the security group specified in securityGroupNameOrId\n===")
+  @Test
+  public void shouldGetSecurityGroupByAccountAndName() throws InterruptedException, IOException {
+    // ------------------------- given --------------------------
+    String appName = "getmanifest";
+    System.out.println("> Using namespace " + account1Ns);
+
+    KubeTestUtils.deployIfMissing(
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "networkPolicy",
+        NETWORK_POLICY_1_NAME,
+        appName,
+        kubeCluster);
+    KubeTestUtils.repeatUntilTrue(
+        () -> {
+          // ------------------------- when --------------------------
+          System.out.println("> Sending get securityGroups request");
+          Response resp =
+              get(
+                  baseUrl()
+                      + "/securityGroups/"
+                      + ACCOUNT1_NAME
+                      + "/kubernetes/"
+                      + account1Ns
+                      + "/networkolicy "
+                      + NETWORK_POLICY_1_NAME);
+
+          // ------------------------- then --------------------------
+          System.out.println(resp.asString());
+          if (resp.statusCode() == 404) {
+            return false;
+          }
+          resp.then().statusCode(200);
+          var displayName = resp.jsonPath().getString("displayName");
+          return displayName != null && displayName.equals(NETWORK_POLICY_1_NAME);
+        },
+        CACHE_TIMEOUT_MIN,
+        TimeUnit.MINUTES,
+        "Waited "
+            + CACHE_TIMEOUT_MIN
+            + " minutes for GET /securityGroups/"
+            + ACCOUNT1_NAME
+            + "/kubernetes/"
+            + account1Ns
+            + "/networkolicy "
+            + NETWORK_POLICY_1_NAME
+            + " to return valid data");
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given a kubernetes deployments\n"
+          + "When sending get clusters /applications/{appName}/serverGroupManagers\n"
+          + "Then the deployment should be present in serverGroups list of the response\n===")
+  @Test
+  public void shouldGetServerGroupManagerForApplication() throws InterruptedException, IOException {
+    // ------------------------- given --------------------------
+    String appName = "getclusters";
+    System.out.println("> Using namespace " + account1Ns);
+    KubeTestUtils.deployIfMissing(
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "deployment",
+        DEPLOYMENT_1_NAME,
+        appName,
+        kubeCluster);
+
+    KubeTestUtils.repeatUntilTrue(
+        () -> {
+          // ------------------------- when --------------------------
+          System.out.println("> Sending get clusters request");
+          Response resp = get(baseUrl() + "/applications/" + appName + "/serverGroupManagers");
+
+          // ------------------------- then --------------------------
+          System.out.println(resp.asString());
+          if (resp.statusCode() == 404) {
+            return false;
+          }
+          resp.then().statusCode(200);
+          List<Object> serverGroupList = resp.jsonPath().getList("$");
+          return serverGroupList != null && serverGroupList.size() == 1;
+        },
+        CACHE_TIMEOUT_MIN,
+        TimeUnit.MINUTES,
+        "Waited "
+            + CACHE_TIMEOUT_MIN
+            + " minutes for 'deployment "
+            + "deployment"
+            + "' cluster to return from GET /applications/"
+            + appName
+            + "/serverGroupManagers");
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given a kubernetes deployment of one application made by spinnaker\n"
+          + "When sending get /applications/{application} request\n"
+          + "Then an application object should be returned\n===")
+  @Test
+  public void shouldGetApplicationInCluster() throws InterruptedException, IOException {
+    // ------------------------- given --------------------------
+    String appName = "getclusters";
+    System.out.println("> Using namespace " + account1Ns);
+    KubeTestUtils.deployIfMissing(
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "deployment",
+        DEPLOYMENT_1_NAME,
+        appName,
+        kubeCluster);
+
+    KubeTestUtils.repeatUntilTrue(
+        () -> {
+          // ------------------------- when --------------------------
+          System.out.println("> Sending get clusters request");
+          Response resp = get(baseUrl() + "/applications/" + appName);
+
+          // ------------------------- then --------------------------
+          System.out.println(resp.asString());
+          if (resp.statusCode() == 404) {
+            return false;
+          }
+          resp.then().statusCode(200).and();
+          var appNameResp = resp.jsonPath().getString("name");
+          return appNameResp != null && appNameResp.equals(appName);
+        },
+        CACHE_TIMEOUT_MIN,
+        TimeUnit.MINUTES,
+        "Waited "
+            + CACHE_TIMEOUT_MIN
+            + " minutes for 'deployment "
+            + "deployment"
+            + "' cluster to return from GET /applications/"
+            + appName);
   }
 }

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/InfrastructureIT.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/InfrastructureIT.java
@@ -37,11 +37,13 @@ public class InfrastructureIT extends BaseTest {
   private static final int CACHE_TIMEOUT_MIN = 5;
   private static final String DEPLOYMENT_1_NAME = "deployment1";
   private static final String SERVICE_1_NAME = "service1";
-  private static String ns;
+  private static String account1Ns;
+  private static String account2Ns;
 
   @BeforeAll
   public static void setUpAll() throws IOException, InterruptedException {
-    ns = kubeCluster.getAvailableNamespace();
+    account1Ns = kubeCluster.createNamespace(ACCOUNT1_NAME);
+    account2Ns = kubeCluster.createNamespace(ACCOUNT2_NAME);
   }
 
   @DisplayName(
@@ -53,11 +55,23 @@ public class InfrastructureIT extends BaseTest {
   public void shouldGetClusters() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
     String appName = "getclusters";
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, ns, "deployment", DEPLOYMENT_1_NAME, appName, kubeCluster);
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "deployment",
+        DEPLOYMENT_1_NAME,
+        appName,
+        kubeCluster);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT2_NAME, "default", "deployment", DEPLOYMENT_1_NAME, appName, kubeCluster);
+        baseUrl(),
+        ACCOUNT2_NAME,
+        account2Ns,
+        "deployment",
+        DEPLOYMENT_1_NAME,
+        appName,
+        kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
@@ -95,11 +109,23 @@ public class InfrastructureIT extends BaseTest {
   public void shouldGetClustersByAccount() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
     String appName = "getclustersbyaccount";
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, ns, "deployment", DEPLOYMENT_1_NAME, appName, kubeCluster);
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "deployment",
+        DEPLOYMENT_1_NAME,
+        appName,
+        kubeCluster);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT2_NAME, "default", "deployment", DEPLOYMENT_1_NAME, appName, kubeCluster);
+        baseUrl(),
+        ACCOUNT2_NAME,
+        account2Ns,
+        "deployment",
+        DEPLOYMENT_1_NAME,
+        appName,
+        kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
@@ -148,11 +174,17 @@ public class InfrastructureIT extends BaseTest {
   public void shouldGetClustersByAccountAndName() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
     String appName = "getclustersbyaccountandname";
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, ns, "deployment", DEPLOYMENT_1_NAME, appName, kubeCluster);
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "deployment",
+        DEPLOYMENT_1_NAME,
+        appName,
+        kubeCluster);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, ns, "deployment", "other", appName, kubeCluster);
+        baseUrl(), ACCOUNT1_NAME, account1Ns, "deployment", "other", appName, kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
@@ -208,11 +240,11 @@ public class InfrastructureIT extends BaseTest {
   public void shouldGetClustersByAccountNameAndType() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
     String appName = "getclustersbyaccountnametype";
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     KubeTestUtils.deployAndWaitStable(
-        baseUrl(), ACCOUNT1_NAME, ns, "deployment", DEPLOYMENT_1_NAME, appName);
+        baseUrl(), ACCOUNT1_NAME, account1Ns, "deployment", DEPLOYMENT_1_NAME, appName);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, ns, "deployment", "other", appName, kubeCluster);
+        baseUrl(), ACCOUNT1_NAME, account1Ns, "deployment", "other", appName, kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
@@ -260,11 +292,11 @@ public class InfrastructureIT extends BaseTest {
   public void shouldGetServerGroups() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
     String appName = "getservergroups";
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
-        ns,
+        account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
         appName,
@@ -273,7 +305,7 @@ public class InfrastructureIT extends BaseTest {
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
-        ns,
+        account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
         appName,
@@ -295,7 +327,7 @@ public class InfrastructureIT extends BaseTest {
                       "findAll { it.account == '"
                           + ACCOUNT1_NAME
                           + "' && it.region == '"
-                          + ns
+                          + account1Ns
                           + "' && it.cluster == 'deployment "
                           + DEPLOYMENT_1_NAME
                           + "'}");
@@ -317,11 +349,17 @@ public class InfrastructureIT extends BaseTest {
   public void shouldGetServerGroupsForApplications() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
     String appName = "getservergroupsapp";
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, ns, "deployment", DEPLOYMENT_1_NAME, appName, kubeCluster);
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "deployment",
+        DEPLOYMENT_1_NAME,
+        appName,
+        kubeCluster);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, ns, "deployment", "other", APP2_NAME, kubeCluster);
+        baseUrl(), ACCOUNT1_NAME, account1Ns, "deployment", "other", APP2_NAME, kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
@@ -339,7 +377,7 @@ public class InfrastructureIT extends BaseTest {
                       "findAll { it.account == '"
                           + ACCOUNT1_NAME
                           + "' && it.region == '"
-                          + ns
+                          + account1Ns
                           + "'}");
           return list != null && list.size() > 1;
         },
@@ -359,11 +397,11 @@ public class InfrastructureIT extends BaseTest {
   public void shouldGetServerGroupByMoniker() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
     String appName = "getservergroupsmoniker";
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
-        ns,
+        account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
         appName,
@@ -372,7 +410,7 @@ public class InfrastructureIT extends BaseTest {
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
-        ns,
+        account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
         appName,
@@ -384,7 +422,7 @@ public class InfrastructureIT extends BaseTest {
             .splitToList(
                 kubeCluster.execKubectl(
                     "get -n "
-                        + ns
+                        + account1Ns
                         + " rs -o=jsonpath='{.items[?(@.metadata.ownerReferences[*].name==\""
                         + DEPLOYMENT_1_NAME
                         + "\")].metadata.name}'"));
@@ -398,7 +436,7 @@ public class InfrastructureIT extends BaseTest {
                   + "/serverGroups/"
                   + ACCOUNT1_NAME
                   + "/"
-                  + ns
+                  + account1Ns
                   + "/replicaSet "
                   + rsNames.get(0);
           System.out.println("> Sending get server groups request to " + url);
@@ -430,11 +468,11 @@ public class InfrastructureIT extends BaseTest {
   public void shouldGetServerGroupByApplication() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
     String appName = "getservergroupbyapp";
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
-        ns,
+        account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
         appName,
@@ -443,7 +481,7 @@ public class InfrastructureIT extends BaseTest {
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
-        ns,
+        account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
         appName,
@@ -455,7 +493,7 @@ public class InfrastructureIT extends BaseTest {
             .splitToList(
                 kubeCluster.execKubectl(
                     "get -n "
-                        + ns
+                        + account1Ns
                         + " rs -o=jsonpath='{.items[?(@.metadata.ownerReferences[*].name==\""
                         + DEPLOYMENT_1_NAME
                         + "\")].metadata.name}'"));
@@ -471,7 +509,7 @@ public class InfrastructureIT extends BaseTest {
                   + "/serverGroups/"
                   + ACCOUNT1_NAME
                   + "/"
-                  + ns
+                  + account1Ns
                   + "/replicaSet "
                   + rsNames.get(0);
           System.out.println("> Sending get server groups request to " + url);
@@ -503,11 +541,11 @@ public class InfrastructureIT extends BaseTest {
   public void shouldGetInstanceByAccountRegionId() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
     String appName = "getinstancebyaccount";
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/deployment.yml")
             .withValue("metadata.name", DEPLOYMENT_1_NAME)
-            .withValue("metadata.namespace", ns)
+            .withValue("metadata.namespace", account1Ns)
             .withValue("spec.replicas", 2)
             .asList();
     List<Map<String, Object>> body =
@@ -516,13 +554,14 @@ public class InfrastructureIT extends BaseTest {
             .withValue("deployManifest.moniker.app", appName)
             .withValue("deployManifest.manifests", manifest)
             .asList();
-    KubeTestUtils.deployAndWaitStable(baseUrl(), body, ns, "deployment " + DEPLOYMENT_1_NAME);
+    KubeTestUtils.deployAndWaitStable(
+        baseUrl(), body, account1Ns, "deployment " + DEPLOYMENT_1_NAME);
 
     List<String> allPodNames =
         Splitter.on(" ")
             .splitToList(
                 kubeCluster.execKubectl(
-                    "get -n " + ns + " pod -o=jsonpath='{.items[*].metadata.name}'"));
+                    "get -n " + account1Ns + " pod -o=jsonpath='{.items[*].metadata.name}'"));
     List<String> podNames = new ArrayList<>();
     for (String name : allPodNames) {
       if (name.startsWith(DEPLOYMENT_1_NAME)) {
@@ -535,7 +574,13 @@ public class InfrastructureIT extends BaseTest {
         () -> {
           // ------------------------- when --------------------------
           String url =
-              baseUrl() + "/instances/" + ACCOUNT1_NAME + "/" + ns + "/pod " + podNames.get(0);
+              baseUrl()
+                  + "/instances/"
+                  + ACCOUNT1_NAME
+                  + "/"
+                  + account1Ns
+                  + "/pod "
+                  + podNames.get(0);
           System.out.println("> Sending get instances request to " + url);
           Response resp = get(url);
 
@@ -565,15 +610,21 @@ public class InfrastructureIT extends BaseTest {
   public void shouldGetInstanceLogs() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
     String appName = "getinstancelogs";
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, ns, "deployment", DEPLOYMENT_1_NAME, appName, kubeCluster);
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "deployment",
+        DEPLOYMENT_1_NAME,
+        appName,
+        kubeCluster);
 
     List<String> allPodNames =
         Splitter.on(" ")
             .splitToList(
                 kubeCluster.execKubectl(
-                    "get -n " + ns + " pod -o=jsonpath='{.items[*].metadata.name}'"));
+                    "get -n " + account1Ns + " pod -o=jsonpath='{.items[*].metadata.name}'"));
     List<String> podNames = new ArrayList<>();
     for (String name : allPodNames) {
       if (name.startsWith(DEPLOYMENT_1_NAME)) {
@@ -590,7 +641,7 @@ public class InfrastructureIT extends BaseTest {
                   + "/instances/"
                   + ACCOUNT1_NAME
                   + "/"
-                  + ns
+                  + account1Ns
                   + "/pod "
                   + podNames.get(0)
                   + "/console?provider=kubernetes";
@@ -623,11 +674,11 @@ public class InfrastructureIT extends BaseTest {
   public void shouldGetLoadBalancers() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
     String appName = "getloadbalancers";
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, ns, "service", SERVICE_1_NAME, appName, kubeCluster);
+        baseUrl(), ACCOUNT1_NAME, account1Ns, "service", SERVICE_1_NAME, appName, kubeCluster);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT2_NAME, "default", "service", SERVICE_1_NAME, appName, kubeCluster);
+        baseUrl(), ACCOUNT2_NAME, account2Ns, "service", SERVICE_1_NAME, appName, kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
@@ -646,7 +697,7 @@ public class InfrastructureIT extends BaseTest {
                           + "' && it.name == 'service "
                           + SERVICE_1_NAME
                           + "' && it.namespace == '"
-                          + ns
+                          + account1Ns
                           + "'}");
           Map<Object, Object> lbAcc2 =
               resp.jsonPath()
@@ -655,7 +706,9 @@ public class InfrastructureIT extends BaseTest {
                           + ACCOUNT2_NAME
                           + "' && it.name == 'service "
                           + SERVICE_1_NAME
-                          + "' && it.namespace == 'default'}");
+                          + "' && it.namespace == '"
+                          + account2Ns
+                          + "'}");
           return lbAcc1 != null && !lbAcc1.isEmpty() && lbAcc2 != null && !lbAcc2.isEmpty();
         },
         CACHE_TIMEOUT_MIN,
@@ -679,11 +732,11 @@ public class InfrastructureIT extends BaseTest {
       throws InterruptedException, IOException {
     // ------------------------- given --------------------------
     String appName = "getloadbalancersbyparams";
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, ns, "service", SERVICE_1_NAME, appName, kubeCluster);
+        baseUrl(), ACCOUNT1_NAME, account1Ns, "service", SERVICE_1_NAME, appName, kubeCluster);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, ns, "service", "other", appName, kubeCluster);
+        baseUrl(), ACCOUNT1_NAME, account1Ns, "service", "other", appName, kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
@@ -695,7 +748,7 @@ public class InfrastructureIT extends BaseTest {
                       + "/kubernetes/loadBalancers/"
                       + ACCOUNT1_NAME
                       + "/"
-                      + ns
+                      + account1Ns
                       + "/service "
                       + SERVICE_1_NAME);
 
@@ -711,7 +764,7 @@ public class InfrastructureIT extends BaseTest {
                       "findAll { it.account == '"
                           + ACCOUNT1_NAME
                           + "' && it.region == '"
-                          + ns
+                          + account1Ns
                           + "' && it.name == 'service "
                           + SERVICE_1_NAME
                           + "' && it.moniker.app == '"
@@ -728,7 +781,7 @@ public class InfrastructureIT extends BaseTest {
             + "' to return from GET /kubernetes/loadBalancers/"
             + ACCOUNT1_NAME
             + "/"
-            + ns
+            + account1Ns
             + "/service other");
   }
 
@@ -741,9 +794,15 @@ public class InfrastructureIT extends BaseTest {
   public void shouldGetManifestByAccountLocationName() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
     String appName = "getmanifest";
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, ns, "deployment", DEPLOYMENT_1_NAME, appName, kubeCluster);
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "deployment",
+        DEPLOYMENT_1_NAME,
+        appName,
+        kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
@@ -755,7 +814,7 @@ public class InfrastructureIT extends BaseTest {
                       + "/manifests/"
                       + ACCOUNT1_NAME
                       + "/"
-                      + ns
+                      + account1Ns
                       + "/deployment "
                       + DEPLOYMENT_1_NAME);
 
@@ -766,7 +825,7 @@ public class InfrastructureIT extends BaseTest {
           }
           resp.then().statusCode(200);
           return resp.jsonPath().getString("account").equals(ACCOUNT1_NAME)
-              && resp.jsonPath().getString("location").equals(ns)
+              && resp.jsonPath().getString("location").equals(account1Ns)
               && resp.jsonPath().getString("name").equals("deployment " + DEPLOYMENT_1_NAME);
         },
         CACHE_TIMEOUT_MIN,
@@ -776,7 +835,7 @@ public class InfrastructureIT extends BaseTest {
             + " minutes for GET /manifests/"
             + ACCOUNT1_NAME
             + "/"
-            + ns
+            + account1Ns
             + "/deployment "
             + DEPLOYMENT_1_NAME
             + " to return valid data");
@@ -791,12 +850,12 @@ public class InfrastructureIT extends BaseTest {
   //  @Test
   public void shouldGetRawResources() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    System.out.println("> Using namespace " + ns);
+    System.out.println("> Using namespace " + account1Ns);
     String appName = "getrawresources";
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/configmap.yml")
             .withValue("metadata.name", "myconfig")
-            .withValue("metadata.namespace", ns)
+            .withValue("metadata.namespace", account1Ns)
             .asList();
     List<Map<String, Object>> body =
         KubeTestUtils.loadJson("classpath:requests/deploy_manifest.json")
@@ -804,7 +863,7 @@ public class InfrastructureIT extends BaseTest {
             .withValue("deployManifest.moniker.app", appName)
             .withValue("deployManifest.manifests", manifest)
             .asList();
-    KubeTestUtils.deployAndWaitStable(baseUrl(), body, ns, "configMap myconfig-v000");
+    KubeTestUtils.deployAndWaitStable(baseUrl(), body, account1Ns, "configMap myconfig-v000");
 
     KubeTestUtils.repeatUntilTrue(
         () -> {

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/InfrastructureIT.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/InfrastructureIT.java
@@ -18,7 +18,8 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.it;
 
 import static io.restassured.RestAssured.get;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Splitter;
 import com.netflix.spinnaker.clouddriver.kubernetes.it.utils.KubeTestUtils;
@@ -39,6 +40,9 @@ public class InfrastructureIT extends BaseTest {
   private static final String NETWORK_POLICY_1_NAME = "default-deny-ingress";
   private static final String NETWORK_POLICY_2_NAME = "default-deny-ingress-second";
   private static final String SERVICE_1_NAME = "service1";
+  private static final String APP_SECURITY_GROUPS = "security-groups";
+  private static final String APP_SERVER_GROUP_MGRS = "server-group-managers";
+  private static final String APP_LOAD_BALANCERS = "load-balancers";
   private static String account1Ns;
   private static String account2Ns;
 
@@ -56,15 +60,14 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetClusters() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getclusters";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SERVER_GROUP_MGRS);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         kubeCluster);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
@@ -72,14 +75,15 @@ public class InfrastructureIT extends BaseTest {
         account2Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get clusters request");
-          Response resp = get(baseUrl() + "/applications/" + appName + "/clusters");
+          String url = baseUrl() + "/applications/" + APP_SERVER_GROUP_MGRS + "/clusters";
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -98,7 +102,7 @@ public class InfrastructureIT extends BaseTest {
             + " minutes for 'deployment "
             + DEPLOYMENT_1_NAME
             + "' cluster to return from GET /applications/"
-            + appName
+            + APP_SERVER_GROUP_MGRS
             + "/clusters");
   }
 
@@ -110,15 +114,14 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetClustersByAccount() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getclustersbyaccount";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SERVER_GROUP_MGRS);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         kubeCluster);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
@@ -126,15 +129,16 @@ public class InfrastructureIT extends BaseTest {
         account2Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get clusters request");
-          Response resp =
-              get(baseUrl() + "/applications/" + appName + "/clusters/" + ACCOUNT1_NAME);
+          String url =
+              baseUrl() + "/applications/" + APP_SERVER_GROUP_MGRS + "/clusters/" + ACCOUNT1_NAME;
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -162,7 +166,7 @@ public class InfrastructureIT extends BaseTest {
             + " minutes for 'deployment "
             + DEPLOYMENT_1_NAME
             + "' cluster to return from GET /applications/"
-            + appName
+            + APP_SERVER_GROUP_MGRS
             + "/clusters/"
             + ACCOUNT1_NAME);
   }
@@ -175,33 +179,38 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetClustersByAccountAndName() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getclustersbyaccountandname";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SERVER_GROUP_MGRS);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         kubeCluster);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, account1Ns, "deployment", "other", appName, kubeCluster);
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "deployment",
+        "other",
+        APP_SERVER_GROUP_MGRS,
+        kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get clusters request");
-          Response resp =
-              get(
-                  baseUrl()
-                      + "/applications/"
-                      + appName
-                      + "/clusters/"
-                      + ACCOUNT1_NAME
-                      + "/deployment "
-                      + DEPLOYMENT_1_NAME
-                      + "?expand=true");
+          String url =
+              baseUrl()
+                  + "/applications/"
+                  + APP_SERVER_GROUP_MGRS
+                  + "/clusters/"
+                  + ACCOUNT1_NAME
+                  + "/deployment "
+                  + DEPLOYMENT_1_NAME
+                  + "?expand=true";
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -217,7 +226,7 @@ public class InfrastructureIT extends BaseTest {
                           + "' && it.name == 'deployment "
                           + DEPLOYMENT_1_NAME
                           + "' && it.application == '"
-                          + appName
+                          + APP_SERVER_GROUP_MGRS
                           + "'}");
           return map != null && !map.isEmpty() && resp.jsonPath().getList("$").size() == 1;
         },
@@ -228,7 +237,7 @@ public class InfrastructureIT extends BaseTest {
             + " minutes for 'deployment "
             + DEPLOYMENT_1_NAME
             + "' cluster to return from GET /applications/"
-            + appName
+            + APP_SERVER_GROUP_MGRS
             + "/clusters/"
             + ACCOUNT1_NAME);
   }
@@ -241,27 +250,37 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetClustersByAccountNameAndType() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getclustersbyaccountnametype";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SERVER_GROUP_MGRS);
     KubeTestUtils.deployAndWaitStable(
-        baseUrl(), ACCOUNT1_NAME, account1Ns, "deployment", DEPLOYMENT_1_NAME, appName);
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "deployment",
+        DEPLOYMENT_1_NAME,
+        APP_SERVER_GROUP_MGRS);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, account1Ns, "deployment", "other", appName, kubeCluster);
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "deployment",
+        "other",
+        APP_SERVER_GROUP_MGRS,
+        kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get clusters request");
-          Response resp =
-              get(
-                  baseUrl()
-                      + "/applications/"
-                      + appName
-                      + "/clusters/"
-                      + ACCOUNT1_NAME
-                      + "/deployment "
-                      + DEPLOYMENT_1_NAME
-                      + "/kubernetes?expand=true");
+          String url =
+              baseUrl()
+                  + "/applications/"
+                  + APP_SERVER_GROUP_MGRS
+                  + "/clusters/"
+                  + ACCOUNT1_NAME
+                  + "/deployment "
+                  + DEPLOYMENT_1_NAME
+                  + "/kubernetes?expand=true";
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -271,7 +290,7 @@ public class InfrastructureIT extends BaseTest {
           resp.then().statusCode(200);
           return resp.jsonPath().getString("accountName").equals(ACCOUNT1_NAME)
               && resp.jsonPath().getString("name").equals("deployment " + DEPLOYMENT_1_NAME)
-              && resp.jsonPath().getString("application").equals(appName);
+              && resp.jsonPath().getString("application").equals(APP_SERVER_GROUP_MGRS);
         },
         CACHE_TIMEOUT_MIN,
         TimeUnit.MINUTES,
@@ -280,7 +299,7 @@ public class InfrastructureIT extends BaseTest {
             + " minutes for 'deployment "
             + DEPLOYMENT_1_NAME
             + "' cluster to return from GET /applications/"
-            + appName
+            + APP_SERVER_GROUP_MGRS
             + "/clusters/"
             + ACCOUNT1_NAME);
   }
@@ -293,15 +312,14 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetServerGroups() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getservergroups";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SERVER_GROUP_MGRS);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         "index.docker.io/library/alpine:3.11",
         kubeCluster);
     KubeTestUtils.deployIfMissing(
@@ -310,15 +328,17 @@ public class InfrastructureIT extends BaseTest {
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         "index.docker.io/library/alpine:3.12",
         kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get server groups request");
-          Response resp = get(baseUrl() + "/applications/" + appName + "/serverGroups?expand=true");
+          String url =
+              baseUrl() + "/applications/" + APP_SERVER_GROUP_MGRS + "/serverGroups?expand=true";
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -350,25 +370,31 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetServerGroupsForApplications() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getservergroupsapp";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SERVER_GROUP_MGRS);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         kubeCluster);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, account1Ns, "deployment", "other", APP2_NAME, kubeCluster);
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "deployment",
+        DEPLOYMENT_1_NAME,
+        APP2_NAME,
+        kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get server groups request");
-          Response resp =
-              get(baseUrl() + "/serverGroups?applications=" + appName + "," + APP2_NAME);
+          String url =
+              baseUrl() + "/serverGroups?applications=" + APP_SERVER_GROUP_MGRS + "," + APP2_NAME;
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -398,15 +424,14 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetServerGroupByMoniker() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getservergroupsmoniker";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SERVER_GROUP_MGRS);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         "index.docker.io/library/alpine:3.11",
         kubeCluster);
     KubeTestUtils.deployIfMissing(
@@ -415,7 +440,7 @@ public class InfrastructureIT extends BaseTest {
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         "index.docker.io/library/alpine:3.12",
         kubeCluster);
 
@@ -441,7 +466,7 @@ public class InfrastructureIT extends BaseTest {
                   + account1Ns
                   + "/replicaSet "
                   + rsNames.get(0);
-          System.out.println("> Sending get server groups request to " + url);
+          System.out.println("> GET " + url);
           Response resp = get(url);
 
           // ------------------------- then --------------------------
@@ -469,15 +494,14 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetServerGroupByApplication() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getservergroupbyapp";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SERVER_GROUP_MGRS);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         "index.docker.io/library/alpine:3.11",
         kubeCluster);
     KubeTestUtils.deployIfMissing(
@@ -486,7 +510,7 @@ public class InfrastructureIT extends BaseTest {
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         "index.docker.io/library/alpine:3.12",
         kubeCluster);
 
@@ -507,14 +531,14 @@ public class InfrastructureIT extends BaseTest {
           String url =
               baseUrl()
                   + "/applications/"
-                  + appName
+                  + APP_SERVER_GROUP_MGRS
                   + "/serverGroups/"
                   + ACCOUNT1_NAME
                   + "/"
                   + account1Ns
                   + "/replicaSet "
                   + rsNames.get(0);
-          System.out.println("> Sending get server groups request to " + url);
+          System.out.println("> GET " + url);
           Response resp = get(url);
 
           // ------------------------- then --------------------------
@@ -542,8 +566,7 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetInstanceByAccountRegionId() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getinstancebyaccount";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SERVER_GROUP_MGRS);
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/deployment.yml")
             .withValue("metadata.name", DEPLOYMENT_1_NAME)
@@ -553,7 +576,7 @@ public class InfrastructureIT extends BaseTest {
     List<Map<String, Object>> body =
         KubeTestUtils.loadJson("classpath:requests/deploy_manifest.json")
             .withValue("deployManifest.account", ACCOUNT1_NAME)
-            .withValue("deployManifest.moniker.app", appName)
+            .withValue("deployManifest.moniker.app", APP_SERVER_GROUP_MGRS)
             .withValue("deployManifest.manifests", manifest)
             .asList();
     KubeTestUtils.deployAndWaitStable(
@@ -583,7 +606,7 @@ public class InfrastructureIT extends BaseTest {
                   + account1Ns
                   + "/pod "
                   + podNames.get(0);
-          System.out.println("> Sending get instances request to " + url);
+          System.out.println("> GET " + url);
           Response resp = get(url);
 
           // ------------------------- then --------------------------
@@ -611,15 +634,14 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetInstanceLogs() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getinstancelogs";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SERVER_GROUP_MGRS);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         kubeCluster);
 
     List<String> allPodNames =
@@ -647,7 +669,7 @@ public class InfrastructureIT extends BaseTest {
                   + "/pod "
                   + podNames.get(0)
                   + "/console?provider=kubernetes";
-          System.out.println("> Sending get instance logs request to " + url);
+          System.out.println("> GET " + url);
           Response resp = get(url);
 
           // ------------------------- then --------------------------
@@ -675,18 +697,30 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetLoadBalancers() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getloadbalancers";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_LOAD_BALANCERS);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, account1Ns, "service", SERVICE_1_NAME, appName, kubeCluster);
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "service",
+        SERVICE_1_NAME,
+        APP_LOAD_BALANCERS,
+        kubeCluster);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT2_NAME, account2Ns, "service", SERVICE_1_NAME, appName, kubeCluster);
+        baseUrl(),
+        ACCOUNT2_NAME,
+        account2Ns,
+        "service",
+        SERVICE_1_NAME,
+        APP_LOAD_BALANCERS,
+        kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get load balancers request");
-          Response resp = get(baseUrl() + "/applications/" + appName + "/loadBalancers");
+          String url = baseUrl() + "/applications/" + APP_LOAD_BALANCERS + "/loadBalancers";
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -720,7 +754,7 @@ public class InfrastructureIT extends BaseTest {
             + " minutes for 'service "
             + SERVICE_1_NAME
             + "' to return from GET /applications/"
-            + appName
+            + APP_LOAD_BALANCERS
             + "/loadBalancers");
   }
 
@@ -733,26 +767,31 @@ public class InfrastructureIT extends BaseTest {
   public void shouldGetLoadBalancerByAccountRegionAndName()
       throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getloadbalancersbyparams";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_LOAD_BALANCERS);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, account1Ns, "service", SERVICE_1_NAME, appName, kubeCluster);
+        baseUrl(),
+        ACCOUNT1_NAME,
+        account1Ns,
+        "service",
+        SERVICE_1_NAME,
+        APP_LOAD_BALANCERS,
+        kubeCluster);
     KubeTestUtils.deployIfMissing(
-        baseUrl(), ACCOUNT1_NAME, account1Ns, "service", "other", appName, kubeCluster);
+        baseUrl(), ACCOUNT1_NAME, account1Ns, "service", "other", APP_LOAD_BALANCERS, kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get load balancers request");
-          Response resp =
-              get(
-                  baseUrl()
-                      + "/kubernetes/loadBalancers/"
-                      + ACCOUNT1_NAME
-                      + "/"
-                      + account1Ns
-                      + "/service "
-                      + SERVICE_1_NAME);
+          String url =
+              baseUrl()
+                  + "/kubernetes/loadBalancers/"
+                  + ACCOUNT1_NAME
+                  + "/"
+                  + account1Ns
+                  + "/service "
+                  + SERVICE_1_NAME;
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -770,7 +809,7 @@ public class InfrastructureIT extends BaseTest {
                           + "' && it.name == 'service "
                           + SERVICE_1_NAME
                           + "' && it.moniker.app == '"
-                          + appName
+                          + APP_LOAD_BALANCERS
                           + "'}");
           return list != null && !list.isEmpty();
         },
@@ -795,30 +834,29 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetManifestByAccountLocationName() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getmanifest";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_LOAD_BALANCERS);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_LOAD_BALANCERS,
         kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get manifest request");
-          Response resp =
-              get(
-                  baseUrl()
-                      + "/manifests/"
-                      + ACCOUNT1_NAME
-                      + "/"
-                      + account1Ns
-                      + "/deployment "
-                      + DEPLOYMENT_1_NAME);
+          String url =
+              baseUrl()
+                  + "/manifests/"
+                  + ACCOUNT1_NAME
+                  + "/"
+                  + account1Ns
+                  + "/deployment "
+                  + DEPLOYMENT_1_NAME;
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -850,7 +888,7 @@ public class InfrastructureIT extends BaseTest {
           + "Then only the desired manifest should be returned\n===")
   // TODO: Uncomment after fixing rawResources endpoint
   //  @Test
-  public void shouldGetRawResources() throws InterruptedException, IOException {
+  public void shouldGetRawResources() throws InterruptedException {
     // ------------------------- given --------------------------
     System.out.println("> Using namespace " + account1Ns);
     String appName = "getrawresources";
@@ -899,9 +937,13 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldListSecurityGroups() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-
-    String appName = "getmanifest";
-    System.out.println("> Using namespace " + account1Ns + " and " + account2Ns);
+    System.out.println(
+        "> Using namespace "
+            + account1Ns
+            + " and "
+            + account2Ns
+            + ", appName: "
+            + APP_SECURITY_GROUPS);
 
     KubeTestUtils.deployIfMissing(
         baseUrl(),
@@ -909,7 +951,7 @@ public class InfrastructureIT extends BaseTest {
         account1Ns,
         "networkPolicy",
         NETWORK_POLICY_1_NAME,
-        appName,
+        APP_SECURITY_GROUPS,
         kubeCluster);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
@@ -917,14 +959,15 @@ public class InfrastructureIT extends BaseTest {
         account2Ns,
         "networkPolicy",
         NETWORK_POLICY_1_NAME,
-        appName,
+        APP_SECURITY_GROUPS,
         kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get securityGroups request");
-          Response resp = get(baseUrl() + "/securityGroups");
+          String url = baseUrl() + "/securityGroups";
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -950,9 +993,7 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldListSecurityGroupsByAccount() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-
-    String appName = "getmanifest";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SECURITY_GROUPS);
 
     KubeTestUtils.deployIfMissing(
         baseUrl(),
@@ -960,7 +1001,7 @@ public class InfrastructureIT extends BaseTest {
         account1Ns,
         "networkPolicy",
         NETWORK_POLICY_1_NAME,
-        appName,
+        APP_SECURITY_GROUPS,
         kubeCluster);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
@@ -968,14 +1009,15 @@ public class InfrastructureIT extends BaseTest {
         account1Ns,
         "networkPolicy",
         NETWORK_POLICY_2_NAME,
-        appName,
+        APP_SECURITY_GROUPS,
         kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get securityGroups request");
-          Response resp = get(baseUrl() + "/securityGroups/" + ACCOUNT1_NAME);
+          String url = baseUrl() + "/securityGroups/" + ACCOUNT1_NAME;
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -1004,9 +1046,7 @@ public class InfrastructureIT extends BaseTest {
   public void shouldListSecurityGroupsByAccountAndRegion()
       throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-
-    String appName = "getmanifest";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SECURITY_GROUPS);
 
     KubeTestUtils.deployIfMissing(
         baseUrl(),
@@ -1014,7 +1054,7 @@ public class InfrastructureIT extends BaseTest {
         account1Ns,
         "networkPolicy",
         NETWORK_POLICY_1_NAME,
-        appName,
+        APP_SECURITY_GROUPS,
         kubeCluster);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
@@ -1022,15 +1062,15 @@ public class InfrastructureIT extends BaseTest {
         account2Ns,
         "networkPolicy",
         NETWORK_POLICY_2_NAME,
-        appName,
+        APP_SECURITY_GROUPS,
         kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get securityGroups request");
-          Response resp =
-              get(baseUrl() + "/securityGroups/" + ACCOUNT1_NAME + "?region=" + account1Ns);
+          String url = baseUrl() + "/securityGroups/" + ACCOUNT1_NAME + "?region=" + account1Ns;
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -1061,9 +1101,7 @@ public class InfrastructureIT extends BaseTest {
   public void shouldListSecurityGroupsByAccountAndCloudProvider()
       throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-
-    String appName = "getmanifest";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SECURITY_GROUPS);
 
     KubeTestUtils.deployIfMissing(
         baseUrl(),
@@ -1071,15 +1109,15 @@ public class InfrastructureIT extends BaseTest {
         account1Ns,
         "networkPolicy",
         NETWORK_POLICY_1_NAME,
-        appName,
+        APP_SECURITY_GROUPS,
         kubeCluster);
-    ;
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get securityGroups request");
-          Response resp = get(baseUrl() + "/securityGroups/" + ACCOUNT1_NAME + "/kubernetes");
+          String url = baseUrl() + "/securityGroups/" + ACCOUNT1_NAME + "/kubernetes";
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -1109,8 +1147,7 @@ public class InfrastructureIT extends BaseTest {
   public void shouldListSecurityGroupsByAccountAndCloudProviderAndName()
       throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getmanifest";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SECURITY_GROUPS);
 
     KubeTestUtils.deployIfMissing(
         baseUrl(),
@@ -1118,7 +1155,7 @@ public class InfrastructureIT extends BaseTest {
         account1Ns,
         "networkPolicy",
         NETWORK_POLICY_1_NAME,
-        appName,
+        APP_SECURITY_GROUPS,
         kubeCluster);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
@@ -1126,20 +1163,20 @@ public class InfrastructureIT extends BaseTest {
         account1Ns,
         "networkPolicy",
         NETWORK_POLICY_2_NAME,
-        appName,
+        APP_SECURITY_GROUPS,
         kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get securityGroups request");
-          Response resp =
-              get(
-                  baseUrl()
-                      + "/securityGroups/"
-                      + ACCOUNT1_NAME
-                      + "/kubernetes/networkpolicy "
-                      + NETWORK_POLICY_1_NAME);
+          String url =
+              baseUrl()
+                  + "/securityGroups/"
+                  + ACCOUNT1_NAME
+                  + "/kubernetes/networkpolicy "
+                  + NETWORK_POLICY_1_NAME;
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -1169,8 +1206,7 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetSecurityGroupByAccountAndName() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getmanifest";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SECURITY_GROUPS);
 
     KubeTestUtils.deployIfMissing(
         baseUrl(),
@@ -1178,21 +1214,21 @@ public class InfrastructureIT extends BaseTest {
         account1Ns,
         "networkPolicy",
         NETWORK_POLICY_1_NAME,
-        appName,
+        APP_SECURITY_GROUPS,
         kubeCluster);
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get securityGroups request");
-          Response resp =
-              get(
-                  baseUrl()
-                      + "/securityGroups/"
-                      + ACCOUNT1_NAME
-                      + "/kubernetes/"
-                      + account1Ns
-                      + "/networkolicy "
-                      + NETWORK_POLICY_1_NAME);
+          String url =
+              baseUrl()
+                  + "/securityGroups/"
+                  + ACCOUNT1_NAME
+                  + "/kubernetes/"
+                  + account1Ns
+                  + "/networkolicy "
+                  + NETWORK_POLICY_1_NAME;
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -1224,22 +1260,23 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetServerGroupManagerForApplication() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getclusters";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SERVER_GROUP_MGRS);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get clusters request");
-          Response resp = get(baseUrl() + "/applications/" + appName + "/serverGroupManagers");
+          String url =
+              baseUrl() + "/applications/" + APP_SERVER_GROUP_MGRS + "/serverGroupManagers";
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -1247,7 +1284,16 @@ public class InfrastructureIT extends BaseTest {
             return false;
           }
           resp.then().statusCode(200);
-          List<Object> serverGroupList = resp.jsonPath().getList("$");
+          List<Object> serverGroupList =
+              resp.jsonPath()
+                  .getList(
+                      "findAll { it.account == '"
+                          + ACCOUNT1_NAME
+                          + "' && it.namespace == '"
+                          + account1Ns
+                          + "' && it.name == 'deployment "
+                          + DEPLOYMENT_1_NAME
+                          + "'}");
           return serverGroupList != null && serverGroupList.size() == 1;
         },
         CACHE_TIMEOUT_MIN,
@@ -1257,7 +1303,7 @@ public class InfrastructureIT extends BaseTest {
             + " minutes for 'deployment "
             + "deployment"
             + "' cluster to return from GET /applications/"
-            + appName
+            + APP_SERVER_GROUP_MGRS
             + "/serverGroupManagers");
   }
 
@@ -1269,22 +1315,22 @@ public class InfrastructureIT extends BaseTest {
   @Test
   public void shouldGetApplicationInCluster() throws InterruptedException, IOException {
     // ------------------------- given --------------------------
-    String appName = "getclusters";
-    System.out.println("> Using namespace " + account1Ns);
+    System.out.println("> Using namespace " + account1Ns + ", appName: " + APP_SERVER_GROUP_MGRS);
     KubeTestUtils.deployIfMissing(
         baseUrl(),
         ACCOUNT1_NAME,
         account1Ns,
         "deployment",
         DEPLOYMENT_1_NAME,
-        appName,
+        APP_SERVER_GROUP_MGRS,
         kubeCluster);
 
     KubeTestUtils.repeatUntilTrue(
         () -> {
           // ------------------------- when --------------------------
-          System.out.println("> Sending get clusters request");
-          Response resp = get(baseUrl() + "/applications/" + appName);
+          String url = baseUrl() + "/applications/" + APP_SERVER_GROUP_MGRS;
+          System.out.println("> GET " + url);
+          Response resp = get(url);
 
           // ------------------------- then --------------------------
           System.out.println(resp.asString());
@@ -1293,7 +1339,7 @@ public class InfrastructureIT extends BaseTest {
           }
           resp.then().statusCode(200).and();
           var appNameResp = resp.jsonPath().getString("name");
-          return appNameResp != null && appNameResp.equals(appName);
+          return appNameResp != null && appNameResp.equals(APP_SERVER_GROUP_MGRS);
         },
         CACHE_TIMEOUT_MIN,
         TimeUnit.MINUTES,
@@ -1302,6 +1348,6 @@ public class InfrastructureIT extends BaseTest {
             + " minutes for 'deployment "
             + "deployment"
             + "' cluster to return from GET /applications/"
-            + appName);
+            + APP_SERVER_GROUP_MGRS);
   }
 }

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/containers/KubernetesCluster.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/containers/KubernetesCluster.java
@@ -36,24 +36,21 @@ public class KubernetesCluster extends GenericContainer<KubernetesCluster> {
 
   private static final String DOCKER_IMAGE = "rancher/k3s:v1.17.11-k3s1";
   private static final String KUBECFG_IN_CONTAINER = "/etc/rancher/k3s/k3s.yaml";
-  private static final int STARTUP_NAMESPACES = 5;
 
-  private static final Map<String, KubernetesCluster> instances = new HashMap<>();
+  private static KubernetesCluster INSTANCE;
 
   private Path kubecfgPath;
-  private final String accountName;
-  private final Map<String, Boolean> availableNamespaces = new HashMap<>();
+  private final Map<String, List<String>> namespacesByAccount = new HashMap<>();
 
-  public static KubernetesCluster getInstance(String accountName) {
-    return instances.computeIfAbsent(accountName, KubernetesCluster::new);
+  public static KubernetesCluster getInstance() {
+    if (INSTANCE == null) {
+      INSTANCE = new KubernetesCluster();
+    }
+    return INSTANCE;
   }
 
-  private KubernetesCluster(String accountName) {
+  private KubernetesCluster() {
     super(DOCKER_IMAGE);
-    this.accountName = accountName;
-    for (int i = 0; i < STARTUP_NAMESPACES; i++) {
-      this.availableNamespaces.put("testns" + String.format("%02d", i), true);
-    }
 
     // arguments to docker run
     Map<String, String> tmpfs = new HashMap<>();
@@ -75,16 +72,13 @@ public class KubernetesCluster extends GenericContainer<KubernetesCluster> {
     return kubecfgPath;
   }
 
-  public String getAvailableNamespace() throws IOException, InterruptedException {
-    for (Map.Entry<String, Boolean> entry : availableNamespaces.entrySet()) {
-      if (entry.getValue()) {
-        entry.setValue(false);
-        execKubectl("create ns " + entry.getKey());
-        return entry.getKey();
-      }
-    }
-    fail("Ran out of available test namespaces, consider increasing STARTUP_NAMESPACES");
-    return null;
+  public String createNamespace(String accountName) throws IOException, InterruptedException {
+    List<String> existing =
+        namespacesByAccount.computeIfAbsent(accountName, k -> new ArrayList<>());
+    String newNamespace = String.format("%s-testns%02d", accountName, existing.size());
+    execKubectl("create ns " + newNamespace);
+    existing.add(newNamespace);
+    return newNamespace;
   }
 
   public String execKubectl(String args) throws IOException, InterruptedException {
@@ -129,7 +123,7 @@ public class KubernetesCluster extends GenericContainer<KubernetesCluster> {
   public void start() {
     super.start();
     String containerName = getContainerInfo().getName().replaceAll("/", "");
-    System.setProperty(this.accountName + "_containername", containerName);
+    System.setProperty("containername", containerName);
     try {
       this.kubecfgPath = copyKubecfgFromCluster(containerName);
       fixKubeEndpoint(this.kubecfgPath);

--- a/clouddriver-kubernetes/src/integration/resources/clouddriver.yml
+++ b/clouddriver-kubernetes/src/integration/resources/clouddriver.yml
@@ -51,7 +51,14 @@ kubernetes:
       namespaces:
         - account2-testns00
       omitNamespaces: []
-      kinds: []
+      kinds:
+        - pod
+        - replicaset
+        - deployment
+        - service
+        - configmap
+        - secret
+        - networkpolicy
       omitKinds: []
       customResources: []
       cachingPolicies: []

--- a/clouddriver-kubernetes/src/integration/resources/clouddriver.yml
+++ b/clouddriver-kubernetes/src/integration/resources/clouddriver.yml
@@ -31,6 +31,7 @@ kubernetes:
         - service
         - configmap
         - secret
+        - networkpolicy
       omitKinds: []
       customResources: []
       cachingPolicies: []

--- a/clouddriver-kubernetes/src/integration/resources/clouddriver.yml
+++ b/clouddriver-kubernetes/src/integration/resources/clouddriver.yml
@@ -17,11 +17,12 @@ kubernetes:
       configureImagePullSecrets: true
       cacheThreads: 3
       namespaces:
-        - testns00
-        - testns01
-        - testns02
-        - testns03
-        - testns04
+        - default
+        - account1-testns00
+        - account1-testns01
+        - account1-testns02
+        - account1-testns03
+        - account1-testns04
       omitNamespaces: []
       kinds:
         - pod
@@ -37,16 +38,17 @@ kubernetes:
       oAuthScopes: []
       onlySpinnakerManaged: true
       metrics: false
-      kubeconfigFile: ${KUBECONFIGS_HOME}/kubecfg-${account1_containername}.yml  # File is automatically created during initialization
+      kubeconfigFile: ${KUBECONFIGS_HOME}/kubecfg-${containername}.yml  # File is automatically created during initialization
     - name: account2
-      cacheIntervalSeconds: 30
+      cacheIntervalSeconds: 5
       requiredGroupMembership: []
       providerVersion: V2
       permissions: {}
       dockerRegistries: []
       configureImagePullSecrets: true
       cacheThreads: 1
-      namespaces: []
+      namespaces:
+        - account2-testns00
       omitNamespaces: []
       kinds: []
       omitKinds: []
@@ -56,7 +58,7 @@ kubernetes:
       oAuthScopes: []
       onlySpinnakerManaged: true
       metrics: false
-      kubeconfigFile: ${KUBECONFIGS_HOME}/kubecfg-${account1_containername}.yml  # File is automatically created during initialization
+      kubeconfigFile: ${KUBECONFIGS_HOME}/kubecfg-${containername}.yml  # File is automatically created during initialization
 
 logging.level.com.netflix.spinnaker.cats.sql.cluster: INFO
 logging.level.com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCacheDataConverter: WARN

--- a/clouddriver-kubernetes/src/integration/resources/manifests/networkPolicy.yml
+++ b/clouddriver-kubernetes/src/integration/resources/manifests/networkPolicy.yml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
Kubernetes integration tests now use separate namespaces for both test accounts.
The issue sharing namespaces is that if an object is deployed to one account, it will still show in the results of the second account. This makes troubleshooting more difficult, so having them separate is for cleaner results and easier troubleshooting.