### PR TITLE
feat(ecs): Add support for enableExecuteCommand

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CreateServerGroupDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CreateServerGroupDescription.java
@@ -98,6 +98,7 @@ public class CreateServerGroupDescription extends AbstractECSDescription {
   Map<Object, Object> spelProcessedTaskDefinitionArtifact;
   String taskDefinitionArtifactAccount;
   Map<String, String> containerToImageMap;
+  boolean enableExecuteCommand;
 
   /**
    * @deprecated this field only allows for one container to be specified. ECS supports the ability

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
@@ -545,7 +545,8 @@ public class CreateServerGroupAtomicOperation
             .withPlacementConstraints(description.getPlacementConstraints())
             .withPlacementStrategy(description.getPlacementStrategySequence())
             .withServiceRegistries(serviceRegistries)
-            .withDeploymentConfiguration(deploymentConfiguration);
+            .withDeploymentConfiguration(deploymentConfiguration)
+            .withEnableExecuteCommand(description.isEnableExecuteCommand());
 
     List<Tag> taskDefTags = new LinkedList<>();
     if (description.getTags() != null && !description.getTags().isEmpty()) {

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
@@ -179,6 +179,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       request.tags.get(1).value == 'tomato'
       request.launchType == null
       request.platformVersion == null
+      request.enableExecuteCommand == false
     }) >> new CreateServiceResult().withService(service)
 
     result.getServerGroupNames().size() == 1
@@ -244,7 +245,8 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       subnetType: 'public',
       securityGroupNames: ['helloworld'],
       associatePublicIpAddress: true,
-      serviceDiscoveryAssociations: [serviceRegistry]
+      serviceDiscoveryAssociations: [serviceRegistry],
+      enableExecuteCommand: true
     )
 
     def operation = new CreateServerGroupAtomicOperation(description)
@@ -308,6 +310,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       request.tags == []
       request.launchType == 'FARGATE'
       request.platformVersion == '1.0.0'
+      request.enableExecuteCommand == true
     } as CreateServiceRequest) >> new CreateServiceResult().withService(service)
 
     result.getServerGroupNames().size() == 1


### PR DESCRIPTION
Implements https://github.com/spinnaker/spinnaker/issues/6429

### Testing

Deployment w/ `enableExecuteCommand` set to `true` succeeds & `ecs execute-command` on service task works:

* server group JSON
![image](https://user-images.githubusercontent.com/34254888/120538365-459a0100-c39b-11eb-9e14-0422b2ffd473.png)

* Deployment result
![image](https://user-images.githubusercontent.com/34254888/120537993-cdcbd680-c39a-11eb-9c05-202cd86b066a.png)

* service description:
![image](https://user-images.githubusercontent.com/34254888/120538070-e20fd380-c39a-11eb-8d52-6ccd029e7685.png)

* interactive command session started:
![image](https://user-images.githubusercontent.com/34254888/120538207-15526280-c39b-11eb-9f2d-dd52942a935e.png)

### NOTE on use/requirements
Using [`ecs exec`](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-enabling-and-using) requires that your task definition includes a [task role](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterTaskDefinition.html#ECS-RegisterTaskDefinition-request-taskRoleArn) with relevant SSM permissions. Failure to specify a task role will result in a failed deplyoment:
![image](https://user-images.githubusercontent.com/34254888/120545726-dd035200-c3a3-11eb-823e-ed1277bd11f9.png)

