### PR TITLE
Fix null job name in status

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
@@ -136,6 +136,11 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
+  public void setGenerateName(String name) {
+    getMetadata().put("generateName", name);
+  }
+
+  @JsonIgnore
   @Nonnull
   public String getNamespace() {
     String namespace = (String) getMetadata().get("namespace");

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
@@ -117,12 +117,17 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
+  public String getGenerateName() {
+    return (String) getMetadata().get("generateName");
+  }
+
+  @JsonIgnore
   public boolean hasGenerateName() {
     if (!Strings.isNullOrEmpty(this.getName())) {
       // If a name is present, it will be used instead of a generateName
       return false;
     }
-    return !Strings.isNullOrEmpty((String) getMetadata().get("generateName"));
+    return !Strings.isNullOrEmpty(this.getGenerateName());
   }
 
   @JsonIgnore
@@ -330,7 +335,11 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
   @JsonIgnore
   public String getFullResourceName() {
-    return getFullResourceName(getKind(), getName());
+    // To try to avoid "null" in the return value, use the generateName field if
+    // there's no name.  With neither name nor generateName, the return value
+    // still contains "null".
+    String name = Strings.isNullOrEmpty(getName()) ? getGenerateName() : getName();
+    return getFullResourceName(getKind(), name);
   }
 
   public static String getFullResourceName(KubernetesKind kind, String name) {

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTest.java
@@ -45,6 +45,6 @@ final class KubernetesManifestTest {
     // To be explicit, make sure the name is null
     assertNull(manifest.getName());
 
-    assertThat(manifest.getFullResourceName()).isEqualTo("job null");
+    assertThat(manifest.getFullResourceName()).isEqualTo("job " + GENERATE_NAME);
   }
 }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.description.manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class KubernetesManifestTest {
+
+  private static final String GENERATE_NAME = "my-generate-name";
+
+  @Test
+  void fullResourceNameConsidersGenerateName() {
+    KubernetesManifest manifest = new KubernetesManifest();
+
+    // Job is an arbitrary choice since kubernetes supports generateName in
+    // other resources.  But it's often used with jobs so it's possible to
+    // run the same job multiple times.
+    manifest.setKind(KubernetesKind.JOB);
+
+    manifest.put("metadata", new HashMap<>());
+    manifest.setGenerateName(GENERATE_NAME);
+
+    // To be explicit, make sure the name is null
+    assertNull(manifest.getName());
+
+    assertThat(manifest.getFullResourceName()).isEqualTo("job null");
+  }
+}


### PR DESCRIPTION
Before this PR, when using generateName in kubernetes manifests deployed via deploy manifest or run job (manifest), "null" appears for job names in some places in deck, e.g. Swapping out artifacts in job null from context..., and in pipeline execution source.  For example:
![image](https://user-images.githubusercontent.com/82477955/120734203-5763cd00-c49d-11eb-8ec1-777f0efec30f.png)
After this PR:
![image (1)](https://user-images.githubusercontent.com/82477955/120734228-62b6f880-c49d-11eb-8113-eebb4cf18b02.png)
