### PR TITLE
fix(manifest-replicas): more flexibility with get/set replicas value

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
@@ -224,7 +224,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
   @JsonIgnore
   @SuppressWarnings("unchecked")
-  public Double getReplicas() {
+  public Integer getReplicas() {
     if (!containsKey("spec")) {
       return null;
     }
@@ -233,21 +233,19 @@ public class KubernetesManifest extends HashMap<String, Object> {
     if (!spec.containsKey("replicas")) {
       return null;
     }
-    return (Double) spec.get("replicas");
+
+    return ((Number) spec.get("replicas")).intValue();
   }
 
   @JsonIgnore
   @SuppressWarnings("unchecked")
-  public void setReplicas(Double replicas) {
+  public void setReplicas(Number replicas) {
     if (!containsKey("spec")) {
       return;
     }
 
     Map<String, Object> spec = (Map<String, Object>) get("spec");
-    if (!spec.containsKey("replicas")) {
-      return;
-    }
-    spec.put("replicas", replicas);
+    spec.put("replicas", replicas.intValue());
   }
 
   @JsonIgnore

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesSourceCapacity.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesSourceCapacity.java
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordi
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 
 public class KubernetesSourceCapacity {
-  public static Double getSourceCapacity(
+  public static Integer getSourceCapacity(
       KubernetesManifest manifest, KubernetesCredentials credentials) {
     KubernetesManifest currentManifest =
         credentials.get(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
@@ -117,7 +117,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
 
                   KubernetesHandler deployer = properties.getHandler();
                   if (strategy.isUseSourceCapacity() && deployer instanceof CanScale) {
-                    Double replicas =
+                    Integer replicas =
                         KubernetesSourceCapacity.getSourceCapacity(manifest, credentials);
                     if (replicas != null) {
                       manifest.setReplicas(replicas);

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestReplicasTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestReplicasTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.description.manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+public class KubernetesManifestReplicasTest {
+  private static final JsonNodeFactory jsonFactory = JsonNodeFactory.instance;
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void replicasValueShouldBeNullWithoutSpecDefined() throws JsonProcessingException {
+    String serialized = jsonFactory.objectNode().toString();
+    KubernetesManifest manifest = objectMapper.readValue(serialized, KubernetesManifest.class);
+    assertThat(manifest.getReplicas()).isNull();
+  }
+
+  @Test
+  public void replicasValueShouldBeNullWithoutReplicasDefined() throws JsonProcessingException {
+    String serialized =
+        jsonFactory.objectNode().<ObjectNode>set("spec", jsonFactory.objectNode()).toString();
+    KubernetesManifest manifest = objectMapper.readValue(serialized, KubernetesManifest.class);
+    assertThat(manifest.getReplicas()).isNull();
+  }
+
+  @Test
+  public void shouldGetReplicasDoubleValue() throws JsonProcessingException {
+    String serialized =
+        jsonFactory
+            .objectNode()
+            .<ObjectNode>set("spec", jsonFactory.objectNode().put("replicas", 2.0))
+            .toString();
+    KubernetesManifest manifest = objectMapper.readValue(serialized, KubernetesManifest.class);
+    assertThat(manifest.getReplicas()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldGetReplicasIntegerValue() throws JsonProcessingException {
+    String serialized =
+        jsonFactory
+            .objectNode()
+            .<ObjectNode>set("spec", jsonFactory.objectNode().put("replicas", 2))
+            .toString();
+    KubernetesManifest manifest = objectMapper.readValue(serialized, KubernetesManifest.class);
+    assertThat(manifest.getReplicas()).isEqualTo(2);
+  }
+
+  @Test
+  public void replicasValueShouldRemainUnsetWithoutSpecDefined() throws JsonProcessingException {
+    String serialized = jsonFactory.objectNode().toString();
+    KubernetesManifest manifest = objectMapper.readValue(serialized, KubernetesManifest.class);
+
+    manifest.setReplicas(2.0);
+
+    assertThat(manifest.getReplicas()).isEqualTo(null);
+  }
+
+  @Test
+  public void replicasValueShouldBeSetWithReplicasDefined() throws JsonProcessingException {
+    String serialized =
+        jsonFactory
+            .objectNode()
+            .<ObjectNode>set("spec", jsonFactory.objectNode().put("replicas", 1))
+            .toString();
+    KubernetesManifest manifest = objectMapper.readValue(serialized, KubernetesManifest.class);
+
+    manifest.setReplicas(2.0);
+
+    assertThat(manifest.getReplicas()).isEqualTo(2);
+  }
+
+  @Test
+  public void replicasValueShouldBeSetWithReplicasUnDefined() throws JsonProcessingException {
+    String serialized =
+        jsonFactory.objectNode().<ObjectNode>set("spec", jsonFactory.objectNode()).toString();
+    KubernetesManifest manifest = objectMapper.readValue(serialized, KubernetesManifest.class);
+
+    manifest.setReplicas(2.0);
+
+    assertThat(manifest.getReplicas()).isEqualTo(2);
+  }
+}


### PR DESCRIPTION
Replicas value was not being set if it didn't already have a value, however users expect that they can omit the value when leveraging the use-source-capacity strategy. Fix is setting the value despite there not already being one. Additionally, if a third party integration creates a manifest via JSON that serializes the replica count as an integer, a casting exception occurs, so this includes an update to play nicely with integers.