### PR TITLE
fix(kubernetes): address crd delete error

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/GlobalResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/GlobalResourcePropertyRegistry.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesUnregisteredCustomResourceHandler;
+import java.util.HashMap;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -34,6 +35,8 @@ import org.springframework.stereotype.Component;
 @ParametersAreNonnullByDefault
 public class GlobalResourcePropertyRegistry implements ResourcePropertyRegistry {
   private final ImmutableMap<KubernetesKind, KubernetesResourceProperties> globalProperties;
+  private final HashMap<KubernetesKind, KubernetesResourceProperties> crdProperties =
+      new HashMap<KubernetesKind, KubernetesResourceProperties>();
   private final KubernetesResourceProperties defaultProperties;
 
   @Autowired
@@ -50,12 +53,22 @@ public class GlobalResourcePropertyRegistry implements ResourcePropertyRegistry 
         new KubernetesResourceProperties(defaultHandler, defaultHandler.versioned());
   }
 
+  public void updateCrdProperties(KubernetesHandler handler) {
+    this.crdProperties.put(
+        handler.kind(), new KubernetesResourceProperties(handler, handler.versioned()));
+  }
+
   @Override
   @Nonnull
   public KubernetesResourceProperties get(KubernetesKind kind) {
-    KubernetesResourceProperties globalResult = globalProperties.get(kind);
-    if (globalResult != null) {
-      return globalResult;
+    KubernetesResourceProperties result = globalProperties.get(kind);
+    if (result != null) {
+      return result;
+    }
+
+    result = crdProperties.get(kind);
+    if (result != null) {
+      return result;
     }
 
     return defaultProperties;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/GlobalResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/GlobalResourcePropertyRegistry.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesUnregisteredCustomResourceHandler;
-import java.util.HashMap;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -35,8 +34,8 @@ import org.springframework.stereotype.Component;
 @ParametersAreNonnullByDefault
 public class GlobalResourcePropertyRegistry implements ResourcePropertyRegistry {
   private final ImmutableMap<KubernetesKind, KubernetesResourceProperties> globalProperties;
-  private final HashMap<KubernetesKind, KubernetesResourceProperties> crdProperties =
-      new HashMap<KubernetesKind, KubernetesResourceProperties>();
+  private ImmutableMap<KubernetesKind, KubernetesResourceProperties> crdProperties =
+      ImmutableMap.of();
   private final KubernetesResourceProperties defaultProperties;
 
   @Autowired
@@ -53,9 +52,13 @@ public class GlobalResourcePropertyRegistry implements ResourcePropertyRegistry 
         new KubernetesResourceProperties(defaultHandler, defaultHandler.versioned());
   }
 
-  public void updateCrdProperties(KubernetesHandler handler) {
-    this.crdProperties.put(
-        handler.kind(), new KubernetesResourceProperties(handler, handler.versioned()));
+  public void updateCrdProperties(List<KubernetesHandler> handlers) {
+    this.crdProperties =
+        handlers.stream()
+            .collect(
+                toImmutableMap(
+                    KubernetesHandler::kind,
+                    h -> new KubernetesResourceProperties(h, h.versioned())));
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesCustomResourceHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesCustomResourceHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.op.handler;
+
+import static com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesHandler.DeployPriority.LOWEST_PRIORITY;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgentFactory;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesUnregisteredCustomResourceCachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest;
+import javax.annotation.Nonnull;
+
+public class KubernetesCustomResourceHandler extends KubernetesHandler implements CanDelete {
+
+  private final KubernetesKind kind;
+
+  public KubernetesCustomResourceHandler(KubernetesKind kind) {
+    this.kind = kind;
+  }
+
+  @Override
+  public int deployPriority() {
+    return LOWEST_PRIORITY.getValue();
+  }
+
+  @Nonnull
+  @Override
+  public KubernetesKind kind() {
+    return this.kind;
+  }
+
+  @Override
+  public boolean versioned() {
+    return false;
+  }
+
+  @Nonnull
+  @Override
+  public SpinnakerKind spinnakerKind() {
+    return SpinnakerKind.UNCLASSIFIED;
+  }
+
+  @Override
+  public Manifest.Status status(KubernetesManifest manifest) {
+    return Manifest.Status.defaultStatus();
+  }
+
+  @Override
+  protected KubernetesCachingAgentFactory cachingAgentFactory() {
+    return KubernetesUnregisteredCustomResourceCachingAgent::new;
+  }
+}

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -53,6 +53,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesNamerRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesCustomResourceHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor.KubectlException;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor.KubectlNotFoundException;
@@ -328,10 +329,11 @@ public class KubernetesCredentials {
               .collect(
                   toImmutableMap(KubernetesKindProperties::getKubernetesKind, Function.identity()));
 
-      for (KubernetesKind kind : crds.keySet()) {
-        this.globalResourcePropertyRegistry.updateCrdProperties(
-            new KubernetesCustomResourceHandler(kind));
-      }
+      List<KubernetesHandler> crdHandlers =
+          crds.keySet().stream()
+              .map(KubernetesCustomResourceHandler::new)
+              .collect(toImmutableList());
+      this.globalResourcePropertyRegistry.updateCrdProperties(crdHandlers);
 
       return crds;
     } catch (KubectlException e) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -40,6 +40,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurati
 import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.RawResourcesEndpointConfig;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.AccountResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.GlobalResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.JsonPatch;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPatchOptions;

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsSpec.groovy
@@ -22,12 +22,14 @@ import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
 import com.netflix.spinnaker.clouddriver.kubernetes.description.AccountResourcePropertyRegistry
+import com.netflix.spinnaker.clouddriver.kubernetes.description.GlobalResourcePropertyRegistry
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiGroup
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKindProperties
 import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesManifestNamer
 import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesNamerRegistry
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesUnregisteredCustomResourceHandler
 import com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials.KubernetesKindStatus
 import com.netflix.spinnaker.kork.configserver.ConfigFileService
@@ -44,6 +46,7 @@ class KubernetesCredentialsSpec extends Specification {
   KubernetesNamerRegistry namerRegistry = new KubernetesNamerRegistry([new KubernetesManifestNamer()])
   ConfigFileService configFileService = new ConfigFileService()
   KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap = new KubernetesSpinnakerKindMap(ImmutableList.of())
+  GlobalResourcePropertyRegistry globalResourcePropertyRegistry = new GlobalResourcePropertyRegistry(ImmutableList.of(), new KubernetesUnregisteredCustomResourceHandler())
 
   KubernetesCredentials.Factory credentialFactory = new KubernetesCredentials.Factory(
     new NoopRegistry(),
@@ -52,7 +55,8 @@ class KubernetesCredentialsSpec extends Specification {
     configFileService,
     resourcePropertyRegistryFactory,
     kindRegistryFactory,
-    kubernetesSpinnakerKindMap
+    kubernetesSpinnakerKindMap,
+    globalResourcePropertyRegistry
   )
 
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
@@ -21,9 +21,11 @@ import com.google.common.collect.ImmutableList
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
 import com.netflix.spinnaker.clouddriver.kubernetes.description.AccountResourcePropertyRegistry
+import com.netflix.spinnaker.clouddriver.kubernetes.description.GlobalResourcePropertyRegistry
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesManifestNamer
 import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesNamerRegistry
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesUnregisteredCustomResourceHandler
 import com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor
 import com.netflix.spinnaker.fiat.model.Authorization
 import com.netflix.spinnaker.kork.configserver.ConfigFileService
@@ -37,6 +39,7 @@ class KubernetesNamedAccountCredentialsSpec extends Specification {
   AccountResourcePropertyRegistry.Factory resourcePropertyRegistryFactory = Mock(AccountResourcePropertyRegistry.Factory)
   KubernetesKindRegistry.Factory kindRegistryFactory = Mock(KubernetesKindRegistry.Factory)
   KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap = new KubernetesSpinnakerKindMap(ImmutableList.of())
+  GlobalResourcePropertyRegistry globalResourcePropertyRegistry = new GlobalResourcePropertyRegistry(ImmutableList.of(), new KubernetesUnregisteredCustomResourceHandler())
   KubernetesCredentials.Factory credentialFactory = new KubernetesCredentials.Factory(
     new NoopRegistry(),
     namerRegistry,
@@ -44,7 +47,8 @@ class KubernetesNamedAccountCredentialsSpec extends Specification {
     configFileService,
     resourcePropertyRegistryFactory,
     kindRegistryFactory,
-    kubernetesSpinnakerKindMap
+    kubernetesSpinnakerKindMap,
+    globalResourcePropertyRegistry
   )
 
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -610,7 +610,9 @@ final class KubernetesDataProviderIntegrationTest {
             new ConfigFileService(new CloudConfigResourceService()),
             new AccountResourcePropertyRegistry.Factory(resourcePropertyRegistry),
             new KubernetesKindRegistry.Factory(new GlobalKubernetesKindRegistry()),
-            kindMap);
+            kindMap,
+            new GlobalResourcePropertyRegistry(
+                ImmutableList.of(), new KubernetesUnregisteredCustomResourceHandler()));
     return new KubernetesNamedAccountCredentials(managedAccount, credentialFactory);
   }
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsTest.java
@@ -70,7 +70,9 @@ final class KubernetesCredentialsTest {
                     ImmutableList.of(), new KubernetesUnregisteredCustomResourceHandler())),
             new KubernetesKindRegistry.Factory(
                 new GlobalKubernetesKindRegistry(ImmutableList.of())),
-            new KubernetesSpinnakerKindMap(ImmutableList.of()));
+            new KubernetesSpinnakerKindMap(ImmutableList.of()),
+            new GlobalResourcePropertyRegistry(
+                ImmutableList.of(), new KubernetesUnregisteredCustomResourceHandler()));
     ManagedAccount managedAccount = new ManagedAccount();
     managedAccount.setName("my-account");
     return factory.build(managedAccount);


### PR DESCRIPTION
When you try to delete a Kubernetes CRD via Spinnaker UI (kubernetesRawResources Tab) you get an error.

The issue is happening when Spinnaker tries to delete a CRD. The problem is that Kubernetes Kind was being passed as None causing the following error:

![Screen Shot 2021-03-29 at 3 50 34 PM](https://user-images.githubusercontent.com/4214292/112891782-8aa56c80-90a6-11eb-8098-400b6de8526c.png)

Logs:

```
2021-03-25 19:19:37.759 ERROR 1 --- [tionProcessor-0] c.n.s.c.o.DefaultOrchestrationProcessor  : com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor$KubectlException: Failed to delete none/mytestcrd from engineering: error: the server doesn't have a resource type "none"
	at com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor.delete(KubectlJobExecutor.java:154)
	at com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials.lambda$delete$12(KubernetesCredentials.java:475)
	at com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials.runAndRecordMetrics(KubernetesCredentials.java:614)
	at com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials.runAndRecordMetrics(KubernetesCredentials.java:599)
	at com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials.delete(KubernetesCredentials.java:471)
	at com.netflix.spinnaker.clouddriver.kubernetes.op.handler.CanDelete.delete(CanDelete.java:43)
	at com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesDeleteManifestOperation.lambda$operate$0(KubernetesDeleteManifestOperation.java:65)
	at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:405)
	at com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesDeleteManifestOperation.operate(KubernetesDeleteManifestOperation.java:57)
	at com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesDeleteManifestOperation.operate(KubernetesDeleteManifestOperation.java:31)
	at com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation$operate.call(Unknown Source)
	at com.netflix.spinnaker.clouddriver.orchestration.DefaultOrchestrationProcessor$_process_closure1$_closure2.doCall(DefaultOrchestrationProcessor.groovy:118)
	at com.netflix.spinnaker.clouddriver.orchestration.DefaultOrchestrationProcessor$_process_closure1$_closure2.doCall(DefaultOrchestrationProcessor.groovy)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:101)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:263)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1041)
	at groovy.lang.Closure.call(Closure.java:405)
	at groovy.lang.Closure.call(Closure.java:399)
	at com.netflix.spinnaker.clouddriver.metrics.TimedCallable$CallableWrapper.call(TimedCallable.java:81)
	at com.netflix.spinnaker.clouddriver.metrics.TimedCallable.call(TimedCallable.java:45)
	at java_util_concurrent_Callable$call.call(Unknown Source)
	at com.netflix.spinnaker.clouddriver.orchestration.DefaultOrchestrationProcessor$_process_closure1.doCall(DefaultOrchestrationProcessor.groovy:117)
	at com.netflix.spinnaker.clouddriver.orchestration.DefaultOrchestrationProcessor$_process_closure1.doCall(DefaultOrchestrationProcessor.groovy)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:101)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:263)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1041)
	at groovy.lang.Closure.call(Closure.java:405)
	at groovy.lang.Closure.call(Closure.java:399)
	at com.netflix.spinnaker.security.AuthenticatedRequest.lambda$wrapCallableForPrincipal$0(AuthenticatedRequest.java:272)
	at com.netflix.spinnaker.clouddriver.metrics.TimedCallable.call(TimedCallable.java:45)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```


This PR fixes the problem by injecting the correct Kubernetes Kind to the Delete functions.

![Screen Shot 2021-03-29 at 3 48 12 PM](https://user-images.githubusercontent.com/4214292/112891484-31d5d400-90a6-11eb-9be6-162b0ef7180d.png)

Issue: https://github.com/spinnaker/spinnaker/issues/6390