### PR TITLE
fix(lambda): cache state and state reason info for lambda functions

### DIFF
--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgent.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgent.java
@@ -271,6 +271,9 @@ public class LambdaCachingAgent implements CachingAgent, AccountAware, OnDemandA
     attributes.put("code", getFunctionResult.getCode());
     attributes.put("tags", getFunctionResult.getTags());
     attributes.put("concurrency", getFunctionResult.getConcurrency());
+    attributes.put("state", getFunctionResult.getConfiguration().getState());
+    attributes.put("stateReason", getFunctionResult.getConfiguration().getStateReason());
+    attributes.put("stateReasonCode", getFunctionResult.getConfiguration().getStateReasonCode());
     return attributes;
   }
 


### PR DESCRIPTION
the state can be used to determine whether a lambda function is ready
to receive traffic.
