### PR TITLE
fix(cats): '_' can be used as a single character wildcard (in sql databases) and should be escaped

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
@@ -445,7 +445,11 @@ class SqlCache(
       jooq
         .select(field("id"))
         .from(table(sqlNames.resourceTableName(type)))
-        .where(field("id").like(glob.replace('*', '%')))
+        // The underscore is treated as a single character wildcard in currently supported sql backends (mysql/psql)
+        // leading to inconsistencies in current usages of `filterIdentifiers()`.
+        //
+        // If single character wildcard is desired, use '?' rather than '_'.
+        .where(field("id").like(glob.replace('*', '%').replace("_", """\_""")))
     }
 
     val ids = try {

--- a/cats/cats-test/src/main/groovy/com/netflix/spinnaker/cats/cache/CacheSpec.groovy
+++ b/cats/cats-test/src/main/groovy/com/netflix/spinnaker/cats/cache/CacheSpec.groovy
@@ -96,6 +96,7 @@ abstract class CacheSpec extends Specification {
         'bla*'                  | ['blaTEST', 'blaTESTbla', 'blaPest', 'blaFEST']
         'bla[TF]EST'            | ['blaTEST', 'blaFEST']
         'bla????'               | ['blaTEST', 'blaPest', 'blaFEST']
+        'bla____'               | []
         '??a[FTP][Ee][Ss][Tt]*' | ['blaTEST', 'blaTESTbla', 'blaPest', 'blaFEST']
 
         identifiers = ['blaTEST', 'TESTbla', 'blaTESTbla', 'blaPest', 'blaFEST']


### PR DESCRIPTION
The current implementation leads to inconsistencies with similarly named applications.
ie. `es_test` and `esetest`
