### PR TITLE
fix(aws): Fixes name resolver when stack is empty.

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/names/EcsServerGroupNameResolver.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/names/EcsServerGroupNameResolver.java
@@ -69,9 +69,9 @@ public class EcsServerGroupNameResolver {
       for (Service service : result.getServices()) {
         Moniker moniker = naming.deriveMoniker(new EcsResourceService(service));
 
-        if (StringUtils.equals(currentName.getApp(), moniker.getApp())
-            && StringUtils.equals(currentName.getDetail(), moniker.getDetail())
-            && StringUtils.equals(currentName.getStack(), moniker.getStack())) {
+        if (isSameName(currentName.getApp(), moniker.getApp())
+            && isSameName(currentName.getDetail(), moniker.getDetail())
+            && isSameName(currentName.getStack(), moniker.getStack())) {
           takenSequences.add(moniker.getSequence());
         }
       }
@@ -105,6 +105,11 @@ public class EcsServerGroupNameResolver {
                             + " are taken."));
 
     return new EcsServerGroupName(newMoniker);
+  }
+
+  private boolean isSameName(String name, String name2) {
+    return (StringUtils.isBlank(name) && StringUtils.isBlank(name2))
+        || StringUtils.equals(name, name2);
   }
 
   private boolean isNotTaken(Moniker newMoniker) {


### PR DESCRIPTION
fix(aws): Fixes name resolver when stack is empty.

With the current name comparison, if some names (like stack) are empty it would compare them to a `null` value, not adding them to the currently taken sequences. 

The functionality was working on 1.22 and the bug was introduced on https://github.com/spinnaker/clouddriver/commit/fc08d9a75c0498a5e56ac8e9851c8125d8dca7af.