### PR TITLE
feat(cloudfoundry): improved error messages for failed service bindings

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/CreateCloudFoundryServiceBindingAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/CreateCloudFoundryServiceBindingAtomicOperation.java
@@ -66,7 +66,6 @@ public class CreateCloudFoundryServiceBindingAtomicOperation implements AtomicOp
         .getClient()
         .getServiceInstances()
         .findAllServicesBySpaceAndNames(description.getSpace(), serviceInstanceNames)
-        .stream()
         .forEach(s -> serviceInstanceGuids.put(s.getEntity().getName(), s.getMetadata().getGuid()));
 
     List<CreateServiceBinding> bindings =

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/CreateCloudFoundryServiceBindingAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/CreateCloudFoundryServiceBindingAtomicOperation.java
@@ -76,7 +76,9 @@ public class CreateCloudFoundryServiceBindingAtomicOperation implements AtomicOp
                   String serviceGuid = serviceInstanceGuids.get(s.getServiceInstanceName());
                   if (serviceGuid == null || serviceGuid.isEmpty()) {
                     throw new CloudFoundryApiException(
-                        "Unable to find service with the name: '" + s.getServiceInstanceName() + "'");
+                        "Unable to find service with the name: '"
+                            + s.getServiceInstanceName()
+                            + "'");
                   }
                   if (s.isUpdatable()) {
                     removeBindings(serviceGuid, description.getServerGroupId());

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/CreateCloudFoundryServiceBindingAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/CreateCloudFoundryServiceBindingAtomicOperation.java
@@ -69,11 +69,6 @@ public class CreateCloudFoundryServiceBindingAtomicOperation implements AtomicOp
         .stream()
         .forEach(s -> serviceInstanceGuids.put(s.getEntity().getName(), s.getMetadata().getGuid()));
 
-    if (serviceInstanceNames.size() != description.getServiceBindingRequests().size()) {
-      throw new CloudFoundryApiException(
-          "Number of service instances found does not match the number of service binding requests.");
-    }
-
     List<CreateServiceBinding> bindings =
         description.getServiceBindingRequests().stream()
             .map(
@@ -81,9 +76,7 @@ public class CreateCloudFoundryServiceBindingAtomicOperation implements AtomicOp
                   String serviceGuid = serviceInstanceGuids.get(s.getServiceInstanceName());
                   if (serviceGuid == null || serviceGuid.isEmpty()) {
                     throw new CloudFoundryApiException(
-                        "Unable to find service with the name: '"
-                            + s.getServiceInstanceName()
-                            + "'");
+                        "Unable to find service with the name: '" + s.getServiceInstanceName() + "'");
                   }
                   if (s.isUpdatable()) {
                     removeBindings(serviceGuid, description.getServerGroupId());

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -144,8 +144,10 @@ public class DeployCloudFoundryServerGroupAtomicOperation
 
   private void createServiceBindings(
       CloudFoundryServerGroup serverGroup, DeployCloudFoundryServerGroupDescription description) {
+
     List<String> serviceNames = description.getApplicationAttributes().getServices();
     if (serviceNames == null || serviceNames.isEmpty()) return;
+
     getTask()
         .updateStatus(
             PHASE,
@@ -154,32 +156,43 @@ public class DeployCloudFoundryServerGroupAtomicOperation
                 + "' and services: "
                 + description.getApplicationAttributes().getServices());
 
-    List<CreateServiceBinding> bindings =
-        description
-            .getClient()
-            .getServiceInstances()
-            .findAllServicesBySpaceAndNames(
-                serverGroup.getSpace(), description.getApplicationAttributes().getServices())
-            .stream()
-            .map(
-                s ->
-                    new CreateServiceBinding(
-                        s.getMetadata().getGuid(), serverGroup.getId(), Collections.emptyMap()))
-            .collect(toList());
+    Map<String, String> serviceInstanceGuids = new HashMap<>();
 
-    if (bindings.size() != description.getApplicationAttributes().getServices().size()) {
-      getTask()
-          .updateStatus(
-              PHASE,
-              "Failed to create Cloud Foundry service bindings between application '"
-                  + description.getServerGroupName()
-                  + "' and services: "
-                  + description.getApplicationAttributes().getServices());
-      throw new CloudFoundryApiException(
-          "Number of service instances does not match the number of service names");
-    }
+    // find guids for services
+    description
+      .getClient()
+      .getServiceInstances()
+      .findAllServicesBySpaceAndNames(serverGroup.getSpace(), serviceNames)
+      .stream()
+      .forEach(s -> serviceInstanceGuids.put(s.getEntity().getName(), s.getMetadata().getGuid()));
+
+    // try and create service binding request for each service
+    List<CreateServiceBinding> bindings =
+      serviceNames
+        .map(
+          s -> {
+            String serviceGuid = serviceInstanceGuids.get(s);
+            if (serviceGuid == null || serviceGuid.isEmpty()) {
+              getTask()
+                .updateStatus(
+                  PHASE,
+                  "Failed to create Cloud Foundry service bindings between application '"
+                    + description.getServerGroupName()
+                    + "' and services: "
+                    + serviceNames);
+
+              throw new CloudFoundryApiException(
+                "Unable to find service with the name: '" + s.getServiceInstanceName() + "' in "
+                  + serverGroup.getSpace());
+            }
+
+            return new CreateServiceBinding(
+              serviceGuid, serverGroup.getId(), Collections.emptyMap());
+          })
+        .collect(Collectors.toList());
 
     bindings.forEach(b -> description.getClient().getServiceInstances().createServiceBinding(b));
+
     getTask()
         .updateStatus(
             PHASE,

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -46,6 +46,7 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.*;
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Data;
@@ -163,12 +164,11 @@ public class DeployCloudFoundryServerGroupAtomicOperation
         .getClient()
         .getServiceInstances()
         .findAllServicesBySpaceAndNames(serverGroup.getSpace(), serviceNames)
-        .stream()
         .forEach(s -> serviceInstanceGuids.put(s.getEntity().getName(), s.getMetadata().getGuid()));
 
     // try and create service binding request for each service
     List<CreateServiceBinding> bindings =
-        serviceNames
+        serviceNames.stream()
             .map(
                 s -> {
                   String serviceGuid = serviceInstanceGuids.get(s);
@@ -183,7 +183,7 @@ public class DeployCloudFoundryServerGroupAtomicOperation
 
                     throw new CloudFoundryApiException(
                         "Unable to find service with the name: '"
-                            + s.getServiceInstanceName()
+                            + s
                             + "' in "
                             + serverGroup.getSpace());
                   }


### PR DESCRIPTION
The error messages surfaced to Deck when a CF service doesn't exist don't make sense to end users who aren't familiar with the code.

I've taken the implementation from the `CreateCloudFoundryServiceBindingRequestAtomicOperation`, which fetches the GUIDs from CAPI and then verifies each service to bind has a GUID. This differs from the previous implementation that just checked the number of services returned == number of services wanting to bind.

I also removed this size check from the Create Service Bindings operation - as far as I can tell it wasn't adding anything, since each service was checked immediately afterwards anyway.

cc @zachsmith1 (I can't run tests locally at the moment due to corporate dependency management, working on it!)