### PR TITLE
feat(aws/enclave): Enable Nitro Enclave option

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/AutoScalingWorker.groovy
@@ -121,6 +121,7 @@ class AutoScalingWorker {
       }
       return shouldUseMip
     }
+    Boolean enableEnclave
   }
 
   /**

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -137,7 +137,7 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
    * This is a Launch Template only feature
    * * https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html
    */
-  Boolean enableEnclave = false
+  Boolean enableEnclave
 
   /**
    * Launch template placement details, see {@link com.amazonaws.services.ec2.model.LaunchTemplatePlacementRequest}.

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -133,6 +133,13 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
   Boolean unlimitedCpuCredits
 
   /**
+   * When set to true, the created server group will be configured with Nitro Enclaves enabled
+   * This is a Launch Template only feature
+   * * https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html
+   */
+  Boolean enableEnclave = false
+
+  /**
    * Launch template placement details, see {@link com.amazonaws.services.ec2.model.LaunchTemplatePlacementRequest}.
    */
   LaunchTemplatePlacement placement
@@ -195,7 +202,7 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
     return ["requireIMDSv2", "associateIPv6Address", "unlimitedCpuCredits",
             "placement", "licenseSpecifications", "onDemandAllocationStrategy",
             "onDemandBaseCapacity", "onDemandPercentageAboveBaseCapacity", "spotAllocationStrategy",
-            "spotInstancePools", "launchTemplateOverridesForInstanceType"].toSet()
+            "spotInstancePools", "launchTemplateOverridesForInstanceType", "enableEnclave"].toSet()
   }
 
   static Set<String> getMixedInstancesPolicyFieldNames() {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -302,6 +302,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         lifecycleHooks: getLifecycleHooks(account, description),
         setLaunchTemplate: description.setLaunchTemplate,
         requireIMDSv2: description.requireIMDSv2,
+        enableEnclave: description.enableEnclave,
         associateIPv6Address: description.associateIPv6Address,
         unlimitedCpuCredits: description.unlimitedCpuCredits != null
           ? description.unlimitedCpuCredits

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -169,8 +169,9 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
           iamInstanceProfile = launchTemplateData.iamInstanceProfile?.name
           instanceMonitoring = launchTemplateData.monitoring?.enabled
           spotMaxPrice = launchTemplateData.instanceMarketOptions?.spotOptions?.maxPrice
+          newDescription.enableEnclave = launchTemplateData.enclaveOptions != null ? launchTemplateData.enclaveOptions.getEnabled() : false
           newDescription.requireIMDSv2 = description.requireIMDSv2 != null ? description.requireIMDSv2 : launchTemplateData.metadataOptions?.httpTokens == "required"
-          newDescription.associateIPv6Address = description.associateIPv6Address 
+          newDescription.associateIPv6Address = description.associateIPv6Address
           if (!launchTemplateData.networkInterfaces?.empty && launchTemplateData.networkInterfaces*.associatePublicIpAddress?.any()) {
             associatePublicIpAddress = true
           }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -169,7 +169,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
           iamInstanceProfile = launchTemplateData.iamInstanceProfile?.name
           instanceMonitoring = launchTemplateData.monitoring?.enabled
           spotMaxPrice = launchTemplateData.instanceMarketOptions?.spotOptions?.maxPrice
-          newDescription.enableEnclave = launchTemplateData.enclaveOptions != null ? launchTemplateData.enclaveOptions.getEnabled() : false
+          newDescription.enableEnclave = description.enableEnclave != null ? description.enableEnclave :  launchTemplateData.enclaveOptions?.getEnabled()
           newDescription.requireIMDSv2 = description.requireIMDSv2 != null ? description.requireIMDSv2 : launchTemplateData.metadataOptions?.httpTokens == "required"
           newDescription.associateIPv6Address = description.associateIPv6Address
           if (!launchTemplateData.networkInterfaces?.empty && launchTemplateData.networkInterfaces*.associatePublicIpAddress?.any()) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidator.groovy
@@ -105,6 +105,7 @@ class BasicAmazonDeployDescriptionValidator extends AmazonDescriptionValidationS
     // certain features work as expected only when AWS EC2 Launch Template feature is enabled and used
     if (!description.setLaunchTemplate) {
       def ltFeaturesEnabled = getLtFeaturesEnabled(description)
+
       if (ltFeaturesEnabled) {
         warnings.add("WARNING: The following fields ${ltFeaturesEnabled} work as expected only with AWS EC2 Launch Template, " +
                 "but 'setLaunchTemplate' is set to false in request with account: ${description.account}, " +

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/description/ModifyServerGroupLaunchTemplateDescription.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/description/ModifyServerGroupLaunchTemplateDescription.java
@@ -24,6 +24,7 @@ public class ModifyServerGroupLaunchTemplateDescription
   private String imageId;
   private Boolean associateIPv6Address;
   private Boolean unlimitedCpuCredits;
+  private Boolean enableEnclave;
 
   public Boolean getRequireIMDV2() {
     return requireIMDV2;
@@ -63,5 +64,13 @@ public class ModifyServerGroupLaunchTemplateDescription
 
   public void setUnlimitedCpuCredits(Boolean unlimitedCpuCredits) {
     this.unlimitedCpuCredits = unlimitedCpuCredits;
+  }
+
+  public Boolean getEnableEnclave() {
+    return enableEnclave;
+  }
+
+  public void setEnableEnclave(Boolean enableEnclave) {
+    this.enableEnclave = enableEnclave;
   }
 }

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -248,7 +248,7 @@ public class LaunchTemplateService {
     networkInterfaceRequest.setGroups(description.getSecurityGroups());
 
     // Nitro Enclave options
-    if (asgConfiguration.getEnableEnclave() != null) {
+    if (description.getEnableEnclave() != null) {
       request.setEnclaveOptions(
           new LaunchTemplateEnclaveOptionsRequest()
               .withEnabled(asgConfiguration.getEnableEnclave()));

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -247,6 +247,10 @@ public class LaunchTemplateService {
     networkInterfaceRequest.setDeviceIndex(0);
     networkInterfaceRequest.setGroups(description.getSecurityGroups());
 
+    // Nitro Enclave options
+    request.setEnclaveOptions(
+        new LaunchTemplateEnclaveOptionsRequest().withEnabled(asgConfiguration.getEnableEnclave()));
+
     return request.withNetworkInterfaces(networkInterfaceRequest);
   }
 
@@ -335,6 +339,10 @@ public class LaunchTemplateService {
             .withIpv6AddressCount(asgConfig.getAssociateIPv6Address() ? 1 : 0)
             .withGroups(asgConfig.getSecurityGroups())
             .withDeviceIndex(0));
+
+    // Nitro Enclave options
+    request.setEnclaveOptions(
+        new LaunchTemplateEnclaveOptionsRequest().withEnabled(asgConfig.getEnableEnclave()));
 
     return request;
   }

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -248,8 +248,11 @@ public class LaunchTemplateService {
     networkInterfaceRequest.setGroups(description.getSecurityGroups());
 
     // Nitro Enclave options
-    request.setEnclaveOptions(
-        new LaunchTemplateEnclaveOptionsRequest().withEnabled(asgConfiguration.getEnableEnclave()));
+    if (asgConfiguration.getEnableEnclave() != null) {
+      request.setEnclaveOptions(
+          new LaunchTemplateEnclaveOptionsRequest()
+              .withEnabled(asgConfiguration.getEnableEnclave()));
+    }
 
     return request.withNetworkInterfaces(networkInterfaceRequest);
   }
@@ -341,8 +344,10 @@ public class LaunchTemplateService {
             .withDeviceIndex(0));
 
     // Nitro Enclave options
-    request.setEnclaveOptions(
-        new LaunchTemplateEnclaveOptionsRequest().withEnabled(asgConfig.getEnableEnclave()));
+    if (asgConfig.getEnableEnclave() != null) {
+      request.setEnclaveOptions(
+          new LaunchTemplateEnclaveOptionsRequest().withEnabled(asgConfig.getEnableEnclave()));
+    }
 
     return request;
   }

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -250,8 +250,7 @@ public class LaunchTemplateService {
     // Nitro Enclave options
     if (description.getEnableEnclave() != null) {
       request.setEnclaveOptions(
-          new LaunchTemplateEnclaveOptionsRequest()
-              .withEnabled(asgConfiguration.getEnableEnclave()));
+          new LaunchTemplateEnclaveOptionsRequest().withEnabled(description.getEnableEnclave()));
     }
 
     return request.withNetworkInterfaces(networkInterfaceRequest);

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidatorSpec.groovy
@@ -209,6 +209,7 @@ class BasicAmazonDeployDescriptionValidatorSpec extends Specification {
     'unlimitedCpuCredits'   | false            | 't3.large'
     'requireIMDSv2'         | true             | 'c3.small'
     'associateIPv6Address'  | true             | 'm5.large'
+    'enableEnclave'         | true             | 'm5.large'
   }
 
   void "valid request with launch template disabled and all launch template only features omitted succeeds validation"() {


### PR DESCRIPTION
[AWS Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html) is a feature that allows for isolated execution environments, or _enclaves_, to be launched alongside of normal instances.

This PR adds a property, `enableEnclave`, to the deploy description. Restrict
this feature to launch templates since it can only be enabled via
Launch Templates

Fixes spinnaker/spinnaker#6396

## Verification

I created a clouddriver container off this branch by first compiling the JAR:
```
./gradlew clouddriver-web:installDist -x test
```
and built a container with `Dockerfile.ubuntu` and pushed it to dockerhub. I then launched a [Minnaker](https://github.com/armory/minnaker) with OSS spinnaker, and applied the following patchfile:

```
apiVersion: spinnaker.io/v1alpha2
kind: SpinnakerService
metadata:
  name: spinnaker
spec:
  spinnakerConfig:
    service-settings:
      clouddriver:
        artifactId: lflux/clouddriver:nitro-ubuntu
    profiles:
      clouddriver:
        aws:
          features:
            launch-templates:
              enabled: true
              all-applications:
                enabled: true
```

I then created a pipeline which launched an Amazon Linux AMI with the option ` "enableEnclave": true` option set in it.

Launching the instance, I can see that the Enclave option is set

```
$ aws ec2 describe-launch-template-versions --launch-template-id lt-xxxx --query LaunchTemplateVersions[0].LaunchTemplateData.EnclaveOptions
{
    "Enabled": true
}
```
 and on the instance I can see that the device is available:

```
$ ls -la /dev/nitro_enclaves
crw-rw---- 1 root ne 10, 57 Apr 12 04:21 /dev/nitro_enclaves
```

Modifying the pipeline to remove `"enableEnclave": true" line, the AMI deploys with a launch template with the enclave option disabled:

```
$ aws ec2 describe-launch-template-versions --launch-template-id lt-yyy --query LaunchTemplateVersions[0].LaunchTemplateData.EnclaveOptions
{
    "Enabled": false
}
```

and the instance does not have the device:

```
$ ls /dev/nitro_enclaves
ls: cannot access /dev/nitro_enclaves: No such file or directory
```
