### PR TITLE
chore(kubernetes): Bump kubectl binary version to 1.20.6

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -2,7 +2,7 @@ FROM python:3.7-alpine3.12
 LABEL maintainer="sig-platform@spinnaker.io"
 
 # KUBECTL_RELEASE kept one minor version behind latest to maximise compatibility overlap
-ENV KUBECTL_RELEASE=1.18.10
+ENV KUBECTL_RELEASE=1.20.6
 ENV AWS_CLI_VERSION=1.18.152
 ENV AWS_CLI_S3_CMD=2.0.2
 ENV AWS_AIM_AUTHENTICATOR_VERSION=0.4.0


### PR DESCRIPTION
Routine version bump. 1.21.0 has been released.

1.20.6 is the latest [`kubectl` release](https://github.com/kubernetes/kubectl/releases) - presumably 1.21.0 is due soon but we are still keeping to 1 minor version behind the latest controller version.

Note this does not fix: https://github.com/spinnaker/spinnaker/issues/6420