### PR TITLE
fix(ecs): refactor applicationCachingAgent to use unique namespace

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 public class Keys implements KeyParser {
   public enum Namespace {
-    APPLICATIONS,
+    ECS_APPLICATIONS,
     IAM_ROLE,
     SERVICES,
     ECS_CLUSTERS,
@@ -98,7 +98,7 @@ public class Keys implements KeyParser {
         Namespace.valueOf(CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, parts[1]));
 
     switch (namespace) {
-      case APPLICATIONS:
+      case ECS_APPLICATIONS:
         result.put("application", parts[2]);
         break;
       case SERVICES:
@@ -176,7 +176,7 @@ public class Keys implements KeyParser {
   }
 
   public static String getApplicationKey(String name) {
-    return ID + SEPARATOR + Namespace.APPLICATIONS + SEPARATOR + name.toLowerCase();
+    return ID + SEPARATOR + Namespace.ECS_APPLICATIONS + SEPARATOR + name.toLowerCase();
   }
 
   public static String getTaskKey(String account, String region, String taskId) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
-import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.APPLICATIONS;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_APPLICATIONS;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.IAM_ROLE;
 
@@ -221,7 +221,7 @@ abstract class AbstractEcsCachingAgent<T> implements CachingAgent, AccountAware 
             // Application keys are not account or region specific so this will be true. The region
             // and
             // account will be checked for other keys.
-            || (authoritativeKeyName.equals(APPLICATIONS.ns)));
+            || (authoritativeKeyName.equals(ECS_APPLICATIONS.ns)));
   }
 
   /**

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ApplicationCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ApplicationCachingAgent.java
@@ -18,7 +18,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
-import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.APPLICATIONS;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_APPLICATIONS;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.ecs.AmazonECS;
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 public class ApplicationCachingAgent extends AbstractEcsOnDemandAgent<Application> {
   private static final Collection<AgentDataType> types =
       Collections.unmodifiableCollection(
-          Arrays.asList(AUTHORITATIVE.forType(APPLICATIONS.toString())));
+          Arrays.asList(AUTHORITATIVE.forType(ECS_APPLICATIONS.toString())));
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   private ObjectMapper objectMapper;
@@ -82,7 +82,7 @@ public class ApplicationCachingAgent extends AbstractEcsOnDemandAgent<Applicatio
 
     Map<String, Collection<CacheData>> cacheDataMap = new HashMap<>();
     log.info("Amazon ECS ApplicationCachingAgent will cache applications in a future update");
-    cacheDataMap.put(APPLICATIONS.toString(), applicationData);
+    cacheDataMap.put(ECS_APPLICATIONS.toString(), applicationData);
 
     return cacheDataMap;
   }

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/KeysSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/KeysSpec.groovy
@@ -57,8 +57,8 @@ class KeysSpec extends Specification {
     def application_2 = 'test-application-2'
 
     expect:
-    Keys.parse(ID + SEPARATOR + APPLICATIONS.ns + SEPARATOR + application_1) == [provider: ID, type: APPLICATIONS.ns, application: application_1]
-    Keys.parse(ID + SEPARATOR + APPLICATIONS.ns + SEPARATOR + application_2) == [provider: ID, type: APPLICATIONS.ns, application: application_2]
+    Keys.parse(ID + SEPARATOR + ECS_APPLICATIONS.ns + SEPARATOR + application_1) == [provider: ID, type: ECS_APPLICATIONS.ns, application: application_1]
+    Keys.parse(ID + SEPARATOR + ECS_APPLICATIONS.ns + SEPARATOR + application_2) == [provider: ID, type: ECS_APPLICATIONS.ns, application: application_2]
   }
 
   def 'should generate the proper application key'() {
@@ -67,8 +67,8 @@ class KeysSpec extends Specification {
     def application_2 = 'test-application-2'
 
     expect:
-    Keys.getApplicationKey(application_1) == ID + SEPARATOR + APPLICATIONS.ns + SEPARATOR + application_1
-    Keys.getApplicationKey(application_2) == ID + SEPARATOR + APPLICATIONS.ns + SEPARATOR + application_2
+    Keys.getApplicationKey(application_1) == ID + SEPARATOR + ECS_APPLICATIONS.ns + SEPARATOR + application_1
+    Keys.getApplicationKey(application_2) == ID + SEPARATOR + ECS_APPLICATIONS.ns + SEPARATOR + application_2
   }
 
   def 'should parse a given iam role key properly'() {


### PR DESCRIPTION
This change updates the application caching agent to use a new namespace ECS_APPLICATIONS rather than reusing the existing APPLICATIONS namespace.

Verified:
1) ECS provider deployments still work 
2) ApplicationCachingAgent is continuing to log messages

Fixes: spinnaker/spinnaker#6084