### PR TITLE
fix(aws): Fix copy of block devices in clone operation

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -582,8 +582,6 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
    * @param newAsgDescription description in request
    * @return a list of {@link AmazonBlockDevice} for the requested configuration
    */
-  @VisibleForTesting
-  @PackageScope
   List<AmazonBlockDevice> buildBlockDeviceMappingsFromSourceAsg(
     RegionScopedProviderFactory.RegionScopedProvider sourceAsgRegionScopedProvider,
     AutoScalingGroup sourceAsg,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -280,7 +280,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
         newDescription.tags = description.tags != null ? description.tags : ancestorAsg.tags?.collectEntries {
           [(it.getKey()): it.getValue()]
         }
-//        newDescription.blockDevices  // todo(pdk27): FixMe. This seems like an incomplete LOC related to blockDevicesTags https://github.com/spinnaker/clouddriver/pull/5244/files.
+        newDescription.blockDevices = description.blockDevices != null ? description.blockDevices : basicAmazonDeployHandler.buildBlockDeviceMappingsFromSourceAsg(sourceRegionScopedProvider, ancestorAsg, description)
         newDescription.capacityRebalance = description.capacityRebalance != null ? description.capacityRebalance : ancestorAsg.capacityRebalance
         newDescription.lifecycleHooks = description.lifecycleHooks != null && !description.lifecycleHooks.isEmpty()
           ? description.lifecycleHooks


### PR DESCRIPTION
## Summary
Fixed copy of block devices in clone op. 
Fixed LOC - https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy#L283 
Seems like an incomplete LOC introduced in https://github.com/spinnaker/clouddriver/pull/5244/files

The "clone" behavior for block devices implemented in this PR, is the same behavior seen when creating a server group with `copySourceCustomBlockDeviceMappings` enabled - [code ref](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy#L442)

## Testing
Manually created server groups with block devices and cloned them.  Block devices were created / cloned as expected. 
