### PR TITLE
fix(namespaceValidation): validation should use declared namespaces in order to leverage live namespace suppliers and remove omitted namespaces

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtil.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtil.java
@@ -124,7 +124,7 @@ public class KubernetesValidationUtil {
   }
 
   protected boolean validateNamespace(String namespace, KubernetesCredentials credentials) {
-    final List<String> configuredNamespaces = credentials.getNamespaces();
+    final List<String> configuredNamespaces = credentials.getDeclaredNamespaces();
     if (configuredNamespaces != null
         && !configuredNamespaces.isEmpty()
         && !configuredNamespaces.contains(namespace)) {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtilSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtilSpec.groovy
@@ -51,7 +51,7 @@ class KubernetesValidationUtilSpec extends Specification {
     accountCredentialsProvider.getCredentials(kubernetesAccount) >> accountCredentials
     accountCredentials.getCredentials() >> credentials
     credentials.getOmitNamespaces() >> omitNamespaces
-    credentials.namespaces >> namespaces
+    credentials.getDeclaredNamespaces() >> namespaces
     manifest.getNamespace() >> testNamespace
     manifest.getKind() >> kind
     credentials.isValidKind(kind) >> true
@@ -79,7 +79,7 @@ class KubernetesValidationUtilSpec extends Specification {
 
     then:
     credentials.getOmitNamespaces() >> toImmutableList(omitNamespaces)
-    credentials.namespaces >> toImmutableList(namespaces)
+    credentials.getDeclaredNamespaces() >> toImmutableList(namespaces)
     judgement == allowedNamespace
 
     where:


### PR DESCRIPTION
It was discovered that live namespace supplier was being ignored on a deploy manifest operation, causing a slower failure when an invalid namespace was supplied. Rather than the validation failing with "wrongNamespace" the operation would be attempted and eventually fail for the expected reason. By changing the validator to to use `getDeclaredNamespaces` instead, this problem is solved.  