### PR TITLE
fix(aws): Fixing invalid creation of empty AsgConfiguration

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/AutoScalingWorker.groovy
@@ -113,6 +113,11 @@ class AutoScalingWorker {
     List<BasicAmazonDeployDescription.LaunchTemplateOverridesForInstanceType> launchTemplateOverridesForInstanceType
 
     /**
+     * AsgConfiguration object makes sense only when created with all or some of the configuration fields.
+     */
+    private AsgConfiguration() {}
+
+    /**
      * Helper function to determine if the ASG should be created with mixed instances policy, when launch templates are enabled
      * @return boolean true if mixed instances policy parameters are used, false otherwise
      */

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/AmazonResourceTagger.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/AmazonResourceTagger.java
@@ -16,11 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy;
 
-import com.netflix.spinnaker.clouddriver.aws.deploy.asg.AutoScalingWorker;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import lombok.Data;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Allows for custom tags to be set on resources created as a result of autoscaling activity
@@ -29,8 +30,7 @@ import org.jetbrains.annotations.NotNull;
 public interface AmazonResourceTagger {
   @NotNull
   default Collection<Tag> volumeTags(
-      @NotNull AutoScalingWorker.AsgConfiguration asgConfiguration,
-      @NotNull String serverGroupName) {
+      @Nullable Map<String, String> blockDeviceTags, @NotNull String serverGroupName) {
     return Collections.emptyList();
   }
 

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultAmazonResourceTagger.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultAmazonResourceTagger.java
@@ -17,10 +17,10 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy;
 
 import com.netflix.frigga.Names;
-import com.netflix.spinnaker.clouddriver.aws.deploy.asg.AutoScalingWorker;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -52,18 +52,14 @@ public class DefaultAmazonResourceTagger implements AmazonResourceTagger {
   @NotNull
   @Override
   public Collection<Tag> volumeTags(
-      @NotNull AutoScalingWorker.AsgConfiguration asgConfiguration,
-      @NotNull String serverGroupName) {
+      @Nullable Map<String, String> blockDeviceTags, @NotNull String serverGroupName) {
     Names names = Names.parseName(serverGroupName);
 
     List<Tag> tags = new ArrayList<>();
     tags.add(Tag.of(applicationTag, names.getApp()));
     tags.add(Tag.of(clusterTag, names.getCluster()));
     tags.addAll(
-        Optional.ofNullable(asgConfiguration.getBlockDeviceTags())
-            .orElse(Collections.emptyMap())
-            .entrySet()
-            .stream()
+        Optional.ofNullable(blockDeviceTags).orElse(Collections.emptyMap()).entrySet().stream()
             .map(e -> Tag.of(e.getKey(), e.getValue()))
             .collect(Collectors.toList()));
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateServiceSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateServiceSpec.groovy
@@ -119,7 +119,7 @@ class LaunchTemplateServiceSpec extends Specification {
     expect:
     launchTemplateService.tagSpecification(
       amazonResourceTaggers,
-      new AutoScalingWorker.AsgConfiguration(blockDeviceTags: ["blockKey": "blockValue"]),
+      ["blockKey": "blockValue"],
       "application-stack-details-v001"
     ) == result
 


### PR DESCRIPTION
## Summary
- Fixing a bug introduced in a previous PR. 
- Restricted usage of AsgConfiguration's default constructor as it doesn't makes sense to use it without config fields. 
- `blockDeviceTags` is not supported by `modifyServerGroupLaunchTemplateDescription`. So, replacing empty ASG Configuration with null to be explicit.
