### PR TITLE
feat(kubernetes/job): Return the most recent pod name instead of the list of pod status

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesJobStatus.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesJobStatus.java
@@ -48,6 +48,7 @@ public class KubernetesJobStatus implements JobStatus {
   String logs;
   @JsonIgnore V1Job job;
   List<PodStatus> pods;
+  String mostRecentPodName;
 
   public KubernetesJobStatus(V1Job job, String account) {
     this.job = job;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
@@ -29,15 +29,15 @@ import com.netflix.spinnaker.clouddriver.model.JobProvider;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1Pod;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import org.apache.commons.lang3.NotImplementedException;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -46,12 +46,15 @@ public class KubernetesJobProvider implements JobProvider<KubernetesJobStatus> {
   @Getter private final String platform = "kubernetes";
   private final AccountCredentialsProvider accountCredentialsProvider;
   private final KubernetesManifestProvider manifestProvider;
+  private final boolean detailedPodStatus;
 
   KubernetesJobProvider(
       AccountCredentialsProvider accountCredentialsProvider,
-      KubernetesManifestProvider manifestProvider) {
+      KubernetesManifestProvider manifestProvider,
+      @Value("${kubernetes.jobs.detailed-pod-status:false}") boolean detailedPodStatus) {
     this.accountCredentialsProvider = accountCredentialsProvider;
     this.manifestProvider = manifestProvider;
+    this.detailedPodStatus = detailedPodStatus;
   }
 
   @Override
@@ -73,14 +76,32 @@ public class KubernetesJobProvider implements JobProvider<KubernetesJobStatus> {
             jobStatus.getLocation(),
             KubernetesSelectorList.fromMatchLabels(selector));
 
-    jobStatus.setPods(
+    List<V1Pod> typedPods =
         pods.stream()
-            .map(
-                p -> {
-                  V1Pod pod = KubernetesCacheDataConverter.getResource(p, V1Pod.class);
-                  return new KubernetesJobStatus.PodStatus(pod);
+            .map(m -> KubernetesCacheDataConverter.getResource(m, V1Pod.class))
+            .sorted(
+                (p1, p2) -> {
+                  DateTime dtDefault = new DateTime(0);
+                  DateTime time1 =
+                      p1.getStatus() != null
+                          ? Optional.ofNullable(p1.getStatus().getStartTime()).orElse(dtDefault)
+                          : dtDefault;
+                  DateTime time2 =
+                      p2.getStatus() != null
+                          ? Optional.ofNullable(p2.getStatus().getStartTime()).orElse(dtDefault)
+                          : dtDefault;
+                  return time1.compareTo(time2);
                 })
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList());
+
+    V1Pod mostRecentPod = typedPods.get(typedPods.size() - 1);
+    jobStatus.setMostRecentPodName(
+        mostRecentPod.getMetadata() != null ? mostRecentPod.getMetadata().getName() : "");
+
+    if (detailedPodStatus) {
+      jobStatus.setPods(
+          typedPods.stream().map(KubernetesJobStatus.PodStatus::new).collect(Collectors.toList()));
+    }
 
     return jobStatus;
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
@@ -51,7 +51,7 @@ public class KubernetesJobProvider implements JobProvider<KubernetesJobStatus> {
   KubernetesJobProvider(
       AccountCredentialsProvider accountCredentialsProvider,
       KubernetesManifestProvider manifestProvider,
-      @Value("${kubernetes.jobs.detailed-pod-status:false}") boolean detailedPodStatus) {
+      @Value("${kubernetes.jobs.detailed-pod-status:true}") boolean detailedPodStatus) {
     this.accountCredentialsProvider = accountCredentialsProvider;
     this.manifestProvider = manifestProvider;
     this.detailedPodStatus = detailedPodStatus;

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProviderSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProviderSpec.groovy
@@ -58,7 +58,7 @@ class KubernetesJobProviderSpec extends Specification {
     }
 
     when:
-    def provider = new KubernetesJobProvider(mockAccountCredentialsProvider, mockManifestProvider, false)
+    def provider = new KubernetesJobProvider(mockAccountCredentialsProvider, mockManifestProvider, true)
     def logResult = provider.getFileContents("a", "b", "c", "d")
 
     then:

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProviderSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProviderSpec.groovy
@@ -58,7 +58,7 @@ class KubernetesJobProviderSpec extends Specification {
     }
 
     when:
-    def provider = new KubernetesJobProvider(mockAccountCredentialsProvider, mockManifestProvider)
+    def provider = new KubernetesJobProvider(mockAccountCredentialsProvider, mockManifestProvider, false)
     def logResult = provider.getFileContents("a", "b", "c", "d")
 
     then:


### PR DESCRIPTION
Kubernetes jobs may be executed by many pods, and each pod status is saved to the pipeline execution context. If the number of pods is large enough, the pipeline execution context may grow big enough to make orca crash.

The only place where pod status is needed is in the UI to extract the logs of the most recently created pod. A new field `mostRecentPodName` was added to the response that replaces the list of pod status. The full list of pod status may still be returned by setting the new configuration flag `kubernetes.jobs.detailed-pod-status: true` in `clouddriver.yml`.

