### PR TITLE
fix(6430): Adding missing block device mappings for new launch templates

### DIFF
--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -348,6 +348,11 @@ public class LaunchTemplateService {
           new LaunchTemplateEnclaveOptionsRequest().withEnabled(asgConfig.getEnableEnclave()));
     }
 
+    // block device mappings
+    if (asgConfig.getBlockDevices() != null && !asgConfig.getBlockDevices().isEmpty()) {
+      request.setBlockDeviceMappings(buildDeviceMapping(asgConfig.getBlockDevices()));
+    }
+
     return request;
   }
 


### PR DESCRIPTION
fix(6430): Adding missing block device mappings for new launch templates (thanks @JooeunAhn)

https://github.com/spinnaker/spinnaker/issues/6430
