### PR TITLE
feat(aws): Adding support for modifying mixed instances policy proper…

### DIFF
--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/ModifyServerGroupUtils.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/ModifyServerGroupUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription;
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.reflect.FieldUtils;
+
+public class ModifyServerGroupUtils {
+
+  public static Set<String> getNonMetadataFieldsSetInReq(
+      final ModifyServerGroupLaunchTemplateDescription reqDescription) {
+    final ModifyServerGroupLaunchTemplateDescription descWithDefaults =
+        new ModifyServerGroupLaunchTemplateDescription();
+    final Set<String> nonMetadataFieldsSet = new HashSet<>();
+
+    // get all field names for the description type
+    final Set<String> allFieldNames =
+        FieldUtils.getAllFieldsList(reqDescription.getClass()).stream()
+            .map(Field::getName)
+            .collect(Collectors.toSet());
+
+    // get the fields set in the request
+    allFieldNames.stream()
+        .forEach(
+            fieldName -> {
+              // ignore Groovy object's special fields
+              if (fieldName.contains("$") || fieldName.equals("metaClass")) {
+                return;
+              }
+              Object defaultValue = descWithDefaults.getProperty(fieldName);
+              Object requestedValue = reqDescription.getProperty(fieldName);
+              boolean isMetadataField =
+                  ModifyServerGroupLaunchTemplateDescription.getMetadataFieldNames()
+                      .contains(fieldName);
+              if (!Objects.equals(requestedValue, defaultValue) && !isMetadataField) {
+                nonMetadataFieldsSet.add(fieldName);
+              }
+            });
+
+    return nonMetadataFieldsSet;
+  }
+}

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/asg/AsgConfigHelper.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/asg/AsgConfigHelper.java
@@ -21,6 +21,7 @@ import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
 import com.amazonaws.services.autoscaling.model.Ebs;
 import com.amazonaws.services.autoscaling.model.LaunchConfiguration;
 import com.amazonaws.services.autoscaling.model.LaunchTemplateSpecification;
+import com.amazonaws.services.ec2.model.CreditSpecification;
 import com.amazonaws.services.ec2.model.EbsBlockDevice;
 import com.amazonaws.services.ec2.model.LaunchTemplateBlockDeviceMapping;
 import com.amazonaws.services.ec2.model.LaunchTemplateEbsBlockDevice;
@@ -377,7 +378,7 @@ public class AsgConfigHelper {
    * @param launchTemplateBlockDeviceMappings AWS LaunchTemplate BlockDeviceMappings
    * @return list of AmazonBlockDevice
    */
-  protected static List<AmazonBlockDevice> transformLaunchTemplateBlockDeviceMapping(
+  public static List<AmazonBlockDevice> transformLaunchTemplateBlockDeviceMapping(
       List<LaunchTemplateBlockDeviceMapping> launchTemplateBlockDeviceMappings) {
     return launchTemplateBlockDeviceMappings.stream()
         .map(
@@ -403,5 +404,31 @@ public class AsgConfigHelper {
               return amzBd;
             })
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Method to evaluate the value to be set for unlimitedCpuCredits given a value from source ASG.
+   * Used during CloneServerGroup and ModifyServerGroupLaunchTemplate operations, when the value is
+   * set in source ASG.
+   *
+   * @param sourceAsgCreditSpec credit specification from a source ASG.
+   * @param isBurstingSupportedByAllTypesRequested boolean, true if bursting is supported by all
+   *     instance types in request, includes changed types, if any.
+   * @return Boolean, non-null only if all instance types(description.instanceType and
+   *     description.launchTemplateOverridesForInstanceType.instanceType) support bursting. The
+   *     non-null value comes from source credit specification.
+   */
+  public static Boolean getUnlimitedCpuCreditsFromAncestorLt(
+      final CreditSpecification sourceAsgCreditSpec,
+      boolean isBurstingSupportedByAllTypesRequested) {
+    if (sourceAsgCreditSpec == null) {
+      return null;
+    }
+
+    // return non-null unlimitedCpuCredits iff ALL requested instance types (includes changed types,
+    // if any) support CPU credits specification, to ensure compatibility
+    return isBurstingSupportedByAllTypesRequested
+        ? sourceAsgCreditSpec.getCpuCredits().equals("unlimited") ? true : false
+        : null;
   }
 }

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/description/ModifyServerGroupLaunchTemplateDescription.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/description/ModifyServerGroupLaunchTemplateDescription.java
@@ -17,8 +17,64 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description;
 
-public class ModifyServerGroupLaunchTemplateDescription
-    extends ModifyAsgLaunchConfigurationDescription {
+import com.amazonaws.util.CollectionUtils;
+import com.google.common.collect.ImmutableSet;
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice;
+import com.netflix.spinnaker.clouddriver.aws.userdata.UserDataOverride;
+import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupsNameable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Description type that encapsulates properties associated with 1. EC2 launch template
+ * (https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/ec2/model/ResponseLaunchTemplateData.html)
+ * 2. Launch template overrides
+ * (https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/autoscaling/model/LaunchTemplate.html)
+ * 3. Instance diversification
+ * (https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/autoscaling/model/InstancesDistribution.html)
+ *
+ * <p>Used to modify properties associated with the AWS entities listed above. Applicable to AWS
+ * AutoScalingGroups backed by EC2 launch template with / without mixed instances policy
+ * (https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/autoscaling/model/MixedInstancesPolicy.html)
+ */
+@Getter
+@Setter
+public class ModifyServerGroupLaunchTemplateDescription extends AbstractAmazonCredentialsDescription
+    implements ServerGroupsNameable {
+  String region;
+  String asgName;
+  String amiName;
+  String instanceType;
+  String subnetType;
+  String iamRole;
+  String keyPair;
+  Boolean associatePublicIpAddress;
+  String spotPrice;
+  String ramdiskId;
+  Boolean instanceMonitoring;
+  Boolean ebsOptimized;
+  String classicLinkVpcId;
+  List<String> classicLinkVpcSecurityGroups;
+  Boolean legacyUdf;
+  String base64UserData;
+  UserDataOverride userDataOverride = new UserDataOverride();
+  List<AmazonBlockDevice> blockDevices;
+  List<String> securityGroups;
+  Boolean securityGroupsAppendOnly;
+
+  /**
+   * If false, the newly created server group will not pick up block device mapping customizations
+   * from an ancestor group
+   */
+  boolean copySourceCustomBlockDeviceMappings = true;
+
+  // Launch Template only fields
   private Boolean requireIMDV2;
   private String kernelId;
   private String imageId;
@@ -26,51 +82,121 @@ public class ModifyServerGroupLaunchTemplateDescription
   private Boolean unlimitedCpuCredits;
   private Boolean enableEnclave;
 
-  public Boolean getRequireIMDV2() {
-    return requireIMDV2;
+  /**
+   * Mixed Instances Policy properties.
+   *
+   * <p>Why are these properties here instead of {@link
+   * com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyAsgDescription}?: Although most
+   * of these properties are associated with the server group itself rather than it's launch
+   * template, these properties are closely associated with and modify certain launch template
+   * properties e.g. LaunchTemplateOverridesForInstanceType, spotPrice.
+   */
+  private String onDemandAllocationStrategy;
+
+  private Integer onDemandBaseCapacity;
+  private Integer onDemandPercentageAboveBaseCapacity;
+  private String spotAllocationStrategy;
+  private Integer spotInstancePools;
+  private List<BasicAmazonDeployDescription.LaunchTemplateOverridesForInstanceType>
+      launchTemplateOverridesForInstanceType;
+
+  @Override
+  public Collection<String> getServerGroupNames() {
+    return Collections.singletonList(asgName);
   }
 
-  public void setRequireIMDV2(Boolean requireIMDV2) {
-    this.requireIMDV2 = requireIMDV2;
+  public static Set<String> getMetadataFieldNames() {
+    return ImmutableSet.of(
+        // read-only fields: serverGroupNames, applications
+        "account",
+        "region",
+        "asgName",
+        "credentials",
+        "securityGroupsAppendOnly",
+        "copySourceCustomBlockDeviceMappings");
   }
 
-  public String getKernelId() {
-    return kernelId;
+  public static Set<String> getMixedInstancesPolicyOnlyFieldNames() {
+    return ImmutableSet.of(
+        "onDemandAllocationStrategy",
+        "onDemandBaseCapacity",
+        "onDemandPercentageAboveBaseCapacity",
+        "spotAllocationStrategy",
+        "spotInstancePools",
+        "launchTemplateOverridesForInstanceType");
   }
 
-  public void setKernelId(String kernelId) {
-    this.kernelId = kernelId;
+  public static Set<String> getMixedInstancesPolicyFieldNames() {
+    return ImmutableSet.of(
+        "onDemandAllocationStrategy",
+        "onDemandBaseCapacity",
+        "onDemandPercentageAboveBaseCapacity",
+        "spotAllocationStrategy",
+        "spotInstancePools",
+        "spotPrice", // spotMaxPrice
+        "launchTemplateOverridesForInstanceType");
   }
 
-  public String getImageId() {
-    return imageId;
+  /**
+   * Get all instance types in description.
+   *
+   * <p>Why does this method exist? When launchTemplateOverrides are specified, either the overrides
+   * or instanceType is used, but all instance type inputs are returned by this method. When is this
+   * method used? Used primarily for validation purposes, to ensure all instance types in request
+   * are compatible with other validated configuration parameters (to prevent ambiguity).
+   *
+   * @return all instance type(s)
+   */
+  public Set<String> getAllInstanceTypes() {
+    Set instanceTypes = new HashSet();
+    if (StringUtils.isNotBlank(this.getInstanceType())) {
+      instanceTypes.add(this.getInstanceType());
+    }
+    if (!CollectionUtils.isNullOrEmpty(launchTemplateOverridesForInstanceType)) {
+      launchTemplateOverridesForInstanceType.forEach(
+          override -> instanceTypes.add(override.getInstanceType()));
+    }
+    return instanceTypes;
   }
 
-  public void setImageId(String imageId) {
-    this.imageId = imageId;
-  }
-
-  public Boolean getAssociateIPv6Address() {
-    return associateIPv6Address;
-  }
-
-  public void setAssociateIPv6Address(boolean associateIPv6Address) {
-    this.associateIPv6Address = associateIPv6Address;
-  }
-
-  public Boolean getUnlimitedCpuCredits() {
-    return unlimitedCpuCredits;
-  }
-
-  public void setUnlimitedCpuCredits(Boolean unlimitedCpuCredits) {
-    this.unlimitedCpuCredits = unlimitedCpuCredits;
-  }
-
-  public Boolean getEnableEnclave() {
-    return enableEnclave;
-  }
-
-  public void setEnableEnclave(Boolean enableEnclave) {
-    this.enableEnclave = enableEnclave;
+  @Override
+  public String toString() {
+    return new StringBuilder("ModifyServerGroupLaunchTemplateDescription{")
+        .append("region=" + region)
+        .append(", asgName=" + asgName)
+        .append(", amiName=" + amiName)
+        .append(", instanceType=" + instanceType)
+        .append(", subnetType=" + subnetType)
+        .append(", iamRole=" + iamRole)
+        .append(", keyPair=" + keyPair)
+        .append(", associatePublicIpAddress=" + associatePublicIpAddress)
+        .append(", spotPrice=" + spotPrice)
+        .append(", ramdiskId=" + ramdiskId)
+        .append(", instanceMonitoring=" + instanceMonitoring)
+        .append(", ebsOptimized=" + ebsOptimized)
+        .append(", classicLinkVpcId=" + classicLinkVpcId)
+        .append(", classicLinkVpcSecurityGroups=" + classicLinkVpcSecurityGroups)
+        .append(", legacyUdf=" + legacyUdf)
+        .append(", base64UserData=" + base64UserData)
+        .append(", userDataOverride=" + userDataOverride)
+        .append(", blockDevices=" + blockDevices)
+        .append(", securityGroups=" + securityGroups)
+        .append(", securityGroupsAppendOnly=" + securityGroupsAppendOnly)
+        .append(", copySourceCustomBlockDeviceMappings=" + copySourceCustomBlockDeviceMappings)
+        .append(", requireIMDV2=" + requireIMDV2)
+        .append(", kernelId=" + kernelId)
+        .append(", imageId=" + imageId)
+        .append(", associateIPv6Address=" + associateIPv6Address)
+        .append(", unlimitedCpuCredits=" + unlimitedCpuCredits)
+        .append(", onDemandAllocationStrategy=" + onDemandAllocationStrategy)
+        .append(", onDemandBaseCapacity=" + onDemandBaseCapacity)
+        .append(", onDemandPercentageAboveBaseCapacity=" + onDemandPercentageAboveBaseCapacity)
+        .append(", spotAllocationStrategy=" + spotAllocationStrategy)
+        .append(", spotInstancePools=" + spotInstancePools)
+        .append(
+            ", launchTemplateOverridesForInstanceType=" + launchTemplateOverridesForInstanceType)
+        .append("}")
+        .toString()
+        .replaceAll(",\\s[a-zA-Z0-9]+=null", "");
   }
 }

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyServerGroupLaunchTemplateAtomicOperation.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyServerGroupLaunchTemplateAtomicOperation.java
@@ -21,6 +21,7 @@ import static com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions.PrepareMo
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription;
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions.ModifyServerGroupLaunchTemplate;
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions.PrepareModifyServerGroupLaunchTemplate;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions.PrepareUpdateAutoScalingGroup;
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions.UpdateAutoScalingGroup;
 import com.netflix.spinnaker.clouddriver.orchestration.sagas.AbstractSagaAtomicOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.sagas.SagaAtomicOperationBridge;
@@ -29,6 +30,12 @@ import com.netflix.spinnaker.kork.exceptions.IntegrationException;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+/**
+ * Atomic Operation Usage: To modify properties associated with the AWS entities associated with
+ * {@link ModifyServerGroupLaunchTemplateDescription}. Applicable to AWS AutoScalingGroups backed by
+ * EC2 launch template with / without mixed instances policy
+ * (https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/autoscaling/model/MixedInstancesPolicy.html)
+ */
 public class ModifyServerGroupLaunchTemplateAtomicOperation
     extends AbstractSagaAtomicOperation<ModifyServerGroupLaunchTemplateDescription, Object, Void> {
   public ModifyServerGroupLaunchTemplateAtomicOperation(
@@ -42,6 +49,7 @@ public class ModifyServerGroupLaunchTemplateAtomicOperation
     return new SagaFlow()
         .then(PrepareModifyServerGroupLaunchTemplate.class)
         .then(ModifyServerGroupLaunchTemplate.class)
+        .then(PrepareUpdateAutoScalingGroup.class)
         .then(UpdateAutoScalingGroup.class);
   }
 

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/PrepareModifyServerGroupLaunchTemplate.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/PrepareModifyServerGroupLaunchTemplate.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.netflix.spinnaker.clouddriver.aws.deploy.AmiIdResolver;
 import com.netflix.spinnaker.clouddriver.aws.deploy.InstanceTypeUtils.BlockDeviceConfig;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ModifyServerGroupUtils;
 import com.netflix.spinnaker.clouddriver.aws.deploy.ResolvedAmiResult;
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription;
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.ModifyServerGroupLaunchTemplateAtomicOperation.LaunchTemplateException;
@@ -54,10 +55,13 @@ import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.NonFinal;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
+/**
+ * Action to prepare for the description for launch template changes. This action may be skipped if
+ * no launch template changes are requested.
+ */
 @Component
 public class PrepareModifyServerGroupLaunchTemplate
     implements SagaAction<
@@ -83,128 +87,90 @@ public class PrepareModifyServerGroupLaunchTemplate
     NetflixAmazonCredentials credentials =
         (NetflixAmazonCredentials) credentialsRepository.getOne(description.getAccount());
 
-    saga.log("Preparing launch template update: " + description);
+    saga.log(
+        "[SAGA_ACTION] Performing modifyServerGroupLaunchTemplate operation for description "
+            + description);
 
     RegionScopedProvider regionScopedProvider =
         regionScopedProviderFactory.forRegion(credentials, description.getRegion());
-
     AutoScalingGroup autoScalingGroup =
         getAutoScalingGroup(description.getAsgName(), regionScopedProvider);
     LaunchTemplateVersion launchTemplateVersion =
         getLaunchTemplateVersion(autoScalingGroup, regionScopedProvider);
     ResponseLaunchTemplateData launchTemplateData = launchTemplateVersion.getLaunchTemplateData();
 
-    LaunchTemplateInstanceMarketOptions marketOptions =
-        launchTemplateData.getInstanceMarketOptions();
-    String maxPrice = null;
-    if (marketOptions != null && marketOptions.getSpotOptions() != null) {
-      maxPrice = marketOptions.getSpotOptions().getMaxPrice();
+    boolean isAsgBackedByMip = autoScalingGroup.getMixedInstancesPolicy() != null;
+    boolean asgUsesSpotLt = launchTemplateData.getInstanceMarketOptions() != null;
+
+    /**
+     * A valid request should include fields mapped to either launch template or AWS ASG config or
+     * both. ModifyServerGroupLaunchTemplateValidator rejects requests with only metadata fields
+     * i.e. no launch template or ASG config changes.
+     */
+    final Set<String> nonMetadataFieldsSet =
+        ModifyServerGroupUtils.getNonMetadataFieldsSetInReq(description);
+    boolean isReqToModifyMipFieldsOnly =
+        nonMetadataFieldsSet.stream()
+            .allMatch(
+                f ->
+                    ModifyServerGroupLaunchTemplateDescription.getMixedInstancesPolicyFieldNames()
+                        .contains(f));
+
+    // Selectively skip launch template modification in some cases when NO launch template changes
+    // are required:
+    // 1. ASG with MIP + isReqToModifyMixedInstancesPolicyOnlyFields (including spotMaxPrice)
+    // 2. ASG with OD LT + isReqToModifyMixedInstancesPolicyOnlyFields (including spotMaxPrice)
+    //    Reason is to prevent an error like ->
+    //    AmazonAutoScalingException: Incompatible launch template:
+    //        You cannot use a launch template that is set to request Spot Instances
+    //        (InstanceMarketOptions) when you configure an Auto Scaling group with a mixed
+    // instances policy.
+    //        Add a different launch template to the group and try again.
+    if (isReqToModifyMipFieldsOnly && (isAsgBackedByMip || !asgUsesSpotLt)) {
+      saga.log(
+          "[SAGA_ACTION] Skipping PrepareModifyServerGroupLaunchTemplate as only mixed instances policy will be updated.");
+
+      return new Result(
+          ModifyServerGroupLaunchTemplate.ModifyServerGroupLaunchTemplateCommand.builder()
+              .description(description)
+              .isReqToModifyLaunchTemplate(false)
+              .isAsgBackedByMixedInstancesPolicy(isAsgBackedByMip)
+              .isReqToUpgradeAsgToMixedInstancesPolicy(!isAsgBackedByMip)
+              .sourceVersion(launchTemplateVersion)
+              .build(),
+          Collections.emptyList());
     }
 
-    String spotMaxPrice = Optional.ofNullable(description.getSpotPrice()).orElse(maxPrice);
-    if (spotMaxPrice != null && spotMaxPrice.equals("")) {
-      // a spotMaxPrice of "" indicates that it should be removed regardless of value on source
-      // launch template
-      description.setSpotPrice(null);
-    }
+    saga.log("[SAGA_ACTION] Preparing for launch template modification");
+    transformLaunchTemplateVersionToDesc(
+        saga,
+        description,
+        launchTemplateVersion,
+        credentials.getAccountId(),
+        regionScopedProvider.getAmazonEC2(),
+        autoScalingGroup);
 
-    description.setSpotPrice(spotMaxPrice);
-    if (description.getImageId() == null) {
-      saga.log("Resolving Image Id for " + description.getAmiName());
-      // resolve imageId
-      Optional<String> imageId =
-          getImageId(
-              description.getAmiName(),
-              description.getRegion(),
-              credentials.getAccountId(),
-              regionScopedProvider.getAmazonEC2());
-      description.setImageId(
-          imageId.orElseThrow(
-              () ->
-                  new LaunchTemplateException(
-                          String.format(
-                              "Failed to resolve image id for %s", description.getAmiName()))
-                      .setRetryable(StringUtils.isNotBlank(description.getAmiName()))));
-    }
-
-    Set<String> securityGroups = new HashSet<>();
-    if (description.getSecurityGroups() != null) {
-      securityGroups.addAll(description.getSecurityGroups());
-    }
-
-    Boolean includePreviousGroups =
-        Optional.ofNullable(description.getSecurityGroupsAppendOnly())
-            .orElseGet(securityGroups::isEmpty);
-    if (includePreviousGroups) {
-      securityGroups.addAll(
-          launchTemplateData.getNetworkInterfaces().stream()
-              .filter(i -> i.getDeviceIndex() == 0)
-              .findFirst()
-              .map(LaunchTemplateInstanceNetworkInterfaceSpecification::getGroups)
-              .orElse(Collections.emptyList()));
-    }
-    description.setSecurityGroups(new ArrayList<>(securityGroups));
-
-    // if we are changing instance types and don't have explicitly supplied block device mappings
-    String instanceType =
-        Optional.ofNullable(description.getInstanceType())
-            .orElseGet(launchTemplateData::getInstanceType);
-    LaunchTemplateIamInstanceProfileSpecification iamInstanceProfile =
-        launchTemplateData.getIamInstanceProfile();
-    String iamRole = null;
-    if (iamInstanceProfile != null) {
-      iamRole = iamInstanceProfile.getName();
-    }
-
-    description.setIamRole(Optional.ofNullable(description.getIamRole()).orElse(iamRole));
-    description.setKeyPair(
-        Optional.ofNullable(description.getIamRole()).orElseGet(launchTemplateData::getKeyName));
-    description.setRamdiskId(
-        Optional.ofNullable(description.getRamdiskId())
-            .orElseGet(launchTemplateData::getRamDiskId));
-
-    List<AmazonBlockDevice> blockDevices = description.getBlockDevices();
-    if (blockDevices == null
-        && instanceType != null
-        && !instanceType.equals(launchTemplateData.getInstanceType())) {
-      // set default mapping for instance type if we are changing instance types and don't have
-      // explicitly supplied block device mappings
-      List<AmazonBlockDevice> devices =
-          blockDeviceConfig.getBlockDevicesForInstanceType(instanceType);
-      if (!description.isCopySourceCustomBlockDeviceMappings()) {
-        description.setBlockDevices(devices);
-      } else {
-        // if prior version used default mapping do use default mapping on new version as well
-        List<AmazonBlockDevice> defaultDevices =
-            blockDeviceConfig.getBlockDevicesForInstanceType(launchTemplateData.getInstanceType());
-        if (matchingBlockDevices(launchTemplateData.getBlockDeviceMappings(), defaultDevices)) {
-          description.setBlockDevices(devices);
-        }
-      }
-    }
+    boolean isReqToModifyAtleastOneMipOnlyField =
+        nonMetadataFieldsSet.stream()
+            .anyMatch(
+                f ->
+                    ModifyServerGroupLaunchTemplateDescription
+                        .getMixedInstancesPolicyOnlyFieldNames()
+                        .contains(f));
 
     return new Result(
         ModifyServerGroupLaunchTemplate.ModifyServerGroupLaunchTemplateCommand.builder()
             .description(description)
+            .isReqToModifyLaunchTemplate(true)
+            .isAsgBackedByMixedInstancesPolicy(isAsgBackedByMip)
+            .isReqToUpgradeAsgToMixedInstancesPolicy(
+                !isAsgBackedByMip
+                    && isReqToModifyAtleastOneMipOnlyField) // upgrade to MIP if request includes at
+            // least 1 MIP field (along with 1 or
+            // more launch template fields)
             .sourceVersion(launchTemplateVersion)
             .build(),
         Collections.emptyList());
-  }
-
-  private Optional<String> getImageId(
-      String amiName, String region, String accountId, AmazonEC2 ec2) {
-    if (amiName != null) {
-      try {
-        ResolvedAmiResult ami =
-            AmiIdResolver.resolveAmiIdFromAllSources(ec2, region, amiName, accountId);
-        return Optional.ofNullable(ami.getAmiId());
-      } catch (Exception e) {
-        throw new LaunchTemplateException(
-            String.format("Failed to resolve image id for %s", amiName), e);
-      }
-    }
-
-    return Optional.empty();
   }
 
   private AutoScalingGroup getAutoScalingGroup(
@@ -220,12 +186,18 @@ public class PrepareModifyServerGroupLaunchTemplate
   private LaunchTemplateVersion getLaunchTemplateVersion(
       AutoScalingGroup autoScalingGroup, RegionScopedProvider regionScopedProvider) {
     LaunchTemplateSpecification launchTemplateSpec =
-        Optional.ofNullable(autoScalingGroup.getLaunchTemplate())
+        Optional.ofNullable(
+                autoScalingGroup.getMixedInstancesPolicy() != null
+                    ? autoScalingGroup
+                        .getMixedInstancesPolicy()
+                        .getLaunchTemplate()
+                        .getLaunchTemplateSpecification()
+                    : autoScalingGroup.getLaunchTemplate())
             .orElseThrow(
                 () ->
                     new IllegalArgumentException(
                         String.format(
-                            "Server group %s is not backed by a launch template",
+                            "Server group is not backed by a launch template.\n%s",
                             autoScalingGroup)));
 
     return regionScopedProvider
@@ -238,11 +210,144 @@ public class PrepareModifyServerGroupLaunchTemplate
                         "Requested launch template %s does not exist.", launchTemplateSpec)));
   }
 
+  private void transformLaunchTemplateVersionToDesc(
+      Saga saga,
+      ModifyServerGroupLaunchTemplateDescription modifyDesc,
+      LaunchTemplateVersion sourceLtVersion,
+      String accountId,
+      AmazonEC2 amazonEC2,
+      AutoScalingGroup autoScalingGroup) {
+    ResponseLaunchTemplateData sourceLtData = sourceLtVersion.getLaunchTemplateData();
+
+    modifyDesc.setSpotPrice(
+        getSpotMaxPrice(modifyDesc.getSpotPrice(), autoScalingGroup, sourceLtData));
+    modifyDesc.setImageId(
+        getImageId(saga, amazonEC2, accountId, modifyDesc).orElse(sourceLtData.getImageId()));
+
+    Set<String> securityGroups = new HashSet<>();
+    if (modifyDesc.getSecurityGroups() != null) {
+      securityGroups.addAll(modifyDesc.getSecurityGroups());
+    }
+
+    Boolean includePreviousGroups =
+        Optional.ofNullable(modifyDesc.getSecurityGroupsAppendOnly())
+            .orElseGet(securityGroups::isEmpty);
+    if (includePreviousGroups) {
+      securityGroups.addAll(
+          sourceLtData.getNetworkInterfaces().stream()
+              .filter(i -> i.getDeviceIndex() == 0)
+              .findFirst()
+              .map(LaunchTemplateInstanceNetworkInterfaceSpecification::getGroups)
+              .orElse(Collections.emptyList()));
+    }
+    modifyDesc.setSecurityGroups(new ArrayList<>(securityGroups));
+
+    LaunchTemplateIamInstanceProfileSpecification iamInstanceProfileInLt =
+        sourceLtData.getIamInstanceProfile();
+    String iamRoleInLt = null;
+    if (iamInstanceProfileInLt != null) {
+      iamRoleInLt = iamInstanceProfileInLt.getName();
+    }
+    modifyDesc.setIamRole(Optional.ofNullable(modifyDesc.getIamRole()).orElse(iamRoleInLt));
+    modifyDesc.setKeyPair(
+        Optional.ofNullable(modifyDesc.getKeyPair()).orElseGet(sourceLtData::getKeyName));
+    modifyDesc.setRamdiskId(
+        Optional.ofNullable(modifyDesc.getRamdiskId()).orElseGet(sourceLtData::getRamDiskId));
+    modifyDesc.setBlockDevices(getBlockDeviceMapping(modifyDesc, sourceLtData));
+  }
+
+  private List<AmazonBlockDevice> getBlockDeviceMapping(
+      ModifyServerGroupLaunchTemplateDescription modifyDesc,
+      ResponseLaunchTemplateData ltDataOldVersion) {
+
+    // if block device mappings are explicitly specified, use them
+    if (modifyDesc.getBlockDevices() != null) {
+      return modifyDesc.getBlockDevices();
+    }
+
+    // modify mapping iff instance type has changed.
+    // for multiple instance types case, use the top-level instance type as it is used to derive
+    // defaults in {@link BasicAmazonDeployHandler}
+    if (modifyDesc.getInstanceType() != null
+        && !modifyDesc.getInstanceType().equals(ltDataOldVersion.getInstanceType())) {
+      final List<AmazonBlockDevice> defaultBdmForNewType =
+          blockDeviceConfig.getBlockDevicesForInstanceType(modifyDesc.getInstanceType());
+      // if copy from source flag is unset, use default mapping for the modified instance type
+      if (!modifyDesc.isCopySourceCustomBlockDeviceMappings()) {
+        return defaultBdmForNewType;
+      } else {
+        // if prior version used default mapping do use default mapping on new version as well
+        List<AmazonBlockDevice> defaultBdmForOldType =
+            blockDeviceConfig.getBlockDevicesForInstanceType(ltDataOldVersion.getInstanceType());
+        if (matchingBlockDevices(ltDataOldVersion.getBlockDeviceMappings(), defaultBdmForOldType)) {
+          return defaultBdmForNewType;
+        }
+      }
+    }
+    return null;
+  }
+
+  private Optional<String> getImageId(
+      Saga saga,
+      AmazonEC2 ec2,
+      String accountId,
+      ModifyServerGroupLaunchTemplateDescription modifyDesc) {
+    if (modifyDesc.getImageId() != null) {
+      return Optional.of(modifyDesc.getImageId());
+    }
+
+    String amiNameInReq = modifyDesc.getAmiName();
+    if (amiNameInReq != null) {
+      saga.log("Resolving Image Id for " + amiNameInReq);
+      try {
+        ResolvedAmiResult ami =
+            AmiIdResolver.resolveAmiIdFromAllSources(
+                ec2, modifyDesc.getRegion(), amiNameInReq, accountId);
+        return Optional.ofNullable(ami.getAmiId());
+      } catch (Exception e) {
+        throw new LaunchTemplateException(
+                String.format("Failed to resolve image id for %s", amiNameInReq), e)
+            .setRetryable(true);
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  private String getSpotMaxPrice(
+      String spotMaxPriceInReq,
+      AutoScalingGroup autoScalingGroup,
+      ResponseLaunchTemplateData ltData) {
+    if (spotMaxPriceInReq != null) {
+      return spotMaxPriceInReq.trim().equals("") ? null : spotMaxPriceInReq;
+    }
+
+    Optional<String> spotMaxPriceForAsg = Optional.empty();
+    if (autoScalingGroup.getMixedInstancesPolicy() != null) {
+      spotMaxPriceForAsg =
+          Optional.ofNullable(
+              autoScalingGroup
+                  .getMixedInstancesPolicy()
+                  .getInstancesDistribution()
+                  .getSpotMaxPrice());
+    } else {
+      LaunchTemplateInstanceMarketOptions marketOptions = ltData.getInstanceMarketOptions();
+      if (marketOptions != null && marketOptions.getSpotOptions() != null) {
+        spotMaxPriceForAsg = Optional.ofNullable(marketOptions.getSpotOptions().getMaxPrice());
+      }
+    }
+    if (spotMaxPriceForAsg.isPresent()) {
+      return spotMaxPriceForAsg.get().trim().equals("") ? null : spotMaxPriceForAsg.get();
+    }
+
+    return null;
+  }
+
   private boolean matchingBlockDevices(
       List<LaunchTemplateBlockDeviceMapping> mappings,
-      List<AmazonBlockDevice> blockDevicesForInstanceType) {
+      List<AmazonBlockDevice> defaultBlockDevicesForInstanceType) {
     for (LaunchTemplateBlockDeviceMapping mapping : mappings) {
-      if (blockDevicesForInstanceType.stream()
+      if (defaultBlockDevicesForInstanceType.stream()
           .anyMatch(deviceForType -> !matchesDevice(deviceForType, mapping))) {
         return false;
       }
@@ -315,7 +420,6 @@ public class PrepareModifyServerGroupLaunchTemplate
   @Value
   public static class PrepareModifyServerGroupLaunchTemplateCommand implements SagaCommand {
     @Nonnull private ModifyServerGroupLaunchTemplateDescription description;
-
     @NonFinal private EventMetadata metadata;
 
     @Override

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/PrepareUpdateAutoScalingGroup.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/PrepareUpdateAutoScalingGroup.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions;
+
+import com.amazonaws.services.autoscaling.model.LaunchTemplateOverrides;
+import com.amazonaws.services.ec2.model.LaunchTemplateVersion;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.BasicAmazonDeployDescription.LaunchTemplateOverridesForInstanceType;
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription;
+import com.netflix.spinnaker.clouddriver.event.EventMetadata;
+import com.netflix.spinnaker.clouddriver.saga.SagaCommand;
+import com.netflix.spinnaker.clouddriver.saga.flow.SagaAction;
+import com.netflix.spinnaker.clouddriver.saga.models.Saga;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+
+/** Action to prepare for AWS EC2 Auto Scaling Group update. */
+@Component
+public class PrepareUpdateAutoScalingGroup
+    implements SagaAction<PrepareUpdateAutoScalingGroup.PrepareUpdateAutoScalingGroupCommand> {
+  @NotNull
+  @Override
+  public Result apply(@NotNull PrepareUpdateAutoScalingGroupCommand command, @NotNull Saga saga) {
+    ModifyServerGroupLaunchTemplateDescription description = command.description;
+
+    saga.log(
+        "[SAGA_ACTION] Preparing to update EC2 Auto Scaling Group " + description.getAsgName());
+
+    // transform overrides
+    List<LaunchTemplateOverridesForInstanceType> overridesInReq =
+        description.getLaunchTemplateOverridesForInstanceType();
+    List<LaunchTemplateOverrides> ltOverrides = null;
+    if (overridesInReq != null && !overridesInReq.isEmpty()) {
+      ltOverrides =
+          description.getLaunchTemplateOverridesForInstanceType().stream()
+              .map(
+                  o ->
+                      new LaunchTemplateOverrides()
+                          .withInstanceType(o.getInstanceType())
+                          .withWeightedCapacity(o.getWeightedCapacity()))
+              .collect(Collectors.toList());
+    }
+
+    UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand updateCommand =
+        UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand.builder()
+            .description(description)
+            .launchTemplateVersion(command.launchTemplateVersion)
+            .launchTemplateOverrides(ltOverrides)
+            .isReqToUpgradeAsgToMixedInstancesPolicy(
+                command.isReqToUpgradeAsgToMixedInstancesPolicy)
+            .newLaunchTemplateVersionNumber(command.newLaunchTemplateVersionNumber)
+            .build();
+    return new Result(updateCommand, Collections.emptyList());
+  }
+
+  @Builder(builderClassName = "PrepareUpdateAutoScalingGroupCommandBuilder", toBuilder = true)
+  @JsonDeserialize(
+      builder =
+          PrepareUpdateAutoScalingGroupCommand.PrepareUpdateAutoScalingGroupCommandBuilder.class)
+  @JsonTypeName("PrepareUpdateAutoScalingGroupCommand")
+  @Value
+  public static class PrepareUpdateAutoScalingGroupCommand implements SagaCommand {
+    @Nonnull private ModifyServerGroupLaunchTemplateDescription description;
+    @Nonnull private LaunchTemplateVersion launchTemplateVersion;
+    @Nonnull private Boolean isReqToUpgradeAsgToMixedInstancesPolicy;
+    @Nullable private Long newLaunchTemplateVersionNumber;
+    @NonFinal private EventMetadata metadata;
+
+    @Override
+    public void setMetadata(@NotNull EventMetadata metadata) {
+      this.metadata = metadata;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class PrepareUpdateAutoScalingGroupCommandBuilder {}
+  }
+}

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/UpdateAutoScalingGroup.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/UpdateAutoScalingGroup.java
@@ -17,27 +17,40 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions;
 
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
+import com.amazonaws.services.autoscaling.model.InstancesDistribution;
+import com.amazonaws.services.autoscaling.model.LaunchTemplate;
+import com.amazonaws.services.autoscaling.model.LaunchTemplateOverrides;
 import com.amazonaws.services.autoscaling.model.LaunchTemplateSpecification;
+import com.amazonaws.services.autoscaling.model.MixedInstancesPolicy;
 import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest;
+import com.amazonaws.services.ec2.model.LaunchTemplateVersion;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription;
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.ModifyServerGroupLaunchTemplateAtomicOperation.LaunchTemplateException;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.services.LaunchTemplateService;
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory;
 import com.netflix.spinnaker.clouddriver.event.EventMetadata;
 import com.netflix.spinnaker.clouddriver.saga.SagaCommand;
 import com.netflix.spinnaker.clouddriver.saga.flow.SagaAction;
 import com.netflix.spinnaker.clouddriver.saga.models.Saga;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
+import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.NonFinal;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
+/** Action to update an AWS EC2 Auto Scaling Group. */
+@Slf4j
 @Component
 public class UpdateAutoScalingGroup
     implements SagaAction<UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand> {
@@ -60,19 +73,150 @@ public class UpdateAutoScalingGroup
         (NetflixAmazonCredentials) credentialsRepository.getOne(description.getAccount());
     RegionScopedProviderFactory.RegionScopedProvider regionScopedProvider =
         regionScopedProviderFactory.forRegion(credentials, description.getRegion());
-    try {
-      regionScopedProvider
-          .getAutoScaling()
-          .updateAutoScalingGroup(
-              new UpdateAutoScalingGroupRequest()
-                  .withAutoScalingGroupName(description.getAsgName())
-                  .withLaunchTemplate(command.launchTemplateSpecification));
-    } catch (Exception e) {
-      throw new LaunchTemplateException(
-          String.format("Failed to update server group %s", description.getAsgName()), e);
+
+    saga.log("[SAGA_ACTION] Updating EC2 Auto Scaling Group " + description.getAsgName());
+
+    // build update request
+    UpdateAutoScalingGroupRequest updateReq =
+        new UpdateAutoScalingGroupRequest().withAutoScalingGroupName(description.getAsgName());
+
+    AutoScalingGroup autoScalingGroup =
+        getAutoScalingGroup(description.getAsgName(), regionScopedProvider);
+    boolean isAsgBackedByMip = autoScalingGroup.getMixedInstancesPolicy() != null;
+
+    if (isAsgBackedByMip) {
+      // update existing MIP
+      final MixedInstancesPolicy existingMipInAsg = autoScalingGroup.getMixedInstancesPolicy();
+
+      MixedInstancesPolicy mip =
+          new MixedInstancesPolicy()
+              .withLaunchTemplate(
+                  new LaunchTemplate()
+                      .withLaunchTemplateSpecification(
+                          new LaunchTemplateSpecification()
+                              .withLaunchTemplateId(
+                                  command.launchTemplateVersion.getLaunchTemplateId())
+                              .withVersion(
+                                  String.valueOf(command.launchTemplateVersion.getVersionNumber())))
+                      .withOverrides(
+                          command.launchTemplateOverrides != null
+                              ? command.launchTemplateOverrides
+                              : existingMipInAsg.getLaunchTemplate().getOverrides()))
+              .withInstancesDistribution(
+                  new InstancesDistribution()
+                      .withOnDemandAllocationStrategy(
+                          description.getOnDemandAllocationStrategy() != null
+                              ? description.getOnDemandAllocationStrategy()
+                              : existingMipInAsg
+                                  .getInstancesDistribution()
+                                  .getOnDemandAllocationStrategy())
+                      .withOnDemandBaseCapacity(
+                          description.getOnDemandBaseCapacity() != null
+                              ? description.getOnDemandBaseCapacity()
+                              : existingMipInAsg
+                                  .getInstancesDistribution()
+                                  .getOnDemandBaseCapacity())
+                      .withOnDemandPercentageAboveBaseCapacity(
+                          description.getOnDemandPercentageAboveBaseCapacity() != null
+                              ? description.getOnDemandPercentageAboveBaseCapacity()
+                              : existingMipInAsg
+                                  .getInstancesDistribution()
+                                  .getOnDemandPercentageAboveBaseCapacity())
+                      .withSpotAllocationStrategy(
+                          description.getSpotAllocationStrategy() != null
+                              ? description.getSpotAllocationStrategy()
+                              : existingMipInAsg
+                                  .getInstancesDistribution()
+                                  .getSpotAllocationStrategy())
+                      .withSpotInstancePools(
+                          description.getSpotInstancePools() != null
+                              ? description.getSpotInstancePools()
+                              : existingMipInAsg.getInstancesDistribution().getSpotInstancePools())
+                      .withSpotMaxPrice(
+                          StringUtils.isNotBlank(description.getSpotPrice())
+                              ? description.getSpotPrice()
+                              : existingMipInAsg.getInstancesDistribution().getSpotMaxPrice()));
+
+      updateReq.withMixedInstancesPolicy(mip);
+    } else {
+      if (command.isReqToUpgradeAsgToMixedInstancesPolicy) {
+        // create new MIP
+        MixedInstancesPolicy mip =
+            new MixedInstancesPolicy()
+                .withLaunchTemplate(
+                    new LaunchTemplate()
+                        .withLaunchTemplateSpecification(
+                            new LaunchTemplateSpecification()
+                                .withLaunchTemplateId(
+                                    command.launchTemplateVersion.getLaunchTemplateId())
+                                .withVersion(
+                                    String.valueOf(
+                                        command.launchTemplateVersion.getVersionNumber())))
+                        .withOverrides(command.launchTemplateOverrides))
+                .withInstancesDistribution(
+                    new InstancesDistribution()
+                        .withOnDemandAllocationStrategy(description.getOnDemandAllocationStrategy())
+                        .withOnDemandBaseCapacity(description.getOnDemandBaseCapacity())
+                        .withOnDemandPercentageAboveBaseCapacity(
+                            description.getOnDemandPercentageAboveBaseCapacity())
+                        .withSpotAllocationStrategy(description.getSpotAllocationStrategy())
+                        .withSpotInstancePools(description.getSpotInstancePools())
+                        .withSpotMaxPrice(description.getSpotPrice()));
+
+        updateReq.withMixedInstancesPolicy(mip);
+      } else {
+        updateReq.withLaunchTemplate(
+            new LaunchTemplateSpecification()
+                .withLaunchTemplateId(command.launchTemplateVersion.getLaunchTemplateId())
+                .withVersion(String.valueOf(command.launchTemplateVersion.getVersionNumber())));
+      }
     }
 
+    try {
+      regionScopedProvider.getAutoScaling().updateAutoScalingGroup(updateReq);
+    } catch (Exception e) {
+      StringBuilder exceptionMsg =
+          new StringBuilder("Failed to update server group " + description.getAsgName() + ".");
+      if (StringUtils.isNotBlank(e.getMessage())) {
+        exceptionMsg.append(" Error message(s): " + e.getMessage());
+      }
+
+      try {
+        // Clean up newly created launch template version by the Saga Flow, in order to keep the
+        // latest version unaltered.
+        // This step is required because only the default and latest launch template versions for a
+        // launch template are cached.
+        // Not cleaning up will result in Internal Server Error for Clouddriver API requests and
+        // subsequent Deck errors.
+        if (command.getNewLaunchTemplateVersionNumber() != null) {
+          log.info("Cleaning up to keep the operation atomic.");
+          cleanUpOnFailure(
+              regionScopedProvider.getLaunchTemplateService(),
+              command.getLaunchTemplateVersion().getLaunchTemplateId(),
+              command.getNewLaunchTemplateVersionNumber());
+        }
+      } catch (Exception ex) {
+        exceptionMsg.append(ex.getMessage());
+      }
+      throw new LaunchTemplateException(exceptionMsg.toString(), e);
+    }
     return new Result();
+  }
+
+  private AutoScalingGroup getAutoScalingGroup(
+      String autoScalingGroupName,
+      RegionScopedProviderFactory.RegionScopedProvider regionScopedProvider) {
+    try {
+      return regionScopedProvider.getAsgService().getAutoScalingGroup(autoScalingGroupName);
+    } catch (Exception e) {
+      throw new LaunchTemplateException(
+          String.format("Failed to get server group %s.", autoScalingGroupName), e);
+    }
+  }
+
+  private void cleanUpOnFailure(
+      LaunchTemplateService ltService, String launchTemplateId, Long ltVersionToDelete) {
+    ltService.deleteLaunchTemplateVersion(launchTemplateId, ltVersionToDelete);
   }
 
   @Builder(builderClassName = "UpdateAutoScalingGroupCommandBuilder", toBuilder = true)
@@ -81,14 +225,16 @@ public class UpdateAutoScalingGroup
   @JsonTypeName("updateAutoScalingGroupCommand")
   @Value
   public static class UpdateAutoScalingGroupCommand implements SagaCommand {
-    @Nonnull private LaunchTemplateSpecification launchTemplateSpecification;
     @Nonnull private ModifyServerGroupLaunchTemplateDescription description;
-
+    @Nonnull private LaunchTemplateVersion launchTemplateVersion;
+    @Nullable private Long newLaunchTemplateVersionNumber;
+    @Nullable private List<LaunchTemplateOverrides> launchTemplateOverrides;
+    @Nonnull private Boolean isReqToUpgradeAsgToMixedInstancesPolicy;
     @NonFinal private EventMetadata metadata;
 
     @Override
-    public void setMetadata(@NotNull EventMetadata eventMetadata) {
-      this.metadata = eventMetadata;
+    public void setMetadata(@NotNull EventMetadata metadata) {
+      this.metadata = metadata;
     }
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -23,6 +23,8 @@ import com.amazonaws.services.autoscaling.model.LaunchTemplateSpecification;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.*;
 import com.netflix.spinnaker.clouddriver.aws.deploy.AmazonResourceTagger;
+import com.netflix.spinnaker.clouddriver.aws.deploy.InstanceTypeUtils;
+import com.netflix.spinnaker.clouddriver.aws.deploy.asg.AsgConfigHelper;
 import com.netflix.spinnaker.clouddriver.aws.deploy.asg.AutoScalingWorker.AsgConfiguration;
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription;
 import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.LocalFileUserDataProperties;
@@ -80,21 +82,6 @@ public class LaunchTemplateService {
     this.amazonResourceTaggers = amazonResourceTaggers;
   }
 
-  public LaunchTemplateVersion modifyLaunchTemplate(
-      NetflixAmazonCredentials credentials,
-      ModifyServerGroupLaunchTemplateDescription description,
-      LaunchTemplateVersion sourceVersion) {
-    RequestLaunchTemplateData data =
-        buildLaunchTemplateData(credentials, new AsgConfiguration(), description, sourceVersion);
-    CreateLaunchTemplateVersionResult result =
-        ec2.createLaunchTemplateVersion(
-            new CreateLaunchTemplateVersionRequest()
-                .withSourceVersion(String.valueOf(sourceVersion.getVersionNumber()))
-                .withLaunchTemplateId(sourceVersion.getLaunchTemplateId())
-                .withLaunchTemplateData(data));
-    return result.getLaunchTemplateVersion();
-  }
-
   public Optional<LaunchTemplateVersion> getLaunchTemplateVersion(
       LaunchTemplateSpecification launchTemplateSpecification) {
     final List<LaunchTemplateVersion> versions = new ArrayList<>();
@@ -129,7 +116,7 @@ public class LaunchTemplateService {
       AsgConfiguration asgConfig, String asgName, String launchTemplateName) {
     final RequestLaunchTemplateData data =
         buildLaunchTemplateData(asgConfig, asgName, launchTemplateName);
-    log.debug("Creating launch template with name {}", launchTemplateName);
+    log.info("Creating launch template with name {}", launchTemplateName);
     return retrySupport.retry(
         () -> {
           final CreateLaunchTemplateRequest launchTemplateRequest =
@@ -143,37 +130,146 @@ public class LaunchTemplateService {
         false);
   }
 
+  public LaunchTemplateVersion modifyLaunchTemplate(
+      NetflixAmazonCredentials credentials,
+      ModifyServerGroupLaunchTemplateDescription description,
+      LaunchTemplateVersion sourceLtVersion,
+      boolean shouldUseMixedInstancesPolicy) {
+
+    RequestLaunchTemplateData data =
+        buildLaunchTemplateDataForModify(
+            credentials,
+            new AsgConfiguration(),
+            description,
+            sourceLtVersion,
+            shouldUseMixedInstancesPolicy);
+    CreateLaunchTemplateVersionResult result =
+        ec2.createLaunchTemplateVersion(
+            new CreateLaunchTemplateVersionRequest()
+                .withLaunchTemplateId(sourceLtVersion.getLaunchTemplateId())
+                .withLaunchTemplateData(data));
+
+    return result.getLaunchTemplateVersion();
+  }
+
+  /**
+   * Delete a launch template version. A new launch template when it is modified.
+   * https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeleteLaunchTemplateVersions.html
+   *
+   * @param launchTemplateId launch template ID for the version to delete
+   * @param versionToDelete launch template version to delete
+   */
+  public void deleteLaunchTemplateVersion(String launchTemplateId, Long versionToDelete) {
+    log.info(
+        String.format(
+            "Attempting to delete launch template version %s for launch template ID %s.",
+            versionToDelete, launchTemplateId));
+
+    DeleteLaunchTemplateVersionsResult result =
+        ec2.deleteLaunchTemplateVersions(
+            new DeleteLaunchTemplateVersionsRequest()
+                .withLaunchTemplateId(launchTemplateId)
+                .withVersions(String.valueOf(versionToDelete)));
+
+    if (result.getUnsuccessfullyDeletedLaunchTemplateVersions() != null
+        && !result.getUnsuccessfullyDeletedLaunchTemplateVersions().isEmpty()) {
+      DeleteLaunchTemplateVersionsResponseErrorItem responseErrorItem =
+          result.getUnsuccessfullyDeletedLaunchTemplateVersions().get(0);
+      ResponseError failureResponseError = responseErrorItem.getResponseError();
+      List<String> codesConsideredSuccess =
+          List.of("launchTemplateIdDoesNotExist", "launchTemplateVersionDoesNotExist");
+
+      if (failureResponseError != null
+          && !codesConsideredSuccess.contains(failureResponseError.getCode())) {
+        throw new RuntimeException(
+            String.format(
+                "Failed to delete launch template version %s for launch template ID %s because of %s",
+                responseErrorItem.getVersionNumber(),
+                responseErrorItem.getLaunchTemplateId(),
+                failureResponseError.getCode()));
+      }
+    }
+  }
+
   /**
    * Build launch template data for launch template modification i.e. new launch template version
    */
-  private RequestLaunchTemplateData buildLaunchTemplateData(
+  private RequestLaunchTemplateData buildLaunchTemplateDataForModify(
       NetflixAmazonCredentials credentials,
       AsgConfiguration asgConfiguration,
-      ModifyServerGroupLaunchTemplateDescription description,
-      LaunchTemplateVersion launchTemplateVersion) {
+      ModifyServerGroupLaunchTemplateDescription modifyDesc,
+      LaunchTemplateVersion sourceLtVersion,
+      boolean shouldUseMixedInstancesPolicy) {
+
+    ResponseLaunchTemplateData sourceLtData = sourceLtVersion.getLaunchTemplateData();
+
     RequestLaunchTemplateData request =
         new RequestLaunchTemplateData()
-            .withImageId(description.getImageId())
-            .withKernelId(description.getKernelId())
-            .withInstanceType(description.getInstanceType())
-            .withRamDiskId(description.getRamdiskId())
-            .withIamInstanceProfile(
-                new LaunchTemplateIamInstanceProfileSpecificationRequest()
-                    .withName(description.getIamRole()));
+            .withImageId(
+                modifyDesc.getImageId() != null
+                    ? modifyDesc.getImageId()
+                    : sourceLtData.getImageId())
+            .withKernelId(
+                StringUtils.isNotBlank(modifyDesc.getKernelId())
+                    ? modifyDesc.getKernelId()
+                    : sourceLtData.getKernelId())
+            .withInstanceType(
+                StringUtils.isNotBlank(modifyDesc.getInstanceType())
+                    ? modifyDesc.getInstanceType()
+                    : sourceLtData.getInstanceType())
+            .withRamDiskId(
+                StringUtils.isNotBlank(modifyDesc.getRamdiskId())
+                    ? modifyDesc.getRamdiskId()
+                    : sourceLtData.getRamDiskId())
+            .withEbsOptimized(
+                Optional.ofNullable(modifyDesc.getEbsOptimized())
+                    .orElseGet(sourceLtData::getEbsOptimized));
 
+    // key name
+    if (StringUtils.isNotBlank(modifyDesc.getKeyPair())) {
+      request.withKeyName(modifyDesc.getKeyPair());
+    } else if (StringUtils.isNotBlank(sourceLtData.getKeyName())) {
+      request.withKeyName(sourceLtData.getKeyName());
+    }
+
+    // iam instance profile
+    if (StringUtils.isNotBlank(modifyDesc.getIamRole())) {
+      request.withIamInstanceProfile(
+          new LaunchTemplateIamInstanceProfileSpecificationRequest()
+              .withName(modifyDesc.getIamRole()));
+    } else if (sourceLtData.getIamInstanceProfile() != null
+        && StringUtils.isNotBlank(sourceLtData.getIamInstanceProfile().getName())) {
+      request.withIamInstanceProfile(
+          new LaunchTemplateIamInstanceProfileSpecificationRequest()
+              .withName(sourceLtData.getIamInstanceProfile().getName()));
+    }
+
+    // instance monitoring
+    if (modifyDesc.getInstanceMonitoring() != null) {
+      request.setMonitoring(
+          new LaunchTemplatesMonitoringRequest().withEnabled(modifyDesc.getInstanceMonitoring()));
+    } else if (sourceLtData.getMonitoring() != null
+        && sourceLtData.getMonitoring().getEnabled() != null) {
+      request.setMonitoring(
+          new LaunchTemplatesMonitoringRequest()
+              .withEnabled(sourceLtData.getMonitoring().getEnabled()));
+    }
+
+    // block device mappings
+    if (modifyDesc.getBlockDevices() != null) {
+      request.setBlockDeviceMappings(buildDeviceMapping(modifyDesc.getBlockDevices()));
+    } else if (sourceLtData.getBlockDeviceMappings() != null) {
+      request.setBlockDeviceMappings(
+          buildDeviceMapping(
+              AsgConfigHelper.transformLaunchTemplateBlockDeviceMapping(
+                  sourceLtData.getBlockDeviceMappings())));
+    }
+
+    // tags
     Optional<LaunchTemplateTagSpecificationRequest> tagSpecification =
-        tagSpecification(amazonResourceTaggers, asgConfiguration, description.getAsgName());
+        tagSpecification(amazonResourceTaggers, asgConfiguration, modifyDesc.getAsgName());
     if (tagSpecification.isPresent()) {
       request = request.withTagSpecifications(tagSpecification.get());
-    }
-
-    if (description.getEbsOptimized() != null) {
-      request.setEbsOptimized(description.getEbsOptimized());
-    }
-
-    if (description.getInstanceMonitoring() != null) {
-      request.setMonitoring(
-          new LaunchTemplatesMonitoringRequest().withEnabled(description.getInstanceMonitoring()));
     }
 
     /*
@@ -182,49 +278,59 @@ public class LaunchTemplateService {
     */
     String base64UserData =
         (localFileUserDataProperties != null && !localFileUserDataProperties.isEnabled())
-            ? launchTemplateVersion.getLaunchTemplateData().getUserData()
+            ? sourceLtData.getUserData()
             : null;
     setUserData(
         request,
-        description.getAsgName(),
-        launchTemplateVersion.getLaunchTemplateName(),
-        description.getRegion(),
-        description.getAccount(),
+        modifyDesc.getAsgName(),
+        sourceLtVersion.getLaunchTemplateName(),
+        modifyDesc.getRegion(),
+        modifyDesc.getAccount(),
         credentials.getEnvironment(),
         credentials.getAccountType(),
-        description.getIamRole(),
-        description.getImageId(),
+        modifyDesc.getIamRole(),
+        modifyDesc.getImageId(),
         base64UserData,
-        description.getLegacyUdf(),
-        description.getUserDataOverride());
-
-    // block device mappings
-    if (description.getBlockDevices() != null) {
-      request.setBlockDeviceMappings(buildDeviceMapping(description.getBlockDevices()));
-    }
+        modifyDesc.getLegacyUdf(),
+        modifyDesc.getUserDataOverride());
 
     // metadata options
-    if (description.getRequireIMDV2() != null) {
+    if (modifyDesc.getRequireIMDV2() != null) {
       request.setMetadataOptions(
           new LaunchTemplateInstanceMetadataOptionsRequest()
-              .withHttpTokens(description.getRequireIMDV2() ? "required" : ""));
+              .withHttpTokens(modifyDesc.getRequireIMDV2() ? "required" : ""));
+    } else if (sourceLtData.getMetadataOptions() != null) {
+      request.setMetadataOptions(
+          new LaunchTemplateInstanceMetadataOptionsRequest()
+              .withHttpTokens(sourceLtData.getMetadataOptions().getHttpTokens()));
     }
 
-    // instance market options
-    setSpotInstanceMarketOptions(request, description.getSpotPrice());
+    // set instance market options only when mixed instances policy is NOT used in order to maintain
+    // launch template compatibility
+    if (!shouldUseMixedInstancesPolicy) {
+      setSpotInstanceMarketOptions(request, modifyDesc.getSpotPrice());
+    }
 
-    setCreditSpecification(request, description.getUnlimitedCpuCredits());
+    // credit specification
+    if (modifyDesc.getUnlimitedCpuCredits() != null) {
+      // compatibility is already validated by validator
+      setCreditSpecification(request, modifyDesc.getUnlimitedCpuCredits());
+    } else if (sourceLtData.getCreditSpecification() != null) {
+      // The description might include changed instance types.
+      // Ensure compatibility before using value from sourceLtData.
+      Boolean unlimitedCpuCreditsFromSrcAsg =
+          AsgConfigHelper.getUnlimitedCpuCreditsFromAncestorLt(
+              sourceLtData.getCreditSpecification(),
+              InstanceTypeUtils.isBurstingSupportedByAllTypes(modifyDesc.getAllInstanceTypes()));
+      setCreditSpecification(request, unlimitedCpuCreditsFromSrcAsg);
+    }
 
     // network interfaces
-    LaunchTemplateInstanceNetworkInterfaceSpecificationRequest networkInterfaceRequest =
-        new LaunchTemplateInstanceNetworkInterfaceSpecificationRequest();
-
     LaunchTemplateInstanceNetworkInterfaceSpecification defaultInterface;
-    List<LaunchTemplateInstanceNetworkInterfaceSpecification> networkInterfaces =
-        launchTemplateVersion.getLaunchTemplateData().getNetworkInterfaces();
-    if (networkInterfaces != null && !networkInterfaces.isEmpty()) {
+    if (sourceLtData.getNetworkInterfaces() != null
+        && !sourceLtData.getNetworkInterfaces().isEmpty()) {
       defaultInterface =
-          networkInterfaces.stream()
+          sourceLtData.getNetworkInterfaces().stream()
               .filter(i -> i.getDeviceIndex() == 0)
               .findFirst()
               .orElseGet(LaunchTemplateInstanceNetworkInterfaceSpecification::new);
@@ -232,28 +338,35 @@ public class LaunchTemplateService {
       defaultInterface = new LaunchTemplateInstanceNetworkInterfaceSpecification();
     }
 
-    if (description.getAssociateIPv6Address() != null) {
-      networkInterfaceRequest.setIpv6AddressCount(
-          description.getAssociateIPv6Address() || defaultInterface.getIpv6AddressCount() > 0
-              ? 1
-              : 0);
-    }
-
-    if (description.getAssociatePublicIpAddress() != null) {
-      networkInterfaceRequest.setAssociatePublicIpAddress(
-          description.getAssociatePublicIpAddress());
-    }
-
-    networkInterfaceRequest.setDeviceIndex(0);
-    networkInterfaceRequest.setGroups(description.getSecurityGroups());
+    request.withNetworkInterfaces(
+        new LaunchTemplateInstanceNetworkInterfaceSpecificationRequest()
+            .withAssociatePublicIpAddress(
+                Optional.ofNullable(modifyDesc.getAssociatePublicIpAddress())
+                    .orElseGet(() -> defaultInterface.getAssociatePublicIpAddress()))
+            .withIpv6AddressCount(
+                modifyDesc.getAssociateIPv6Address() != null
+                    ? modifyDesc.getAssociateIPv6Address() ? 1 : 0
+                    : defaultInterface.getIpv6AddressCount() != null
+                            && defaultInterface.getIpv6AddressCount() > 0
+                        ? 1
+                        : 0)
+            .withGroups(
+                modifyDesc.getSecurityGroups() != null && !modifyDesc.getSecurityGroups().isEmpty()
+                    ? modifyDesc.getSecurityGroups()
+                    : defaultInterface.getGroups())
+            .withDeviceIndex(0));
 
     // Nitro Enclave options
-    if (description.getEnableEnclave() != null) {
+    if (modifyDesc.getEnableEnclave() != null) {
       request.setEnclaveOptions(
-          new LaunchTemplateEnclaveOptionsRequest().withEnabled(description.getEnableEnclave()));
+          new LaunchTemplateEnclaveOptionsRequest().withEnabled(modifyDesc.getEnableEnclave()));
+    } else if (sourceLtData.getEnclaveOptions() != null) {
+      request.setEnclaveOptions(
+          new LaunchTemplateEnclaveOptionsRequest()
+              .withEnabled(sourceLtData.getEnclaveOptions().getEnabled()));
     }
 
-    return request.withNetworkInterfaces(networkInterfaceRequest);
+    return request;
   }
 
   /** Build launch template data for new launch template creation */
@@ -325,9 +438,8 @@ public class LaunchTemplateService {
           new LaunchTemplateInstanceMetadataOptionsRequest().withHttpTokens("required"));
     }
 
-    // instance market options only when mixed instances policy is not used in order to maintain
+    // set instance market options only when mixed instances policy is NOT used in order to maintain
     // launch template compatibility
-
     if (!asgConfig.shouldUseMixedInstancesPolicy()) {
       setSpotInstanceMarketOptions(request, asgConfig.getSpotMaxPrice());
     }
@@ -370,7 +482,7 @@ public class LaunchTemplateService {
     if (maxSpotPrice != null && StringUtils.isNotEmpty(maxSpotPrice.trim())) {
       request.setInstanceMarketOptions(
           new LaunchTemplateInstanceMarketOptionsRequest()
-              .withMarketType("spot")
+              .withMarketType(MarketType.Spot)
               .withSpotOptions(
                   new LaunchTemplateSpotMarketOptionsRequest().withMaxPrice(maxSpotPrice)));
     }
@@ -410,6 +522,10 @@ public class LaunchTemplateService {
 
   private List<LaunchTemplateBlockDeviceMappingRequest> buildDeviceMapping(
       List<AmazonBlockDevice> amazonBlockDevices) {
+    if (amazonBlockDevices == null || amazonBlockDevices.isEmpty()) {
+      return null;
+    }
+
     final List<LaunchTemplateBlockDeviceMappingRequest> mappings = new ArrayList<>();
     for (AmazonBlockDevice blockDevice : amazonBlockDevices) {
       LaunchTemplateBlockDeviceMappingRequest mapping =

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -149,6 +149,12 @@ public class LaunchTemplateService {
                 .withLaunchTemplateId(sourceLtVersion.getLaunchTemplateId())
                 .withLaunchTemplateData(data));
 
+    log.info(
+        String.format(
+            "Created new launch template version %s for launch template ID %s",
+            result.getLaunchTemplateVersion().getVersionNumber(),
+            result.getLaunchTemplateVersion().getLaunchTemplateId()));
+
     return result.getLaunchTemplateVersion();
   }
 
@@ -176,6 +182,9 @@ public class LaunchTemplateService {
       DeleteLaunchTemplateVersionsResponseErrorItem responseErrorItem =
           result.getUnsuccessfullyDeletedLaunchTemplateVersions().get(0);
       ResponseError failureResponseError = responseErrorItem.getResponseError();
+
+      // certain error codes can be considered success when they match the desired end state.
+      // this also acts as a safety net in retry scenarios.
       List<String> codesConsideredSuccess =
           List.of("launchTemplateIdDoesNotExist", "launchTemplateVersionDoesNotExist");
 
@@ -183,7 +192,7 @@ public class LaunchTemplateService {
           && !codesConsideredSuccess.contains(failureResponseError.getCode())) {
         throw new RuntimeException(
             String.format(
-                "Failed to delete launch template version %s for launch template ID %s because of %s",
+                "Failed to delete launch template version %s for launch template ID %s because of error '%s'",
                 responseErrorItem.getVersionNumber(),
                 responseErrorItem.getLaunchTemplateId(),
                 failureResponseError.getCode()));

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/ModifyServerGroupLaunchTemplateSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/ModifyServerGroupLaunchTemplateSpec.groovy
@@ -1,0 +1,82 @@
+package com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions
+
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup
+import com.amazonaws.services.autoscaling.model.LaunchTemplateSpecification
+import com.amazonaws.services.ec2.model.*
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription
+import com.netflix.spinnaker.clouddriver.aws.services.LaunchTemplateService
+import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import com.netflix.spinnaker.clouddriver.saga.flow.SagaAction
+import com.netflix.spinnaker.clouddriver.saga.models.Saga
+import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class ModifyServerGroupLaunchTemplateSpec extends Specification {
+  def credentials = TestCredential.named("test")
+  def ltService = Mock(LaunchTemplateService)
+  def credentialsRepository = Stub(MapBackedCredentialsRepository) {
+    getOne(_) >> credentials
+  }
+
+  def autoScalingGroupWithLt = new AutoScalingGroup(
+    autoScalingGroupName: "test-v001",
+    launchTemplate: new LaunchTemplateSpecification(launchTemplateName: "lt-1", version: "1")
+  )
+
+  def regionScopedProvider = Stub(RegionScopedProviderFactory.RegionScopedProvider) {
+    getLaunchTemplateService() >> ltService
+  }
+
+  def regionScopedProviderFactory = Mock(RegionScopedProviderFactory) {
+    forRegion(_, _) >> regionScopedProvider
+  }
+
+  def dummyDescription = new ModifyServerGroupLaunchTemplateDescription(
+    region: "us-east-1",
+    asgName: autoScalingGroupWithLt.autoScalingGroupName,
+    amiName: "ami-1",
+    credentials: credentials
+  )
+
+  @Subject
+  def modifyAction = new ModifyServerGroupLaunchTemplate(credentialsRepository, regionScopedProviderFactory)
+
+  @Unroll
+  def "should modify launch template as expected"() {
+    given:
+    def dummySrcVersion = new LaunchTemplateVersion()
+    def modifyCommand = new ModifyServerGroupLaunchTemplate.ModifyServerGroupLaunchTemplateCommand.ModifyServerGroupLaunchTemplateCommandBuilder()
+      .description(dummyDescription)
+      .isAsgBackedByMixedInstancesPolicy(asgBackedByMip)
+      .isReqToModifyLaunchTemplate(reqToModifyLaunchTemplate)
+      .isReqToUpgradeAsgToMixedInstancesPolicy(convertAsgToUseMip)
+      .sourceVersion(dummySrcVersion)
+      .build()
+
+    def newDummyVersion = new LaunchTemplateVersion(launchTemplateId: "lt-1", versionNumber: 2L)
+
+    when:
+    SagaAction.Result result = modifyAction.apply(modifyCommand, new Saga("test", "test"))
+
+    then:
+    result.nextCommand instanceof PrepareUpdateAutoScalingGroup.PrepareUpdateAutoScalingGroupCommand
+    ((PrepareUpdateAutoScalingGroup.PrepareUpdateAutoScalingGroupCommand) result.nextCommand).newLaunchTemplateVersionNumber == newLtVersionNumber
+    ((PrepareUpdateAutoScalingGroup.PrepareUpdateAutoScalingGroupCommand) result.nextCommand).isReqToUpgradeAsgToMixedInstancesPolicy == convertAsgToUseMip
+    if (reqToModifyLaunchTemplate) {
+      1 * ltService.modifyLaunchTemplate(credentials, dummyDescription, dummySrcVersion, shouldUseMipInModify) >> newDummyVersion
+    } else {
+      // modify action skipped
+      0 * ltService.modifyLaunchTemplate(credentials, dummyDescription, dummySrcVersion, shouldUseMipInModify) >> newDummyVersion
+    }
+
+    where:
+    asgBackedByMip    | reqToModifyLaunchTemplate | convertAsgToUseMip  || shouldUseMipInModify || newLtVersionNumber
+      true            |        true               |        false        ||      true            ||      2L            // update ASG MIP with new LT version
+      true            |        false              |        false        ||      true            ||     null           // update ASG MIP properties without creating a new LT version
+      false           |        true               |        true         ||      true            ||      2L            // update ASG LT with new LT version and convert ASG to use MIP
+      false           |        true               |        false        ||      false           ||      2L            // update ASG LT with new LT version, but don't use MIP
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/PrepareModifyServerGroupLaunchTemplateSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/PrepareModifyServerGroupLaunchTemplateSpec.groovy
@@ -1,7 +1,9 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions
 
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup
+import com.amazonaws.services.autoscaling.model.InstancesDistribution
 import com.amazonaws.services.autoscaling.model.LaunchTemplateSpecification
+import com.amazonaws.services.autoscaling.model.MixedInstancesPolicy
 import com.amazonaws.services.ec2.AmazonEC2
 import com.amazonaws.services.ec2.model.*
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
@@ -11,12 +13,16 @@ import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
 import com.netflix.spinnaker.clouddriver.aws.services.AsgService
 import com.netflix.spinnaker.clouddriver.aws.services.LaunchTemplateService
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import com.netflix.spinnaker.clouddriver.saga.flow.SagaAction
 import com.netflix.spinnaker.clouddriver.saga.models.Saga
 import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.Unroll
 
 class PrepareModifyServerGroupLaunchTemplateSpec extends Specification {
+  private static final String LT_ID_1 = "lt-1", LT_ID_1_V = "1"
+
   def credentials = TestCredential.named("test")
   def ltService = Mock(LaunchTemplateService)
   def asgService = Mock(AsgService)
@@ -26,9 +32,9 @@ class PrepareModifyServerGroupLaunchTemplateSpec extends Specification {
     getOne(_) >> credentials
   }
 
-  def autoScalingGroup = new AutoScalingGroup(
+  def autoScalingGroupWithLt = new AutoScalingGroup(
     autoScalingGroupName: "test-v001",
-    launchTemplate: new LaunchTemplateSpecification(launchTemplateName: "lt-1", version: "1")
+    launchTemplate: new LaunchTemplateSpecification(launchTemplateName: LT_ID_1, version: LT_ID_1_V)
   )
 
   def regionScopedProvider = Stub(RegionScopedProviderFactory.RegionScopedProvider) {
@@ -45,22 +51,29 @@ class PrepareModifyServerGroupLaunchTemplateSpec extends Specification {
   def prepareAction = new PrepareModifyServerGroupLaunchTemplate(
     blockDeviceConfig, credentialsRepository, regionScopedProviderFactory)
 
+  ModifyServerGroupLaunchTemplateDescription modifyDescription
+  def prepareCommand
+
+  def setup() {
+    modifyDescription = new ModifyServerGroupLaunchTemplateDescription(
+      region: "us-east-1",
+      asgName: autoScalingGroupWithLt.autoScalingGroupName,
+      credentials: credentials)
+
+    prepareCommand = new PrepareModifyServerGroupLaunchTemplate.PrepareModifyServerGroupLaunchTemplateCommand.PrepareModifyServerGroupLaunchTemplateCommandBuilder().description(modifyDescription).build()
+  }
+
   def "should prepare for launch template update"() {
     given:
-    def description = new ModifyServerGroupLaunchTemplateDescription(
-      region: "us-east-1",
-      asgName: autoScalingGroup.autoScalingGroupName,
-      amiName: "ami-1",
-      credentials: credentials
-    )
+    modifyDescription.instanceType = "c5.large"
 
-    def prepareCommand = new PrepareModifyServerGroupLaunchTemplate.PrepareModifyServerGroupLaunchTemplateCommand(description, null)
-
-    def ltVersion = new LaunchTemplateVersion(
-      launchTemplateName: "lt-1",
-      versionNumber: "1",
+    and:
+    def ltVersionBeforeModify = new LaunchTemplateVersion(
+      launchTemplateName: LT_ID_1,
+      versionNumber: LT_ID_1_V,
       launchTemplateData: new ResponseLaunchTemplateData(
         imageId: "ami-1",
+        instanceType: "c3.large"
       )
     )
 
@@ -68,22 +81,164 @@ class PrepareModifyServerGroupLaunchTemplateSpec extends Specification {
     prepareAction.apply(prepareCommand, new Saga("test", "test"))
 
     then:
-    1 * asgService.getAutoScalingGroup("test-v001") >> autoScalingGroup
-    1 * ltService.getLaunchTemplateVersion(autoScalingGroup.launchTemplate) >> Optional.of(ltVersion)
-    1 * ec2.describeImages(_) >> { DescribeImagesRequest req ->
-      new DescribeImagesResult().withImages(req.imageIds.collect { new Image(imageId: it) })
-    }
+    1 * asgService.getAutoScalingGroup("test-v001") >> autoScalingGroupWithLt
+    1 * ltService.getLaunchTemplateVersion(autoScalingGroupWithLt.launchTemplate) >> Optional.of(ltVersionBeforeModify)
+    1 * blockDeviceConfig.getBlockDevicesForInstanceType("c5.large")
+    1 * blockDeviceConfig.getBlockDevicesForInstanceType("c3.large")
   }
 
-  def "should include security groups from previous launch template: #desc"() {
-    def description = new ModifyServerGroupLaunchTemplateDescription(
-      region: "us-east-1",
-      asgName: autoScalingGroup.autoScalingGroupName,
-      amiName: "ami-1",
-      securityGroups: securityGroups,
-      securityGroupsAppendOnly: sgAppendOnly
+  @Unroll
+  def "should prepare for launch template and ASG update for a server group backed by mixed instances policy"() {
+    given:
+    modifyDescription.spotAllocationStrategy = spotAllocationStrategy   // Mixed instances policy property
+    modifyDescription.instanceType = instanceType                       // Launch template property
+    modifyDescription.spotPrice = spotPrice                             // Mixed instances policy property as ASG is backed by MIP
+
+    and:
+    def mixedInstancesPolicy = new MixedInstancesPolicy(
+      launchTemplate: new com.amazonaws.services.autoscaling.model.LaunchTemplate(
+        launchTemplateSpecification: autoScalingGroupWithLt.launchTemplate,
+        overrides: [
+          new com.amazonaws.services.autoscaling.model.LaunchTemplateOverrides(instanceType: "c3.large", weightedCapacity: "2"),
+          new com.amazonaws.services.autoscaling.model.LaunchTemplateOverrides(instanceType: "c3.xlarge", weightedCapacity: "4")
+        ]
+      ),
+      instancesDistribution: new InstancesDistribution(
+        onDemandAllocationStrategy: "prioritized",
+        onDemandBaseCapacity: 2,
+        onDemandPercentageAboveBaseCapacity: 50,
+        spotAllocationStrategy: "lowest-price",
+        spotMaxPrice: "1"
+      )
     )
-    def prepareCommand = new PrepareModifyServerGroupLaunchTemplate.PrepareModifyServerGroupLaunchTemplateCommand(description, null)
+    def autoScalingGroup = new AutoScalingGroup(
+      autoScalingGroupName: "test-v001",
+      mixedInstancesPolicy: mixedInstancesPolicy
+    )
+
+    def ltVersionBeforeModify = new LaunchTemplateVersion(
+      launchTemplateName: LT_ID_1,
+      versionNumber: LT_ID_1_V,
+      launchTemplateData: new ResponseLaunchTemplateData(
+        imageId: "ami-1",
+        instanceType: "m5.large"
+      )
+    )
+
+    when:
+    SagaAction.Result result = prepareAction.apply(prepareCommand, new Saga("test", "test"))
+
+    then:
+    1 * asgService.getAutoScalingGroup("test-v001") >> autoScalingGroup
+    1 * ltService.getLaunchTemplateVersion(autoScalingGroup.mixedInstancesPolicy.launchTemplate.launchTemplateSpecification) >> Optional.of(ltVersionBeforeModify)
+    if (!expectedToSkipStep) {
+      1 * blockDeviceConfig.getBlockDevicesForInstanceType("c3.large")
+      1 * blockDeviceConfig.getBlockDevicesForInstanceType("m5.large")
+    }
+
+    and:
+    def nextCommand = ((ModifyServerGroupLaunchTemplate.ModifyServerGroupLaunchTemplateCommand) result.nextCommand)
+    nextCommand instanceof ModifyServerGroupLaunchTemplate.ModifyServerGroupLaunchTemplateCommand
+    nextCommand.isReqToModifyLaunchTemplate == !expectedToSkipStep
+    nextCommand.isAsgBackedByMixedInstancesPolicy == true
+    nextCommand.isReqToUpgradeAsgToMixedInstancesPolicy == false
+
+    where:
+    spotAllocationStrategy| spotPrice | instanceType|| expectedToSkipStep
+     "capacity-optimized" |    null   |  "c3.large" ||     false         // isReqToModifyMipFieldsOnly is false
+             null         |    "1"    |  "c3.large" ||     false         // isReqToModifyMipFieldsOnly is false
+    "capacity-optimized"  |    "1"    |  "c3.large" ||     false         // isReqToModifyMipFieldsOnly is false
+    "capacity-optimized"  |   null    |      null   ||     true          // isReqToModifyMipFieldsOnly is true
+             null         |    "1"    |      null   ||     true          // isReqToModifyMipFieldsOnly is true
+  }
+
+  @Unroll
+  def "should prepare for launch template and ASG update for a server group backed by launch template and to be updated to use mixed instances policy"() {
+    given:
+    modifyDescription.spotAllocationStrategy = spotAllocationStrategy
+    modifyDescription.spotPrice = newSpotPrice
+
+    and:
+    def autoScalingGroup = new AutoScalingGroup(
+      autoScalingGroupName: "test-v001",
+      launchTemplate: new LaunchTemplateSpecification(launchTemplateName: LT_ID_1, version: LT_ID_1_V)
+    )
+
+    def ltVersionBeforeModify = new LaunchTemplateVersion(
+      launchTemplateName: LT_ID_1,
+      versionNumber: LT_ID_1_V,
+      launchTemplateData: new ResponseLaunchTemplateData(
+        imageId: "ami-1",
+        instanceMarketOptions: asgHasSpotLt
+          ? new LaunchTemplateInstanceMarketOptions().withMarketType("spot").withSpotOptions(new LaunchTemplateSpotMarketOptions(maxPrice: "0.5"))
+          : null
+      )
+    )
+
+    when:
+    SagaAction.Result result = prepareAction.apply(prepareCommand, new Saga("test", "test"))
+
+    then:
+    1 * asgService.getAutoScalingGroup("test-v001") >> autoScalingGroup
+    1 * ltService.getLaunchTemplateVersion(autoScalingGroup.launchTemplate) >> Optional.of(ltVersionBeforeModify)
+
+    and:
+    def nextCommand = ((ModifyServerGroupLaunchTemplate.ModifyServerGroupLaunchTemplateCommand) result.nextCommand)
+    nextCommand instanceof ModifyServerGroupLaunchTemplate.ModifyServerGroupLaunchTemplateCommand
+    nextCommand.isReqToModifyLaunchTemplate == !expectedToSkipStep
+    nextCommand.isAsgBackedByMixedInstancesPolicy == false
+    nextCommand.isReqToUpgradeAsgToMixedInstancesPolicy == true
+
+    and:
+    def descPassed = nextCommand.description
+    descPassed.spotPrice == expectedSpotPrice
+
+    where:
+    spotAllocationStrategy | newSpotPrice| asgHasSpotLt ||  expectedSpotPrice  || expectedToSkipStep
+     "capacity-optimized"  |   "1"       |    true      ||         "1"         ||    false             // modify LT, create a new LT version with new spot max price
+     "capacity-optimized"  |  ""         |    true      ||          null       ||    false             // modify LT, create a new LT version withOUT spot options
+     "capacity-optimized"  |  null       |    true      ||         "0.5"       ||    false             // modify LT, create a new LT version with new spot max price
+                null       |  "1"        |    false     ||         "1"         ||    true              // skip new LT version, and upgrade to MIP
+     "capacity-optimized"  |  null       |    false     ||          null       ||    true              // skip new LT version, and upgrade to MIP
+  }
+
+  @Unroll
+  def "should resolve image id correctly, with precedence give to imageId first, ami name second"() {
+    given:
+    modifyDescription.imageId = imageIdInReq
+    modifyDescription.amiName = amiNameInReq
+
+    def ltVersionBeforeModify = new LaunchTemplateVersion(
+      launchTemplateName: LT_ID_1,
+      versionNumber: 1,
+      launchTemplateData: new ResponseLaunchTemplateData(
+        imageId: imageIdInSrc
+      )
+    )
+
+    when:
+    prepareAction.apply(prepareCommand, new Saga("test", "test"))
+
+    then:
+    1 * asgService.getAutoScalingGroup(autoScalingGroupWithLt.autoScalingGroupName) >> autoScalingGroupWithLt
+    1 * ltService.getLaunchTemplateVersion(autoScalingGroupWithLt.launchTemplate) >> Optional.of(ltVersionBeforeModify)
+    resolveAmiCallCount * ec2.describeImages(_) >> { DescribeImagesRequest req ->
+      new DescribeImagesResult().withImages(req.imageIds.collect { new Image(imageId: "img-from-ami") })
+    }
+
+    where:
+    imageIdInReq | amiNameInReq | resolveAmiCallCount | imageIdInSrc   || expectedImageIdPassed
+    "img-req"    | "ami-1"      |         0           | "img-src"      ||   "img-req"
+    null         | "ami-1"      |         1           |  "img-src"     ||   "img-from-ami"
+    null         | null         |         0           |  "img-src"     ||   "img-src"
+  }
+
+  @Unroll
+  def "should include security groups from previous launch template: #desc"() {
+    given:
+    modifyDescription.securityGroups = securityGroups
+    modifyDescription.securityGroupsAppendOnly = sgAppendOnly
+    modifyDescription.amiName = "ami-1"
 
     def launchTemplateData = new ResponseLaunchTemplateData(
       imageId: "ami-1",
@@ -95,8 +250,8 @@ class PrepareModifyServerGroupLaunchTemplateSpec extends Specification {
       ],
     )
 
-    def ltVersion = new LaunchTemplateVersion(
-      launchTemplateName: "lt-1",
+    def ltVersionBeforeModify = new LaunchTemplateVersion(
+      launchTemplateName: LT_ID_1,
       versionNumber: 1,
       launchTemplateData: launchTemplateData
     )
@@ -105,12 +260,12 @@ class PrepareModifyServerGroupLaunchTemplateSpec extends Specification {
     prepareAction.apply(prepareCommand, new Saga("test", "test"))
 
     then:
-    1 * asgService.getAutoScalingGroup(autoScalingGroup.autoScalingGroupName) >> autoScalingGroup
-    1 * ltService.getLaunchTemplateVersion(autoScalingGroup.launchTemplate) >> Optional.of(ltVersion)
+    1 * asgService.getAutoScalingGroup(autoScalingGroupWithLt.autoScalingGroupName) >> autoScalingGroupWithLt
+    1 * ltService.getLaunchTemplateVersion(autoScalingGroupWithLt.launchTemplate) >> Optional.of(ltVersionBeforeModify)
     1 * ec2.describeImages(_) >> { DescribeImagesRequest req ->
       new DescribeImagesResult().withImages(req.imageIds.collect { new Image(imageId: it) })
     }
-    description.getSecurityGroups().sort() == expectedGroups
+    modifyDescription.getSecurityGroups().sort() == expectedGroups
 
     where:
     securityGroups | sgAppendOnly || expectedGroups   || desc
@@ -125,17 +280,10 @@ class PrepareModifyServerGroupLaunchTemplateSpec extends Specification {
   def "should reset custom block devices when changing instance type"() {
     given:
     String newInstanceType = "m3-large"
-    def description = new ModifyServerGroupLaunchTemplateDescription(
-      region: "us-east-1",
-      asgName: autoScalingGroup.autoScalingGroupName,
-      amiName: "ami-1",
-      imageId: "ami-1",
-      credentials: credentials,
-      instanceType: newInstanceType,
-      blockDevices: null
-    )
-
-    def prepareCommand = new PrepareModifyServerGroupLaunchTemplate.PrepareModifyServerGroupLaunchTemplateCommand(description, null)
+    modifyDescription.amiName = "ami-1"
+    modifyDescription.imageId = "ami-1"
+    modifyDescription.instanceType = newInstanceType
+    modifyDescription.blockDevices = null
 
     def launchTemplateData = new ResponseLaunchTemplateData(
       imageId: "ami-1",
@@ -154,8 +302,8 @@ class PrepareModifyServerGroupLaunchTemplateSpec extends Specification {
       ]
     )
 
-    def ltVersion = new LaunchTemplateVersion(
-      launchTemplateName: "lt-1",
+    def ltVersionBeforeModify = new LaunchTemplateVersion(
+      launchTemplateName: LT_ID_1,
       versionNumber: 1,
       launchTemplateData: launchTemplateData
     )
@@ -164,8 +312,8 @@ class PrepareModifyServerGroupLaunchTemplateSpec extends Specification {
     prepareAction.apply(prepareCommand, new Saga("test", "test"))
 
     then:
-    1 * asgService.getAutoScalingGroup("test-v001") >> autoScalingGroup
-    1 * ltService.getLaunchTemplateVersion(autoScalingGroup.launchTemplate) >> Optional.of(ltVersion)
+    1 * asgService.getAutoScalingGroup("test-v001") >> autoScalingGroupWithLt
+    1 * ltService.getLaunchTemplateVersion(autoScalingGroupWithLt.launchTemplate) >> Optional.of(ltVersionBeforeModify)
     1 * blockDeviceConfig.getBlockDevicesForInstanceType(launchTemplateData.instanceType) >> [
       new AmazonBlockDevice(deviceName: '/dev/sdb', size: 40)
     ]
@@ -173,7 +321,7 @@ class PrepareModifyServerGroupLaunchTemplateSpec extends Specification {
       new AmazonBlockDevice(deviceName: '/dev/sdb', size: 80)
     ]
 
-    description.blockDevices.size() == 1
-    description.blockDevices[0].size == 80
+    modifyDescription.blockDevices.size() == 1
+    modifyDescription.blockDevices[0].size == 80
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/PrepareUpdateAutoScalingGroupSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/PrepareUpdateAutoScalingGroupSpec.groovy
@@ -1,0 +1,65 @@
+package com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions
+
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup
+import com.amazonaws.services.autoscaling.model.LaunchTemplateSpecification
+import com.amazonaws.services.ec2.model.*
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.BasicAmazonDeployDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription
+import com.netflix.spinnaker.clouddriver.saga.flow.SagaAction
+import com.netflix.spinnaker.clouddriver.saga.models.Saga
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class PrepareUpdateAutoScalingGroupSpec extends Specification {
+
+  def autoScalingGroupWithLt = new AutoScalingGroup(
+    autoScalingGroupName: "test-v001",
+    launchTemplate: new LaunchTemplateSpecification(launchTemplateName: "lt-1", version: "1")
+  )
+
+  def description = new ModifyServerGroupLaunchTemplateDescription(
+    region: "us-east-1",
+    asgName: autoScalingGroupWithLt.autoScalingGroupName,
+    amiName: "ami-1"
+  )
+
+  @Subject
+  def prepareAction = new PrepareUpdateAutoScalingGroup()
+
+  @Unroll
+  def "should prepare for update ASG as expected"() {
+    given:
+    description.launchTemplateOverridesForInstanceType = descOverrides
+
+    def newDummyVersion = new LaunchTemplateVersion(launchTemplateId: "lt-1", versionNumber: 2L)
+    def prepareCommand = new PrepareUpdateAutoScalingGroup.PrepareUpdateAutoScalingGroupCommand.PrepareUpdateAutoScalingGroupCommandBuilder()
+      .description(description)
+      .launchTemplateVersion(newDummyVersion)
+      .isReqToUpgradeAsgToMixedInstancesPolicy(false)
+      .newLaunchTemplateVersionNumber(2L)
+      .build()
+
+    when:
+    SagaAction.Result result = prepareAction.apply(prepareCommand, new Saga("test", "test"))
+
+    then:
+    result.nextCommand instanceof UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand
+    ((UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand) result.nextCommand).launchTemplateVersion == prepareCommand.launchTemplateVersion
+    ((UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand) result.nextCommand).isReqToUpgradeAsgToMixedInstancesPolicy == prepareCommand.isReqToUpgradeAsgToMixedInstancesPolicy
+    ((UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand) result.nextCommand).newLaunchTemplateVersionNumber == prepareCommand.newLaunchTemplateVersionNumber
+
+    if (descOverrides) {
+      ((UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand) result.nextCommand).launchTemplateOverrides == [new LaunchTemplateOverrides().withWeightedCapacity(2).withInstanceType("m5.xlarge")]
+    } else {
+      ((UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand) result.nextCommand).launchTemplateOverrides == null
+    }
+
+    where:
+    descOverrides << [
+      [new BasicAmazonDeployDescription.LaunchTemplateOverridesForInstanceType(instanceType: "m5.xlarge", weightedCapacity: 2)],
+      null,
+      []
+    ]
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/UpdateAutoScalingGroupSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/UpdateAutoScalingGroupSpec.groovy
@@ -1,0 +1,271 @@
+package com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions
+
+import com.amazonaws.services.autoscaling.AmazonAutoScaling
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup
+import com.amazonaws.services.autoscaling.model.InstancesDistribution
+import com.amazonaws.services.autoscaling.model.LaunchTemplateSpecification
+import com.amazonaws.services.autoscaling.model.MixedInstancesPolicy
+import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest
+import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupResult
+import com.amazonaws.services.ec2.model.*
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.ModifyServerGroupLaunchTemplateAtomicOperation
+import com.netflix.spinnaker.clouddriver.aws.services.AsgService
+import com.netflix.spinnaker.clouddriver.aws.services.LaunchTemplateService
+import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import com.netflix.spinnaker.clouddriver.saga.models.Saga
+import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class UpdateAutoScalingGroupSpec extends Specification {
+  def credentials = TestCredential.named("test")
+  def autoScaling = Mock(AmazonAutoScaling)
+  def ltService = Mock(LaunchTemplateService)
+  def asgService = Mock(AsgService)
+  def credentialsRepository = Stub(MapBackedCredentialsRepository) {
+    getOne(_) >> credentials
+  }
+
+  def regionScopedProvider = Stub(RegionScopedProviderFactory.RegionScopedProvider) {
+    getAsgService() >> asgService
+    getAutoScaling() >> autoScaling
+    getLaunchTemplateService() >> ltService
+  }
+
+  def regionScopedProviderFactory = Mock(RegionScopedProviderFactory) {
+    forRegion(_, _) >> regionScopedProvider
+  }
+
+  @Subject
+  def updateAction = new UpdateAutoScalingGroup(regionScopedProviderFactory, credentialsRepository)
+
+  def asgName = "test-v001"
+  def ltVersion = new LaunchTemplateVersion(
+    launchTemplateId: "lt-1",
+    launchTemplateData: new ResponseLaunchTemplateData(
+      imageId: "ami-1",
+    ),
+    versionNumber: 3L
+  )
+  def existingMip = new MixedInstancesPolicy(
+    launchTemplate: new com.amazonaws.services.autoscaling.model.LaunchTemplate(
+      launchTemplateSpecification: new LaunchTemplateSpecification(launchTemplateId: ltVersion.launchTemplateId, version: ltVersion.versionNumber),
+      overrides: [
+        new com.amazonaws.services.autoscaling.model.LaunchTemplateOverrides(instanceType: "c3.large", weightedCapacity: "2"),
+        new com.amazonaws.services.autoscaling.model.LaunchTemplateOverrides(instanceType: "c3.xlarge", weightedCapacity: "4")
+      ]
+    ),
+    instancesDistribution: new InstancesDistribution(
+      onDemandAllocationStrategy: "prioritized",
+      onDemandBaseCapacity: 2,
+      onDemandPercentageAboveBaseCapacity: 50,
+      spotAllocationStrategy: "lowest-price",
+      spotMaxPrice: "1"
+    )
+  )
+
+  def "should update ASG backed by mixed instances policy correctly"() {
+    given:
+    def modifyDesc = new ModifyServerGroupLaunchTemplateDescription(
+      region: "us-east-1",
+      asgName: asgName,
+      amiName: "ami-1",
+      credentials: credentials,
+      spotAllocationStrategy: "capacity-optimized"
+    )
+
+    and:
+    def asgWithMip = new AutoScalingGroup(
+      autoScalingGroupName: asgName,
+      mixedInstancesPolicy: existingMip
+    )
+
+    and:
+    def updateCommand = new UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand.UpdateAutoScalingGroupCommandBuilder()
+      .description(modifyDesc)
+      .launchTemplateVersion(ltVersion)
+      .newLaunchTemplateVersionNumber(ltVersion.getVersionNumber())
+      .launchTemplateOverrides(null)
+      .isReqToUpgradeAsgToMixedInstancesPolicy(false)
+      .build()
+
+    when:
+    updateAction.apply(updateCommand, new Saga("test", "test"))
+
+    then:
+    1 * asgService.getAutoScalingGroup(asgName) >> asgWithMip
+    1 * autoScaling.updateAutoScalingGroup(_ as UpdateAutoScalingGroupRequest) >> { arguments ->
+      // assert arguments passed and return
+      UpdateAutoScalingGroupRequest updateReq = arguments[0]
+
+      assert updateReq.autoScalingGroupName == asgName
+      assert updateReq.launchTemplate == null
+
+      assert updateReq.mixedInstancesPolicy.instancesDistribution == new InstancesDistribution(
+        onDemandAllocationStrategy: "prioritized",
+        onDemandBaseCapacity: 2,
+        onDemandPercentageAboveBaseCapacity: 50,
+        spotAllocationStrategy: "capacity-optimized",
+        spotInstancePools: null,
+        spotMaxPrice: "1"
+      )
+      assert updateReq.mixedInstancesPolicy.launchTemplate.launchTemplateSpecification == new LaunchTemplateSpecification(
+        launchTemplateId: ltVersion.launchTemplateId,
+        version: String.valueOf(ltVersion.getVersionNumber())
+      )
+      assert updateReq.mixedInstancesPolicy.launchTemplate.overrides == existingMip.launchTemplate.overrides; new UpdateAutoScalingGroupResult()
+    }
+  }
+
+  def "should update ASG backed by launch template correctly"() {
+    given:
+    def modifyDesc = new ModifyServerGroupLaunchTemplateDescription(
+      region: "us-east-1",
+      asgName: asgName,
+      amiName: "ami-1",
+      credentials: credentials,
+      instanceType: "new.type"
+    )
+
+    and:
+    def asgWithLt = new AutoScalingGroup(
+      autoScalingGroupName: asgName,
+      launchTemplate: new LaunchTemplateSpecification(launchTemplateName: ltVersion.launchTemplateId, version: String.valueOf(ltVersion.getVersionNumber()))
+    )
+
+    and:
+    def updateCommand = new UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand.UpdateAutoScalingGroupCommandBuilder()
+      .description(modifyDesc)
+      .launchTemplateVersion(ltVersion)
+      .newLaunchTemplateVersionNumber(ltVersion.getVersionNumber())
+      .launchTemplateOverrides(null)
+      .isReqToUpgradeAsgToMixedInstancesPolicy(false)
+      .build()
+
+    when:
+    updateAction.apply(updateCommand, new Saga("test", "test"))
+
+    then:
+    1 * asgService.getAutoScalingGroup(asgName) >> asgWithLt
+    1 * autoScaling.updateAutoScalingGroup(_ as UpdateAutoScalingGroupRequest) >> { arguments ->
+      // assert arguments passed and return
+      UpdateAutoScalingGroupRequest updateReq = arguments[0]
+
+      assert updateReq.autoScalingGroupName == asgName
+      assert updateReq.mixedInstancesPolicy == null
+
+      assert updateReq.launchTemplate.launchTemplateId == ltVersion.launchTemplateId
+      assert updateReq.launchTemplate.version == String.valueOf(ltVersion.getVersionNumber()); new UpdateAutoScalingGroupResult()
+    }
+  }
+
+  def "should convert ASG backed by launch template to use mixed instances policy correctly"() {
+    given:
+    def modifyDesc = new ModifyServerGroupLaunchTemplateDescription(
+      region: "us-east-1",
+      asgName: asgName,
+      amiName: "ami-1",
+      credentials: credentials,
+      spotAllocationStrategy: "capacity-optimized",
+      spotPrice: "1"
+    )
+
+    and:
+    def asgWithLt = new AutoScalingGroup(
+      autoScalingGroupName: asgName,
+      launchTemplate: new LaunchTemplateSpecification(launchTemplateId: ltVersion.launchTemplateId, version: String.valueOf(ltVersion.getVersionNumber()))
+    )
+
+    and:
+    def updateCommand = new UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand.UpdateAutoScalingGroupCommandBuilder()
+      .description(modifyDesc)
+      .launchTemplateVersion(ltVersion)
+      .newLaunchTemplateVersionNumber(ltVersion.getVersionNumber())
+      .launchTemplateOverrides(null)
+      .isReqToUpgradeAsgToMixedInstancesPolicy(true)
+      .build()
+
+    when:
+    updateAction.apply(updateCommand, new Saga("test", "test"))
+
+    then:
+    1 * asgService.getAutoScalingGroup(asgName) >> asgWithLt
+    1 * autoScaling.updateAutoScalingGroup(_ as UpdateAutoScalingGroupRequest) >> { arguments ->
+      // assert arguments passed and return
+      UpdateAutoScalingGroupRequest updateReq = arguments[0]
+
+      assert updateReq.autoScalingGroupName == asgName
+      assert updateReq.launchTemplate == null
+
+      // null values will take AWS defaults
+      assert updateReq.mixedInstancesPolicy.instancesDistribution == new InstancesDistribution(
+        onDemandAllocationStrategy: null,
+        onDemandBaseCapacity: null,
+        onDemandPercentageAboveBaseCapacity: null,
+        spotAllocationStrategy: "capacity-optimized",
+        spotInstancePools: null,
+        spotMaxPrice: "1"
+      )
+      assert updateReq.mixedInstancesPolicy.launchTemplate.launchTemplateSpecification == new LaunchTemplateSpecification(
+        launchTemplateId: ltVersion.launchTemplateId,
+        version: String.valueOf(ltVersion.getVersionNumber())
+      )
+
+      assert updateReq.mixedInstancesPolicy.launchTemplate.overrides == []; new UpdateAutoScalingGroupResult()
+    }
+  }
+
+  @Unroll
+  def "should clean up newly created launch template version on failure"() {
+    given:
+    def modifyDesc = new ModifyServerGroupLaunchTemplateDescription(
+      region: "us-east-1",
+      asgName: asgName,
+      amiName: "ami-1",
+      credentials: credentials,
+      instanceType: "new.type"
+    )
+
+    and:
+    def asgWithLt = new AutoScalingGroup(
+      autoScalingGroupName: asgName,
+      launchTemplate: new LaunchTemplateSpecification(launchTemplateName: ltVersion.launchTemplateId, version: String.valueOf(ltVersion.getVersionNumber()))
+    )
+
+    and:
+    def updateCommand = new UpdateAutoScalingGroup.UpdateAutoScalingGroupCommand.UpdateAutoScalingGroupCommandBuilder()
+      .description(modifyDesc)
+      .launchTemplateVersion(ltVersion)
+      .newLaunchTemplateVersionNumber(newLtVersionNum)
+      .launchTemplateOverrides(null)
+      .isReqToUpgradeAsgToMixedInstancesPolicy(false)
+      .build()
+
+    when:
+    updateAction.apply(updateCommand, new Saga("test", "test"))
+
+    then:
+    1 * asgService.getAutoScalingGroup(asgName) >> asgWithLt
+    1 * autoScaling.updateAutoScalingGroup(_) >> { throw new RuntimeException("Update ASG failed!")}
+    Exception ex = thrown(ModifyServerGroupLaunchTemplateAtomicOperation.LaunchTemplateException.class)
+
+    // verify clean up and exception message
+    if (newLtVersionNum) {
+      if (deleteLtVersionFailed) {
+        1 * ltService.deleteLaunchTemplateVersion(ltVersion.launchTemplateId, ltVersion.getVersionNumber()) >> { throw new RuntimeException("Launch template version delete failed!") }
+      } else {
+        1 * ltService.deleteLaunchTemplateVersion(ltVersion.launchTemplateId, ltVersion.getVersionNumber())
+      }
+    }
+    ex.message == exceptionMsgExpected
+
+    where:
+    newLtVersionNum | deleteLtVersionFailed |  exceptionMsgExpected
+          null      |          _            | "Failed to update server group test-v001. Error message(s): Update ASG failed!"
+          3L        |         true          | "Failed to update server group test-v001. Error message(s): Update ASG failed!Launch template version delete failed!"
+          3L        |         false         | "Failed to update server group test-v001. Error message(s): Update ASG failed!"
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/UpdateAutoScalingGroupSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/UpdateAutoScalingGroupSpec.groovy
@@ -255,17 +255,17 @@ class UpdateAutoScalingGroupSpec extends Specification {
     // verify clean up and exception message
     if (newLtVersionNum) {
       if (deleteLtVersionFailed) {
-        1 * ltService.deleteLaunchTemplateVersion(ltVersion.launchTemplateId, ltVersion.getVersionNumber()) >> { throw new RuntimeException("Launch template version delete failed!") }
+        1 * ltService.deleteLaunchTemplateVersion(ltVersion.launchTemplateId, newLtVersionNum) >> { throw new RuntimeException("Failed to delete launch template version $newLtVersionNum for launch template ID $ltVersion.launchTemplateId because of error 'unexpectedError'") }
       } else {
-        1 * ltService.deleteLaunchTemplateVersion(ltVersion.launchTemplateId, ltVersion.getVersionNumber())
+        1 * ltService.deleteLaunchTemplateVersion(ltVersion.launchTemplateId, newLtVersionNum)
       }
     }
     ex.message == exceptionMsgExpected
 
     where:
     newLtVersionNum | deleteLtVersionFailed |  exceptionMsgExpected
-          null      |          _            | "Failed to update server group test-v001. Error message(s): Update ASG failed!"
-          3L        |         true          | "Failed to update server group test-v001. Error message(s): Update ASG failed!Launch template version delete failed!"
-          3L        |         false         | "Failed to update server group test-v001. Error message(s): Update ASG failed!"
+          null      |          _            | "Failed to update server group test-v001.Error: Update ASG failed!\n"
+          3L        |         true          | "Failed to update server group test-v001.Error: Update ASG failed!\nFailed to clean up launch template version! Error: Failed to delete launch template version 3 for launch template ID lt-1 because of error 'unexpectedError'"
+          3L        |         false         | "Failed to update server group test-v001.Error: Update ASG failed!\n"
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ModifyServerGroupLaunchTemplateValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ModifyServerGroupLaunchTemplateValidatorSpec.groovy
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.BasicAmazonDeployDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
+import com.netflix.spinnaker.credentials.CredentialsRepository
+import spock.lang.Shared
+import spock.lang.Specification
+
+class ModifyServerGroupLaunchTemplateValidatorSpec extends Specification {
+
+  private static final ACCOUNT_NAME = "auto"
+
+  @Shared
+  ModifyServerGroupLaunchTemplateValidator validator
+
+  @Shared
+  NetflixAmazonCredentials amazonCredentials = TestCredential.named(ACCOUNT_NAME)
+
+  @Shared
+  def credentialsRepository = Stub(CredentialsRepository) {
+    getOne("auto") >> {amazonCredentials}
+  }
+
+  void setupSpec() {
+    validator = new ModifyServerGroupLaunchTemplateValidator()
+    validator.credentialsRepository = credentialsRepository
+  }
+
+  void "pass validation with proper description inputs"() {
+    setup:
+    def description = new ModifyServerGroupLaunchTemplateDescription(
+      asgName: "my-asg-v000", region: "us-east-1", amiName: "foo", instanceType: "foo", credentials: amazonCredentials, subnetType: "internal")
+    def errors = Mock(ValidationErrors)
+
+    when:
+    validator.validate([], description, errors)
+
+    then:
+    0 * errors._
+  }
+
+  void "should fail validation if asgName is unset"() {
+    setup:
+    def description = new ModifyServerGroupLaunchTemplateDescription(
+      asgName: asgName, region: "us-east-1", amiName: "foo", instanceType: "foo", credentials: amazonCredentials, subnetType: "internal")
+    def errors = Mock(ValidationErrors)
+
+    when:
+    validator.validate([], description, errors)
+
+    then:
+    1 * errors.rejectValue("asgName", "modifyservergrouplaunchtemplatedescription.asgName.empty")
+
+    where:
+    asgName << [null, "", " "]
+  }
+
+  void "should fail validation if only metadata fields are set"() {
+    setup:
+    def description = new ModifyServerGroupLaunchTemplateDescription(
+      asgName: "my-asg-v000", region: "us-east-1", credentials: amazonCredentials)
+    def errors = Mock(ValidationErrors)
+
+    when:
+    validator.validate([], description, errors)
+
+    then:
+    1 * errors.rejectValue("multiple fields",
+      "modifyservergrouplaunchtemplatedescription.launchTemplateAndServerGroupFields.empty",
+      "No changes requested to launch template or related server group fields for modifyServerGroupLaunchTemplate operation.")
+  }
+
+  void "valid request with unlimited cpu credits succeeds validation for supported instance types"() {
+    setup:
+    def description = new ModifyServerGroupLaunchTemplateDescription(
+      asgName: "my-asg-v000", region: "us-east-1", amiName: "foo", instanceType: instanceType,
+      credentials: amazonCredentials, subnetType: "internal", unlimitedCpuCredits: unlimitedCpuCredits)
+    def errors = Mock(ValidationErrors)
+
+    when:
+    validator.validate([], description, errors)
+
+    then:
+    if(expectedError == null) {
+      0 * errors._
+    } else {
+      1 * errors.rejectValue("unlimitedCpuCredits", expectedError)
+    }
+
+    where:
+    instanceType    |   unlimitedCpuCredits     ||  expectedError
+    't2.large'      |   null                    ||  null
+    't3.small'      |   true                    ||  null
+    't3a.micro'     |   false                   ||  null
+    'c3.large'      |   false                   || 'modifyservergrouplaunchtemplatedescription.bursting.not.supported.by.instanceType'
+    'c3.large'      |   true                    || 'modifyservergrouplaunchtemplatedescription.bursting.not.supported.by.instanceType'
+  }
+
+  void "validate all instance types in a request with multiple instance types"() {
+    setup:
+    def description = new ModifyServerGroupLaunchTemplateDescription(
+      asgName: "my-asg-v000", amiName: "foo", region: "us-east-1", credentials: amazonCredentials, subnetType: "internal")
+    def errors = Mock(ValidationErrors)
+
+    and:
+    ltOnlyPropertyAndValue.each { entry ->
+      description."$entry.key" = entry.value
+    }
+
+    when:
+    validator.validate([], description, errors)
+
+    then:
+    1 * errors.rejectValue("unlimitedCpuCredits", rejection)
+
+    where:
+    ltOnlyPropertyAndValue                                                              || rejection
+    [instanceType: "t2.large", unlimitedCpuCredits: true,
+     launchTemplateOverridesForInstanceType:[
+       new BasicAmazonDeployDescription.LaunchTemplateOverridesForInstanceType(
+         instanceType: "m5.xlarge", weightedCapacity: 4)]]                              || 'modifyservergrouplaunchtemplatedescription.bursting.not.supported.by.instanceType'
+
+    [instanceType: "c3.large", unlimitedCpuCredits: true,
+     launchTemplateOverridesForInstanceType:[
+       new BasicAmazonDeployDescription.LaunchTemplateOverridesForInstanceType(
+         instanceType: "t2.xlarge", weightedCapacity: 2)]]                              || 'modifyservergrouplaunchtemplatedescription.bursting.not.supported.by.instanceType'
+
+    [instanceType: "t3.small", unlimitedCpuCredits: true,
+     spotAllocationStrategy: "lowest-price",
+     launchTemplateOverridesForInstanceType:[
+       new BasicAmazonDeployDescription.LaunchTemplateOverridesForInstanceType(
+         instanceType: "c3.large", weightedCapacity: 4),
+       new BasicAmazonDeployDescription.LaunchTemplateOverridesForInstanceType(
+         instanceType: "t3.large", weightedCapacity: 2)]]                                  || 'modifyservergrouplaunchtemplatedescription.bursting.not.supported.by.instanceType'
+  }
+
+  void "invalid request with spotInstancePools and unsupported spotAllocationStrategy fails validation"() {
+    setup:
+    def description = new ModifyServerGroupLaunchTemplateDescription(
+      asgName: "my-asg-v000", region: "us-east-1", amiName: "foo", credentials: amazonCredentials,
+      subnetType: "internal", spotInstancePools: 3, spotAllocationStrategy: "capacity-optimized")
+    def errors = Mock(ValidationErrors)
+
+    when:
+    validator.validate([], description, errors)
+
+    then:
+    1 * errors.rejectValue("spotInstancePools", "modifyservergrouplaunchtemplatedescription.spotInstancePools.not.supported.for.spotAllocationStrategy")
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateServiceSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateServiceSpec.groovy
@@ -15,28 +15,79 @@
  */
 package com.netflix.spinnaker.clouddriver.aws.services
 
-import com.amazonaws.services.ec2.model.Tag
-import com.amazonaws.services.ec2.AmazonEC2
+import com.amazonaws.services.ec2.model.CreateLaunchTemplateVersionRequest
+import com.amazonaws.services.ec2.model.CreateLaunchTemplateVersionResult
+import com.amazonaws.services.ec2.model.CreditSpecification
+import com.amazonaws.services.ec2.model.CreditSpecificationRequest
+import com.amazonaws.services.ec2.model.DeleteLaunchTemplateVersionsRequest
+import com.amazonaws.services.ec2.model.DeleteLaunchTemplateVersionsResponseErrorItem
+import com.amazonaws.services.ec2.model.DeleteLaunchTemplateVersionsResponseSuccessItem
+import com.amazonaws.services.ec2.model.DeleteLaunchTemplateVersionsResult
+import com.amazonaws.services.ec2.model.LaunchTemplateBlockDeviceMapping
+import com.amazonaws.services.ec2.model.LaunchTemplateBlockDeviceMappingRequest
+import com.amazonaws.services.ec2.model.LaunchTemplateEbsBlockDevice
+import com.amazonaws.services.ec2.model.LaunchTemplateEbsBlockDeviceRequest
+import com.amazonaws.services.ec2.model.LaunchTemplateEnclaveOptions
+import com.amazonaws.services.ec2.model.LaunchTemplateEnclaveOptionsRequest
+import com.amazonaws.services.ec2.model.LaunchTemplateIamInstanceProfileSpecification
+import com.amazonaws.services.ec2.model.LaunchTemplateIamInstanceProfileSpecificationRequest
+import com.amazonaws.services.ec2.model.LaunchTemplateInstanceMarketOptions
+import com.amazonaws.services.ec2.model.LaunchTemplateInstanceMarketOptionsRequest
+import com.amazonaws.services.ec2.model.LaunchTemplateInstanceMetadataOptions
+import com.amazonaws.services.ec2.model.LaunchTemplateInstanceMetadataOptionsRequest
+import com.amazonaws.services.ec2.model.LaunchTemplateInstanceNetworkInterfaceSpecification
+import com.amazonaws.services.ec2.model.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest
+import com.amazonaws.services.ec2.model.LaunchTemplateSpotMarketOptions
+import com.amazonaws.services.ec2.model.LaunchTemplateSpotMarketOptionsRequest
 import com.amazonaws.services.ec2.model.LaunchTemplateTagSpecificationRequest
+import com.amazonaws.services.ec2.model.LaunchTemplateVersion
+import com.amazonaws.services.ec2.model.LaunchTemplatesMonitoring
+import com.amazonaws.services.ec2.model.LaunchTemplatesMonitoringRequest
+import com.amazonaws.services.ec2.model.RequestLaunchTemplateData
+import com.amazonaws.services.ec2.model.ResponseError
+import com.amazonaws.services.ec2.model.ResponseLaunchTemplateData
+import com.amazonaws.services.ec2.AmazonEC2
+import com.amazonaws.services.ec2.model.Tag
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.AmazonResourceTagger
 import com.netflix.spinnaker.clouddriver.aws.deploy.DefaultAmazonResourceTagger
-import com.netflix.spinnaker.clouddriver.aws.deploy.asg.AutoScalingWorker;
-import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.LocalFileUserDataProperties;
-import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.UserDataProviderAggregator;
+import com.netflix.spinnaker.clouddriver.aws.deploy.asg.AutoScalingWorker
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.LocalFileUserDataProperties
+import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.UserDataProviderAggregator
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Subject
 import spock.lang.Unroll
 
 class LaunchTemplateServiceSpec extends Specification {
-  def launchTemplateService = new LaunchTemplateService(
-    Mock(AmazonEC2),
-    Mock(UserDataProviderAggregator),
-    Mock(LocalFileUserDataProperties),
-    Collections.singletonList(
-      new DefaultAmazonResourceTagger("spinnaker:application", "spinnaker:cluster")
-    )
-  )
+  private static final String LT_ID_1 = "lt-1"
+  private static final String USER_DATA_STR = "my-userdata"
 
+  def mockEc2 = Mock(AmazonEC2)
+  def mockUserDataAggregator = Mock(UserDataProviderAggregator)
+
+  @Shared
+  NetflixAmazonCredentials testCredentials = TestCredential.named('test')
+
+  @Subject
+  @Shared
+  def launchTemplateService
+
+  def setup() {
+    mockUserDataAggregator.aggregate(_) >> USER_DATA_STR
+
+    launchTemplateService = new LaunchTemplateService(
+      mockEc2,
+      mockUserDataAggregator,
+      Mock(LocalFileUserDataProperties),
+      null
+    )
+  }
+
+  @Unroll
   void 'should match ebs encryption'() {
     when:
     def result = launchTemplateService.getLaunchTemplateEbsBlockDeviceRequest(blockDevice)
@@ -47,12 +98,21 @@ class LaunchTemplateServiceSpec extends Specification {
     where:
     blockDevice                                             | encrypted | kmsKeyId
     new AmazonBlockDevice()                                 | null      | null
-    new AmazonBlockDevice(encrypted: true)                  | true      | null
+    new AmazonBlockDevice(encrypted: true) | true | null
     new AmazonBlockDevice(encrypted: true, kmsKeyId: "xxx") | true      | "xxx"
   }
 
   @Unroll
   void 'should generate volume tags'() {
+    given:
+    launchTemplateService = new LaunchTemplateService(
+      mockEc2,
+      mockUserDataAggregator,
+      Mock(LocalFileUserDataProperties),
+      Collections.singletonList(
+        new DefaultAmazonResourceTagger("spinnaker:application", "spinnaker:cluster")
+      ))
+
     expect:
     launchTemplateService.tagSpecification(
       amazonResourceTaggers,
@@ -81,6 +141,193 @@ class LaunchTemplateServiceSpec extends Specification {
           ])
       )
     ]
+  }
 
+  @Unroll
+  void 'should generate launch template data for modify operation, with precedence given to description values first and then to source version values'() {
+    given:
+    def modifyDesc = new ModifyServerGroupLaunchTemplateDescription(
+      region: "us-east-1",
+      asgName: "myasg",
+      amiName: "ami-1",
+      credentials: testCredentials,
+      spotPrice: maxSpotPrice,
+      instanceType: instanceType,
+      securityGroups: secGroupsInDesc,
+    )
+
+    def srcLtVersionDataRespWithSpotOptions = new ResponseLaunchTemplateData(
+      imageId: "ami-1",
+      kernelId: "kernel-id-1",
+      instanceType: "t2.large",
+      ramDiskId: "ramdisk-id-1",
+      ebsOptimized: true,
+      keyName: "my-key-name",
+      iamInstanceProfile: new LaunchTemplateIamInstanceProfileSpecification().withName("my-iam-role"),
+      monitoring: new LaunchTemplatesMonitoring().withEnabled(true),
+      userData: USER_DATA_STR,
+      metadataOptions: new LaunchTemplateInstanceMetadataOptions().withHttpTokens("required"),
+      instanceMarketOptions: new LaunchTemplateInstanceMarketOptions().withMarketType("spot").withSpotOptions(new LaunchTemplateSpotMarketOptions().withMaxPrice("0.5")),
+      creditSpecification: new CreditSpecification().withCpuCredits("standard"),
+      networkInterfaces: [
+        new LaunchTemplateInstanceNetworkInterfaceSpecification(
+          deviceIndex: 0,
+          groups: secGroupsInSrc,
+          associatePublicIpAddress: true,
+          ipv6AddressCount: 1
+        )
+      ],
+      blockDeviceMappings: [
+        new LaunchTemplateBlockDeviceMapping(
+          deviceName: "/dev/sdb",
+          ebs: new LaunchTemplateEbsBlockDevice(volumeSize: 40)
+        )
+      ],
+      enclaveOptions: new LaunchTemplateEnclaveOptions().withEnabled(true)
+    )
+
+    def sourceLtVersion = new LaunchTemplateVersion(
+      launchTemplateId: LT_ID_1,
+      versionNumber: 1,
+      launchTemplateData: srcLtVersionDataRespWithSpotOptions
+    )
+
+    // RequestLaunchTemplateData built in the class under test
+    def expectedNewLtVersionDataReq = new RequestLaunchTemplateData(
+      imageId: "ami-1",
+      kernelId: "kernel-id-1",
+      instanceType: instanceType,
+      ramDiskId: "ramdisk-id-1",
+      ebsOptimized: true,
+      keyName: "my-key-name",
+      iamInstanceProfile: new LaunchTemplateIamInstanceProfileSpecificationRequest().withName("my-iam-role"),
+      monitoring: new LaunchTemplatesMonitoringRequest().withEnabled(true),
+      userData: USER_DATA_STR,
+      metadataOptions: new LaunchTemplateInstanceMetadataOptionsRequest().withHttpTokens("required"),
+      instanceMarketOptions:
+        setSpotOptions
+        ? new LaunchTemplateInstanceMarketOptionsRequest().withMarketType("spot").withSpotOptions(new LaunchTemplateSpotMarketOptionsRequest().withMaxPrice("0.5"))
+        : null,
+      creditSpecification:
+        copyCpuCreditSpecFromSrc ? new CreditSpecificationRequest().withCpuCredits("standard") : null,
+      networkInterfaces: [
+        new LaunchTemplateInstanceNetworkInterfaceSpecificationRequest(
+          deviceIndex: 0,
+          groups: expectedSecGroups,
+          associatePublicIpAddress: true,
+          ipv6AddressCount: 1
+        )
+      ],
+      blockDeviceMappings: [
+        new LaunchTemplateBlockDeviceMappingRequest(
+          deviceName: "/dev/sdb",
+          ebs: new LaunchTemplateEbsBlockDeviceRequest(volumeSize: 40)
+        )
+      ],
+      enclaveOptions: new LaunchTemplateEnclaveOptionsRequest().withEnabled(true)
+    )
+
+    when:
+    launchTemplateService.modifyLaunchTemplate(testCredentials, modifyDesc, sourceLtVersion, shouldUseMixedInstancesPolicy)
+
+    then:
+    1 * mockEc2.createLaunchTemplateVersion(_ as CreateLaunchTemplateVersionRequest) >> { arguments ->
+      // assert arguments passed and return dummy result
+      CreateLaunchTemplateVersionRequest reqInArg = arguments[0]
+      assert reqInArg.launchTemplateId == LT_ID_1 && reqInArg.launchTemplateData == expectedNewLtVersionDataReq ; new CreateLaunchTemplateVersionResult()
+        .withLaunchTemplateVersion(new LaunchTemplateVersion(
+          launchTemplateId: LT_ID_1,
+          versionNumber: 2L,
+          launchTemplateData: new ResponseLaunchTemplateData()))
+    }
+
+    where:
+    shouldUseMixedInstancesPolicy | maxSpotPrice || setSpotOptions | instanceType  || copyCpuCreditSpecFromSrc | secGroupsInDesc  | secGroupsInSrc || expectedSecGroups
+            true                  |     _        ||     false      |  't3.large'   ||     true                 |    ["new-sg-2"]  |  ["src-sg-1"]  ||  ["new-sg-2"]
+            false                 |     ""       ||     false      |  'c3.large'   ||     false                |         []       |  ["src-sg-1"]  ||  ["src-sg-1"]
+            false                 |   null       ||     false      |  't3.large'   ||     true                 |        null      |  ["src-sg-1"]  ||  ["src-sg-1"]
+            false                 |   "0.5"      ||      true      |  'm5.large'   ||     false                |        null      |       null     ||     null
+  }
+
+  @Unroll
+  void 'delete launch template version success scenarios are handled as expected'() {
+    given:
+    def versionToDelete = 2L
+
+    DeleteLaunchTemplateVersionsResponseSuccessItem successItem = ltIdSuccess
+      ? new DeleteLaunchTemplateVersionsResponseSuccessItem()
+      .withLaunchTemplateId(ltIdSuccess)
+      .withVersionNumber(versionToDelete)
+      : null
+
+    DeleteLaunchTemplateVersionsResponseErrorItem errorItem = ltIdFailure
+      ? new DeleteLaunchTemplateVersionsResponseErrorItem()
+      .withLaunchTemplateId(ltIdFailure)
+      .withVersionNumber(versionToDelete)
+      .withResponseError(new ResponseError().withCode(errorCode))
+      : null
+
+    DeleteLaunchTemplateVersionsResult result = new DeleteLaunchTemplateVersionsResult()
+      .withSuccessfullyDeletedLaunchTemplateVersions(successItem)
+      .withUnsuccessfullyDeletedLaunchTemplateVersions(errorItem)
+
+    when:
+    launchTemplateService.deleteLaunchTemplateVersion(LT_ID_1, versionToDelete)
+
+    then:
+    1 * mockEc2.deleteLaunchTemplateVersions(new DeleteLaunchTemplateVersionsRequest()
+      .withLaunchTemplateId(LT_ID_1)
+      .withVersions(String.valueOf(versionToDelete))) >> result
+
+    and:
+    noExceptionThrown()
+
+    where:
+    ltIdSuccess | ltIdFailure |            errorCode
+    LT_ID_1     |     null    |              null                    // success
+    null        |   LT_ID_1   |  "launchTemplateIdDoesNotExist"      // failed with error code considered success
+    null        |   LT_ID_1   | "launchTemplateVersionDoesNotExist"  // failed with error code considered success
+  }
+
+  @Unroll
+  void 'delete launch template version should handle errors as expected'() {
+    given:
+    def versionToDelete = 2L
+
+    DeleteLaunchTemplateVersionsResponseSuccessItem successItem = ltIdSuccess
+      ? new DeleteLaunchTemplateVersionsResponseSuccessItem()
+          .withLaunchTemplateId(ltIdSuccess)
+          .withVersionNumber(versionToDelete)
+      : null
+
+    DeleteLaunchTemplateVersionsResponseErrorItem errorItem = ltIdFailure
+      ? new DeleteLaunchTemplateVersionsResponseErrorItem()
+          .withLaunchTemplateId(ltIdFailure)
+          .withVersionNumber(versionToDelete)
+          .withResponseError(new ResponseError().withCode(errorCode))
+      : null
+
+    DeleteLaunchTemplateVersionsResult result = new DeleteLaunchTemplateVersionsResult()
+      .withSuccessfullyDeletedLaunchTemplateVersions(successItem)
+      .withUnsuccessfullyDeletedLaunchTemplateVersions(errorItem)
+
+    when:
+    launchTemplateService.deleteLaunchTemplateVersion(LT_ID_1, versionToDelete)
+
+    then:
+    1 * mockEc2.deleteLaunchTemplateVersions(new DeleteLaunchTemplateVersionsRequest()
+      .withLaunchTemplateId(LT_ID_1)
+      .withVersions(String.valueOf(versionToDelete))) >> result
+
+    and:
+    def ex = thrown(RuntimeException)
+    errorCode
+      ? ex.message == "Failed to delete launch template version 2 for launch template ID lt-1 because of " + errorCode
+      : ex == null
+
+    where:
+    ltIdSuccess | ltIdFailure |     errorCode
+      null      |  LT_ID_1    |  "unexpectedError"
+      null      |  LT_ID_1    |  "launchTemplateIdMalformed"
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateServiceSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateServiceSpec.groovy
@@ -322,7 +322,7 @@ class LaunchTemplateServiceSpec extends Specification {
     and:
     def ex = thrown(RuntimeException)
     errorCode
-      ? ex.message == "Failed to delete launch template version 2 for launch template ID lt-1 because of " + errorCode
+      ? ex.message == "Failed to delete launch template version 2 for launch template ID lt-1 because of error '" + errorCode + "'"
       : ex == null
 
     where:


### PR DESCRIPTION
## Issue
spinnaker/spinnaker#5989

## Summary
New features in modifyServerGroupLaunchTemplate operation:
1. convert a server group backed by launch template to use mixed instances policy 
1. added a new action `PrepareUpdateAutoScalingGroup` to modify operation
1. added unit tests for modify op actions
1. ability to skip modifying launch template (creating a new version) when not required

Changes to existing features: 
1. _new validation in modify op:_
    - **before:** modifyServerGroupLaunchTemplate op always modified a launch template, even when no launch template changes were included in the request. 
    - **now:** modify a launch template only if launch template config changes are requested
1. _`ModifyServerGroupLaunchTemplateDescription`_
    - **before:** extended `ModifyAsgLaunchConfigurationDescription`
    - **now:** has no association with launch configuration code path
1.  _refactors and typo corrections_ 
1. _API call for creating a new launch template version:_
    - **before:** New version was created with source version
    ```
    new CreateLaunchTemplateVersionRequest()
                .withSourceVersion(String.valueOf(sourceVersion.getVersionNumber()))
    ```
    - **now:**  New version is created without using source version. Instead, source launch template data is used to build new version's launch template data. This change was required the API call with param `withSourceVersion` does not support removing launch template parameters and we have a new use case for removing spot options from a launch template.
1. _Modify op without amiName_:
    - **before:** resulted in error `Failed to resolve image id for null`
    - **now:** no error, if amiName is not requested to be modified, existing LT's image ID is used
  
## Testing
- added / updated unit tests
- added integration tests for modify op - will be part of an upcoming PR - https://github.com/pdk27/clouddriver/commit/20a5a6bbe02af448ff35baf89347422e66c2164f
- comprehensive manual testing with various combinations of configuration parameters