### PR TITLE
chore(aws): remove junit:junit test dependency since it's not used

### DIFF
--- a/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver-aws/clouddriver-aws.gradle
@@ -59,7 +59,6 @@ dependencies {
   testImplementation "io.spinnaker.kork:kork-exceptions"
   testImplementation "cglib:cglib-nodep"
   testImplementation "com.natpryce:hamkrest"
-  testImplementation "junit:junit"
   testImplementation "org.objenesis:objenesis"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"


### PR DESCRIPTION
Both before and after the change:
```
SUCCESS: Executed 1155 tests in 1m 57s
```