### PR TITLE
feat(kubernetes): add retries to kubernetes job executor

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -85,6 +85,7 @@ dependencies {
   implementation "org.springframework.security:spring-security-config"
   implementation "org.springframework.cloud:spring-cloud-context"
   implementation "org.springframework.cloud:spring-cloud-config-server"
+  implementation "io.github.resilience4j:resilience4j-retry"
 
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -27,6 +27,7 @@ import lombok.Data;
 public class KubernetesConfigurationProperties {
   private static final int DEFAULT_CACHE_THREADS = 1;
   private List<ManagedAccount> accounts = new ArrayList<>();
+  private KubernetesJobExecutorProperties jobExecutor = new KubernetesJobExecutorProperties();
 
   @Data
   public static class ManagedAccount implements CredentialsDefinition {
@@ -75,6 +76,36 @@ public class KubernetesConfigurationProperties {
             "At most one of 'kinds' and 'omitKinds' can be specified");
       }
       rawResourcesEndpointConfig.validate();
+    }
+  }
+
+  @Data
+  public static class KubernetesJobExecutorProperties {
+    private Retries retries = new Retries();
+
+    @Data
+    public static class Retries {
+      // flag to turn on/off kubectl retry on errors capability.
+      private boolean enabled = false;
+
+      // total number of attempts that are made to complete a kubectl call
+      int maxAttempts = 3;
+
+      // time in ms to wait before subsequent retry attempts
+      long backOffInMs = 5000;
+
+      // list of error strings on which to retry since kubectl binary returns textual error messages
+      // back
+      List<String> retryableErrorMessages = List.of("TLS handshake timeout");
+
+      // flag to enable exponential backoff - only applicable when enableRetries: true
+      boolean exponentialBackoffEnabled = false;
+
+      // only applicable when exponentialBackoff = true
+      int exponentialBackoffMultiplier = 2;
+
+      // only applicable when exponentialBackoff = true
+      long exponentialBackOffIntervalMs = 10000;
     }
   }
 }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
@@ -18,25 +18,34 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.op.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.io.Resources;
+import com.netflix.spinnaker.clouddriver.jobs.JobExecutionException;
 import com.netflix.spinnaker.clouddriver.jobs.JobExecutor;
 import com.netflix.spinnaker.clouddriver.jobs.JobRequest;
 import com.netflix.spinnaker.clouddriver.jobs.JobResult;
 import com.netflix.spinnaker.clouddriver.jobs.JobResult.Result;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPodMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPodMetric.ContainerMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
@@ -44,18 +53,27 @@ import org.junit.runner.RunWith;
 final class KubectlJobExecutorTest {
   private static final String NAMESPACE = "test-namespace";
 
-  @Test
-  void topPodEmptyOutput() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void topPodEmptyOutput(boolean retriesEnabled) {
     JobExecutor jobExecutor = mock(JobExecutor.class);
     when(jobExecutor.runJob(any(JobRequest.class)))
         .thenReturn(
             JobResult.<String>builder().result(Result.SUCCESS).output("").error("").build());
 
+    KubernetesConfigurationProperties kubernetesConfigurationProperties =
+        new KubernetesConfigurationProperties();
+    kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(retriesEnabled);
+
     KubectlJobExecutor kubectlJobExecutor =
-        new KubectlJobExecutor(jobExecutor, "kubectl", "oauth2l");
+        new KubectlJobExecutor(
+            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
     Collection<KubernetesPodMetric> podMetrics =
         kubectlJobExecutor.topPod(mockKubernetesCredentials(), "test", "");
     assertThat(podMetrics).isEmpty();
+
+    // should only be called once as no retries are performed
+    verify(jobExecutor).runJob(any(JobRequest.class));
   }
 
   @Test
@@ -73,7 +91,8 @@ final class KubectlJobExecutorTest {
                 .build());
 
     KubectlJobExecutor kubectlJobExecutor =
-        new KubectlJobExecutor(jobExecutor, "kubectl", "oauth2l");
+        new KubectlJobExecutor(
+            jobExecutor, "kubectl", "oauth2l", new KubernetesConfigurationProperties());
     Collection<KubernetesPodMetric> podMetrics =
         kubectlJobExecutor.topPod(mockKubernetesCredentials(), NAMESPACE, "");
     assertThat(podMetrics).hasSize(2);
@@ -116,9 +135,185 @@ final class KubectlJobExecutorTest {
     }
   }
 
+  @Test
+  void kubectlRetryHandlingForConfiguredErrorsThatContinueFailingAfterMaxRetryAttempts() {
+    JobExecutor jobExecutor = mock(JobExecutor.class);
+    when(jobExecutor.runJob(any(JobRequest.class)))
+        .thenReturn(
+            JobResult.<String>builder()
+                .result(Result.FAILURE)
+                .output("")
+                .error("Unable to connect to the server: net/http: TLS handshake timeout")
+                .build());
+
+    KubernetesConfigurationProperties kubernetesConfigurationProperties =
+        new KubernetesConfigurationProperties();
+    kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(true);
+    kubernetesConfigurationProperties.getJobExecutor().getRetries().setBackOffInMs(500);
+
+    KubectlJobExecutor kubectlJobExecutor =
+        new KubectlJobExecutor(
+            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+
+    KubectlJobExecutor.KubectlException thrown =
+        assertThrows(
+            KubectlJobExecutor.KubectlException.class,
+            () -> kubectlJobExecutor.topPod(mockKubernetesCredentials(), "test", "test-pod"));
+
+    // should be called 3 times as there were max 3 attempts made
+    verify(jobExecutor, times(3)).runJob(any(JobRequest.class));
+
+    // at the end of retries, the exception should still be thrown
+    assertTrue(
+        thrown
+            .getMessage()
+            .contains("Unable to connect to the server: net/http: TLS handshake timeout"));
+  }
+
+  @Test
+  void kubectlRetryHandlingForConfiguredErrorsThatSucceedsAfterAFewRetries() throws IOException {
+    JobExecutor jobExecutor = mock(JobExecutor.class);
+    when(jobExecutor.runJob(any(JobRequest.class)))
+        .thenReturn(
+            JobResult.<String>builder()
+                .result(Result.FAILURE)
+                .output("")
+                .error("Unable to connect to the server: net/http: TLS handshake timeout")
+                .build())
+        .thenReturn(
+            JobResult.<String>builder()
+                .result(Result.SUCCESS)
+                .output(
+                    Resources.toString(
+                        KubectlJobExecutor.class.getResource("top-pod.txt"),
+                        StandardCharsets.UTF_8))
+                .error("")
+                .build());
+
+    KubernetesConfigurationProperties kubernetesConfigurationProperties =
+        new KubernetesConfigurationProperties();
+    kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(true);
+    kubernetesConfigurationProperties.getJobExecutor().getRetries().setBackOffInMs(500);
+
+    KubectlJobExecutor kubectlJobExecutor =
+        new KubectlJobExecutor(
+            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+
+    Collection<KubernetesPodMetric> podMetrics =
+        kubectlJobExecutor.topPod(mockKubernetesCredentials(), NAMESPACE, "test-pod");
+    assertThat(podMetrics).hasSize(2);
+
+    // should only be called twice as it failed on the first call but succeeded in the second one
+    verify(jobExecutor, times(2)).runJob(any(JobRequest.class));
+
+    ImmutableSetMultimap<String, ContainerMetric> expectedMetrics =
+        ImmutableSetMultimap.<String, ContainerMetric>builder()
+            .putAll(
+                "spinnaker-io-nginx-v000-42gnq",
+                ImmutableList.of(
+                    new ContainerMetric(
+                        "spinnaker-github-io",
+                        ImmutableMap.of("CPU(cores)", "0m", "MEMORY(bytes)", "2Mi")),
+                    new ContainerMetric(
+                        "istio-proxy",
+                        ImmutableMap.of("CPU(cores)", "3m", "MEMORY(bytes)", "28Mi")),
+                    new ContainerMetric(
+                        "istio-init", ImmutableMap.of("CPU(cores)", "0m", "MEMORY(bytes)", "0Mi"))))
+            .putAll(
+                "spinnaker-io-nginx-v001-jvkgb",
+                ImmutableList.of(
+                    new ContainerMetric(
+                        "spinnaker-github-io",
+                        ImmutableMap.of("CPU(cores)", "0m", "MEMORY(bytes)", "2Mi")),
+                    new ContainerMetric(
+                        "istio-proxy",
+                        ImmutableMap.of("CPU(cores)", "32m", "MEMORY(bytes)", "30Mi")),
+                    new ContainerMetric(
+                        "istio-init", ImmutableMap.of("CPU(cores)", "0m", "MEMORY(bytes)", "0Mi"))))
+            .build();
+
+    for (String pod : expectedMetrics.keys()) {
+      Optional<KubernetesPodMetric> podMetric =
+          podMetrics.stream()
+              .filter(metric -> metric.getPodName().equals(pod))
+              .filter(metric -> metric.getNamespace().equals(NAMESPACE))
+              .findAny();
+      assertThat(podMetric.isPresent()).isTrue();
+      assertThat(podMetric.get().getContainerMetrics())
+          .containsExactlyInAnyOrderElementsOf(expectedMetrics.get(pod));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void kubectlJobExecutorHandlingForErrorsThatAreNotConfiguredToBeRetryable(
+      boolean retriesEnabled) {
+    JobExecutor jobExecutor = mock(JobExecutor.class);
+    when(jobExecutor.runJob(any(JobRequest.class)))
+        .thenReturn(
+            JobResult.<String>builder()
+                .result(Result.FAILURE)
+                .output("")
+                .error("un-retryable error")
+                .build());
+
+    KubernetesConfigurationProperties kubernetesConfigurationProperties =
+        new KubernetesConfigurationProperties();
+    kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(retriesEnabled);
+
+    KubectlJobExecutor kubectlJobExecutor =
+        new KubectlJobExecutor(
+            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+
+    KubectlJobExecutor.KubectlException thrown =
+        assertThrows(
+            KubectlJobExecutor.KubectlException.class,
+            () -> kubectlJobExecutor.topPod(mockKubernetesCredentials(), "test", ""));
+
+    assertTrue(thrown.getMessage().contains("un-retryable error"));
+    // should only be called once as no retries are performed for this error
+    verify(jobExecutor).runJob(any(JobRequest.class));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void kubectlJobExecutorRaisesException(boolean retriesEnabled) {
+    JobExecutor jobExecutor = mock(JobExecutor.class);
+    when(jobExecutor.runJob(any(JobRequest.class)))
+        .thenThrow(new JobExecutionException("unknown exception", new IOException()));
+
+    KubernetesConfigurationProperties kubernetesConfigurationProperties =
+        new KubernetesConfigurationProperties();
+
+    if (retriesEnabled) {
+      kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(true);
+      kubernetesConfigurationProperties.getJobExecutor().getRetries().setBackOffInMs(500);
+    }
+
+    KubectlJobExecutor kubectlJobExecutor =
+        new KubectlJobExecutor(
+            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+
+    JobExecutionException thrown =
+        assertThrows(
+            JobExecutionException.class,
+            () -> kubectlJobExecutor.topPod(mockKubernetesCredentials(), "test", "test-pod"));
+
+    if (retriesEnabled) {
+      // should be called 3 times as there were max 3 attempts made
+      verify(jobExecutor, times(3)).runJob(any(JobRequest.class));
+    } else {
+      verify(jobExecutor).runJob(any(JobRequest.class));
+    }
+
+    // at the end, with or without retries, the exception should still be thrown
+    assertTrue(thrown.getMessage().contains("unknown exception"));
+  }
+
   /** Returns a mock KubernetesCredentials object */
   private static KubernetesCredentials mockKubernetesCredentials() {
     KubernetesCredentials credentials = mock(KubernetesCredentials.class);
+    when(credentials.getAccountName()).thenReturn("mock-account");
     when(credentials.getKubectlExecutable()).thenReturn("");
     return credentials;
   }


### PR DESCRIPTION
We have experienced some pipelines failures from time to time due to transient kubectl errors. This PR attempts to address that by adding retrycapability for such kubectl calls. 

This capability can be enabled by setting `kubernetes.jobExecutor.retries.enabled: true`. It is turned off by default.

Any new kubectl errors on which retries will be performed can be configured using the `kuberentes.jobExecutor.retries.retryableErrorMessages` key, which accepts a list of strings. The code does a string.contains() check on this error message - so only certain keywords from the original message can be added here, for example, `TLS handshake timeout`.

Logs are added to indicate the k8s account, the action (such as get, delete etc), the k8s resource as well as retry attempts.
Example log:
```
Retry 'mock-account.topPod.test-pod', waiting PT10S until attempt #3. Last attempt failed with exception com.netflix.spinnaker.clouddriver.jobs.JobExecutionException: TLS handshake timeout
```
