### PR TITLE
fix(docker): filter images with repository and tag

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
@@ -106,10 +106,20 @@ class DockerRegistryImageLookupController {
         return null
       } else {
         def parse = Keys.parse(it.getId())
+        def repo  = (String) parse.repository
+        def tag   = (String) parse.tag
+
+        // if the request asks for specific repositories or tags,
+        // do the filtering accordingly
+        if (lookupOptions.repository && !lookupOptions.repository.equals(repo) ||
+            lookupOptions.repository && lookupOptions.tag && !lookupOptions.tag.equals(tag)) {
+          return null
+        }
+
         if (lookupOptions.includeDetails) {
           return [
-            repository : (String) parse.repository,
-            tag        : (String) parse.tag,
+            repository : repo,
+            tag        : tag,
             account    : it.attributes.account,
             registry   : credentials.getRegistry(),
             digest     : it.attributes.digest,
@@ -118,16 +128,17 @@ class DockerRegistryImageLookupController {
             branch     : it.attributes.labels?.branch,
             artifact   : generateArtifact(credentials.getRegistry(), parse.repository, parse.tag, it.attributes.labels)
           ]
-        } else {
-          return [
-            repository: (String) parse.repository,
-            tag       : (String) parse.tag,
-            account   : it.attributes.account,
-            registry  : credentials.getRegistry(),
-            digest    : it.attributes.digest,
-            artifact  : generateArtifact(credentials.getRegistry(), parse.repository, parse.tag)
-          ]
         }
+
+        return [
+          repository: repo,
+          tag       : tag,
+          account   : it.attributes.account,
+          registry  : credentials.getRegistry(),
+          digest    : it.attributes.digest,
+          artifact  : generateArtifact(credentials.getRegistry(), parse.repository, parse.tag)
+        ]
+
       }
     }
   }
@@ -186,6 +197,8 @@ class DockerRegistryImageLookupController {
     String q
     String account
     String region
+    String repository
+    String tag
     Integer count
     Boolean includeDetails
   }

--- a/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupControllerSpec.groovy
+++ b/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupControllerSpec.groovy
@@ -117,6 +117,50 @@ class DockerRegistryImageLookupControllerSpec extends Specification {
     result[0].artifact.metadata.labels.jobName == "test-job"
   }
 
+  void "When finding images with filtered repository for an image that exists" () {
+    when:
+    def result = dockerRegistryImageLookupController.find(
+      new DockerRegistryImageLookupController.LookupOptions(repository: "test-repo"))
+
+    then:
+    result.size() == 1
+    result[0].account       == "test-account"
+    result[0].digest        == "test-digest"
+    result[0].artifact.type == "docker"
+    result[0].artifact.metadata.registry == "test-registry"
+  }
+
+  void "When finding images with filtered repository and tag for an image that exists" () {
+    when:
+    def result = dockerRegistryImageLookupController.find(
+      new DockerRegistryImageLookupController.LookupOptions(repository: "test-repo", tag: "1.0"))
+
+    then:
+    result.size() == 1
+    result[0].account       == "test-account"
+    result[0].digest        == "test-digest"
+    result[0].artifact.type == "docker"
+    result[0].artifact.metadata.registry == "test-registry"
+  }
+
+  void "When finding images with filtered repository for an image that does not exist" () {
+    when:
+    def result = dockerRegistryImageLookupController.find(
+      new DockerRegistryImageLookupController.LookupOptions(repository: "wrong-repo"))
+
+    then:
+    result.size() == 0
+  }
+
+  void "When finding images with filtered tag for a tag that does not exist" () {
+    when:
+    def result = dockerRegistryImageLookupController.find(
+      new DockerRegistryImageLookupController.LookupOptions(repository: "wrong-tag"))
+
+    then:
+    result.size() == 0
+  }
+
   void "When finding images with no metadata and includeDetails == true"() {
     setup:
     def noLabelResultData = [


### PR DESCRIPTION
even though microservices like Keel expect clouddriver's `dockerRegistry/images/find`
endpoint to filter the returned list by repository or tag, the functionality was not
implemented in clouddriver. this PR adds it.

/cc @JonGilmore @nabuskey 