### PR TITLE
fix(cloudfoundry): remove null route mappings to avoid falsely thrown error

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Routes.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Routes.java
@@ -35,8 +35,8 @@ import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryServerGr
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -100,9 +100,17 @@ public class Routes {
     try {
       mappedApps =
           routeMappings.get(res.getMetadata().getGuid()).stream()
-              .map(rm -> applications.findById(rm.getAppGuid()))
+              .map(
+                  rm -> {
+                    try {
+                      return applications.findById(rm.getAppGuid());
+                    } catch (Exception e) {
+                      return null;
+                    }
+                  })
+              .filter(Objects::nonNull)
               .collect(Collectors.toSet());
-    } catch (ExecutionException e) {
+    } catch (Exception e) {
       if (!(e.getCause() instanceof ResourceNotFoundException))
         throw new CloudFoundryApiException(e.getCause(), "Unable to find route mappings by id");
     }


### PR DESCRIPTION
This fixes an issue when the CF Loadbalancer caching agent will succeed with failures because an old application was no longer in the route mappings. It takes one application caching agent cycle to hide this issue, but now that agents could be run in any order it occasionally happens. This doesn't actually create a problem as the caching agent will succeed the next time around but its better to avoid it than see errors in the logs. The fix will just catch any null apps and filter that out of the route mappings instead of throwing that error. 
