### PR TITLE
perf(kubernetes): change KubernetesNamedAccountCredentials::getNamespaces to not make live calls to a kubernetes cluster

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -358,14 +358,8 @@ public class KubernetesCredentials {
   }
 
   @Nonnull
-  public ImmutableList<String> getDeclaredNamespaces() {
-    ImmutableList<String> result;
-    if (!namespaces.isEmpty()) {
-      result = namespaces;
-    } else {
-      result = liveNamespaceSupplier.get();
-    }
-
+  public ImmutableList<String> filterNamespaces(@Nonnull ImmutableList<String> namespaces) {
+    ImmutableList<String> result = namespaces;
     if (!omitNamespaces.isEmpty()) {
       result =
           result.stream()
@@ -374,6 +368,18 @@ public class KubernetesCredentials {
     }
 
     return result;
+  }
+
+  @Nonnull
+  public ImmutableList<String> getDeclaredNamespaces() {
+    ImmutableList<String> result;
+    if (!namespaces.isEmpty()) {
+      result = namespaces;
+    } else {
+      result = liveNamespaceSupplier.get();
+    }
+
+    return filterNamespaces(result);
   }
 
   public boolean isMetricsEnabled() {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -386,6 +386,7 @@ public class KubernetesCredentials {
       result = liveNamespaceSupplier.getIfPresent();
       if (result == null) {
         // There's nothing in the cache, so return an empty list
+        log.warn("No cached namespaces for account {}", accountName);
         result = ImmutableList.of();
       }
     }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -357,8 +357,9 @@ public class KubernetesCredentials {
     }
   }
 
-  public List<String> getDeclaredNamespaces() {
-    List<String> result;
+  @Nonnull
+  public ImmutableList<String> getDeclaredNamespaces() {
+    ImmutableList<String> result;
     if (!namespaces.isEmpty()) {
       result = namespaces;
     } else {
@@ -367,7 +368,9 @@ public class KubernetesCredentials {
 
     if (!omitNamespaces.isEmpty()) {
       result =
-          result.stream().filter(n -> !omitNamespaces.contains(n)).collect(Collectors.toList());
+          result.stream()
+              .filter(n -> !omitNamespaces.contains(n))
+              .collect(ImmutableList.toImmutableList());
     }
 
     return result;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -89,8 +89,12 @@ public class KubernetesNamedAccountCredentials
     return requiredGroupMembership;
   }
 
+  /**
+   * Get the namespaces without making a call to the kubernetes cluster. If the cache is empty,
+   * return an empty list.
+   */
   public List<String> getNamespaces() {
-    return credentials.getDeclaredNamespaces();
+    return credentials.getDeclaredNamespacesFromCache();
   }
 
   public Map<String, String> getSpinnakerKindMap() {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
@@ -40,10 +40,13 @@ class KubernetesNamedAccountCredentialsSpec extends Specification {
   KubernetesKindRegistry.Factory kindRegistryFactory = Mock(KubernetesKindRegistry.Factory)
   KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap = new KubernetesSpinnakerKindMap(ImmutableList.of())
   GlobalResourcePropertyRegistry globalResourcePropertyRegistry = new GlobalResourcePropertyRegistry(ImmutableList.of(), new KubernetesUnregisteredCustomResourceHandler())
+
+  KubectlJobExecutor mockKubectlJobExecutor = Mock(KubectlJobExecutor)
+
   KubernetesCredentials.Factory credentialFactory = new KubernetesCredentials.Factory(
     new NoopRegistry(),
     namerRegistry,
-    Mock(KubectlJobExecutor),
+    mockKubectlJobExecutor,
     configFileService,
     resourcePropertyRegistryFactory,
     kindRegistryFactory,
@@ -83,5 +86,26 @@ class KubernetesNamedAccountCredentialsSpec extends Specification {
     cleanup:
       Files.delete(file1)
       Files.delete(file2)
+  }
+
+  void 'getting namespaces makes no calls to kubernetes'() {
+    given: 'an account that does not specify namespaces'
+      def file1 = Files.createTempFile("test", "")
+      file1.append("some content")
+      def account1Def = new KubernetesConfigurationProperties.ManagedAccount()
+      account1Def.setName("test")
+      account1Def.setCacheThreads(1)
+      account1Def.getPermissions().add(Authorization.READ, "test@test.com")
+      account1Def.setKubeconfigFile(file1.toString())
+      def account1 = new KubernetesNamedAccountCredentials(account1Def, credentialFactory)
+
+    when: 'retrieving namespaces for the account'
+      account1.getNamespaces()
+
+    then: 'no calls to kubernetes occurred'
+      0 * mockKubectlJobExecutor._
+
+    cleanup:
+      Files.delete(file1)
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
@@ -90,13 +90,11 @@ class KubernetesNamedAccountCredentialsSpec extends Specification {
 
   void 'getting namespaces makes no calls to kubernetes'() {
     given: 'an account that does not specify namespaces'
-      def file1 = Files.createTempFile("test", "")
-      file1.append("some content")
       def account1Def = new KubernetesConfigurationProperties.ManagedAccount()
       account1Def.setName("test")
       account1Def.setCacheThreads(1)
       account1Def.getPermissions().add(Authorization.READ, "test@test.com")
-      account1Def.setKubeconfigFile(file1.toString())
+      account1Def.setServiceAccount(true);
       def account1 = new KubernetesNamedAccountCredentials(account1Def, credentialFactory)
 
     when: 'retrieving namespaces for the account'
@@ -104,8 +102,5 @@ class KubernetesNamedAccountCredentialsSpec extends Specification {
 
     then: 'no calls to kubernetes occurred'
       0 * mockKubectlJobExecutor._
-
-    cleanup:
-      Files.delete(file1)
   }
 }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsLifecycleHandlerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsLifecycleHandlerTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.KubernetesProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgentDispatcher;
@@ -50,7 +51,11 @@ public class KubernetesCredentialsLifecycleHandlerTest {
 
     KubernetesNamedAccountCredentials namedCredentials =
         Mockito.mock(KubernetesNamedAccountCredentials.class);
-    when(namedCredentials.getCredentials()).thenReturn(mock(KubernetesCredentials.class));
+
+    KubernetesCredentials kubernetesCredentials = mock(KubernetesCredentials.class);
+    when(kubernetesCredentials.getDeclaredNamespaces()).thenReturn(ImmutableList.of());
+
+    when(namedCredentials.getCredentials()).thenReturn(kubernetesCredentials);
 
     handler.credentialsAdded(namedCredentials);
     // We should have added an agent


### PR DESCRIPTION
KubernetesNamedAccountCredentials::getNamespaces was already a best effort call since it could return an empty list in
case of an error communicating with the kubernetes cluster.  With this change, it doesn't attempt to communicate with
the kubernetes cluster and returns the last cached valued (or an empty list if there's nothing in the cache).  This can
dramatically speed up the /credentials endpoint if it's called soon after clouddriver starts, before a caching agent has
made a live call to the cluster to retrieve the list of namespaces.