### PR TITLE
feat(cloudfoundry): add remove bindings option to destroy service

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
@@ -16,8 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client;
 
-import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClientUtils.collectPageResources;
-import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClientUtils.safelyCall;
+import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClientUtils.*;
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ConfigFeatureFlag.ConfigFlag.SERVICE_INSTANCE_SHARING;
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.LastOperation.State.*;
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.LastOperation.Type.*;
@@ -57,6 +56,12 @@ public class ServiceInstances {
   private final ServiceInstanceService api;
   private final ConfigService configApi;
   private final Spaces spaces;
+
+  public List<Resource<ServiceBinding>> findAllServiceBindingsByServiceName(String serviceName) {
+    String serviceGuid = findServiceByServiceName(serviceName).getMetadata().getGuid();
+    return collectPageResources(
+        "service bindings", pg -> api.getBindingsForServiceInstance(serviceGuid, pg, null));
+  }
 
   public void createServiceBinding(CreateServiceBinding createServiceBinding) {
     try {

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
@@ -24,6 +24,7 @@ import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Ser
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ServiceInstance.Type.USER_PROVIDED_SERVICE_INSTANCE;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -57,10 +58,13 @@ public class ServiceInstances {
   private final ConfigService configApi;
   private final Spaces spaces;
 
-  public List<Resource<ServiceBinding>> findAllServiceBindingsByServiceName(String serviceName) {
-    String serviceGuid = findServiceByServiceName(serviceName).getMetadata().getGuid();
-    return collectPageResources(
-        "service bindings", pg -> api.getBindingsForServiceInstance(serviceGuid, pg, null));
+  public List<Resource<ServiceBinding>> findAllServiceBindingsByServiceName(
+      String region, String serviceName) {
+    CloudFoundryServiceInstance serviceInstance = getServiceInstance(region, serviceName);
+    if (serviceInstance == null) {
+      return emptyList();
+    }
+    return findAllServiceBindingsByService(serviceInstance.getId());
   }
 
   public void createServiceBinding(CreateServiceBinding createServiceBinding) {
@@ -84,6 +88,12 @@ public class ServiceInstances {
         "service bindings", pg -> api.getAllServiceBindings(singletonList(bindingsQuery)));
   }
 
+  public List<Resource<ServiceBinding>> findAllServiceBindingsByService(String serviceGuid) {
+    String bindingsQuery = "service_instance_guid:" + serviceGuid;
+    return collectPageResources(
+        "service bindings", pg -> api.getAllServiceBindings(singletonList(bindingsQuery)));
+  }
+
   public void deleteServiceBinding(String serviceBindingGuid) {
     safelyCall(() -> api.deleteServiceBinding(serviceBindingGuid));
   }
@@ -92,7 +102,7 @@ public class ServiceInstances {
     List<Resource<Service>> services =
         collectPageResources(
             "services by name", pg -> api.findService(pg, singletonList("label:" + serviceName)));
-    return Optional.ofNullable(services.get(0)).orElse(null);
+    return ofNullable(services.get(0)).orElse(null);
   }
 
   private List<CloudFoundryServicePlan> findAllServicePlansByServiceName(String serviceName) {
@@ -156,7 +166,7 @@ public class ServiceInstances {
         spaces
             .findSpaceByRegion(region)
             .orElseThrow(() -> new CloudFoundryApiException("Cannot find region '" + region + "'"));
-    return Optional.ofNullable(getOsbServiceInstance(space, serviceInstanceName))
+    return ofNullable(getOsbServiceInstance(space, serviceInstanceName))
         .orElseThrow(
             () ->
                 new CloudFoundryApiException(
@@ -176,7 +186,7 @@ public class ServiceInstances {
       throw new CloudFoundryApiException(
           "Please specify a name for the " + gerund + " service instance");
     }
-    sharingRegions = Optional.ofNullable(sharingRegions).orElse(Collections.emptySet());
+    sharingRegions = ofNullable(sharingRegions).orElse(Collections.emptySet());
     if (sharingRegions.size() == 0) {
       throw new CloudFoundryApiException(
           "Please specify a list of regions for " + gerund + " '" + serviceInstanceName + "'");
@@ -246,7 +256,7 @@ public class ServiceInstances {
             .map(Resource::getEntity)
             .map(
                 s ->
-                    Optional.ofNullable(s.getExtra())
+                    ofNullable(s.getExtra())
                         .orElseThrow(
                             () ->
                                 new CloudFoundryApiException(
@@ -322,7 +332,7 @@ public class ServiceInstances {
 
     unshareFromSpaces.forEach(
         space ->
-            Optional.ofNullable(spaces.getServiceInstanceByNameAndSpace(serviceInstanceName, space))
+            ofNullable(spaces.getServiceInstanceByNameAndSpace(serviceInstanceName, space))
                 .map(
                     si ->
                         safelyCall(
@@ -342,21 +352,19 @@ public class ServiceInstances {
             .findSpaceByRegion(region)
             .orElseThrow(() -> new CloudFoundryApiException("Cannot find region '" + region + "'"));
     Supplier<CloudFoundryServiceInstance> si =
-        () -> Optional.ofNullable(getOsbServiceInstance(space, serviceInstanceName)).orElse(null);
+        () -> ofNullable(getOsbServiceInstance(space, serviceInstanceName)).orElse(null);
 
     Supplier<CloudFoundryServiceInstance> up =
-        () ->
-            Optional.ofNullable(getUserProvidedServiceInstance(space, serviceInstanceName))
-                .orElse(null);
+        () -> ofNullable(getUserProvidedServiceInstance(space, serviceInstanceName)).orElse(null);
 
-    return Optional.ofNullable(si.get()).orElseGet(up);
+    return ofNullable(si.get()).orElseGet(up);
   }
 
   @Nullable
   @VisibleForTesting
   CloudFoundryServiceInstance getOsbServiceInstance(
       CloudFoundrySpace space, @Nullable String serviceInstanceName) {
-    return Optional.ofNullable(getServiceInstance(api::all, space, serviceInstanceName))
+    return ofNullable(getServiceInstance(api::all, space, serviceInstanceName))
         .map(
             r ->
                 CloudFoundryServiceInstance.builder()
@@ -374,7 +382,7 @@ public class ServiceInstances {
   @VisibleForTesting
   CloudFoundryServiceInstance getUserProvidedServiceInstance(
       CloudFoundrySpace space, @Nullable String serviceInstanceName) {
-    return Optional.ofNullable(getServiceInstance(api::allUserProvided, space, serviceInstanceName))
+    return ofNullable(getServiceInstance(api::allUserProvided, space, serviceInstanceName))
         .map(
             r ->
                 CloudFoundryServiceInstance.builder()

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DestroyCloudFoundryServiceAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DestroyCloudFoundryServiceAtomicOperationConverter.java
@@ -48,6 +48,10 @@ public class DestroyCloudFoundryServiceAtomicOperationConverter
                 () ->
                     new IllegalArgumentException(
                         "Unable to find space '" + converted.getRegion() + "'.")));
+    if (converted.getApplication() == null || converted.getApplication().isEmpty()) {
+      throw new IllegalArgumentException(
+          "Application must not be null. Please re-create the destroy service stage in order to automatically add this field.");
+    }
     return converted;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DestroyCloudFoundryServiceDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DestroyCloudFoundryServiceDescription.java
@@ -16,11 +16,15 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description;
 
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class DestroyCloudFoundryServiceDescription extends AbstractCloudFoundryServiceDescription {
+public class DestroyCloudFoundryServiceDescription
+    extends AbstractCloudFoundryServerGroupDescription {
   private String serviceInstanceName;
+  private CloudFoundrySpace space;
+  private boolean removeBindings;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DestroyCloudFoundryServiceDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DestroyCloudFoundryServiceDescription.java
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
+import java.util.Collection;
+import java.util.Collections;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -27,4 +29,10 @@ public class DestroyCloudFoundryServiceDescription
   private String serviceInstanceName;
   private CloudFoundrySpace space;
   private boolean removeBindings;
+  private String application;
+
+  @Override
+  public Collection<String> getApplications() {
+    return Collections.singletonList(application);
+  }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DestroyCloudFoundryServiceAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DestroyCloudFoundryServiceAtomicOperation.java
@@ -20,11 +20,15 @@ import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Las
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.ServiceInstanceResponse;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.LastOperation;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ServiceBinding;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DestroyCloudFoundryServiceDescription;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryServerGroup;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -40,6 +44,44 @@ public class DestroyCloudFoundryServiceAtomicOperation
   @Override
   public ServiceInstanceResponse operate(List priorOutputs) {
     Task task = getTask();
+
+    if (description.isRemoveBindings()) {
+
+      // create map of binding guid to service binding entity
+      Map<String, ServiceBinding> map = new HashMap<>();
+      description
+          .getClient()
+          .getServiceInstances()
+          .findAllServiceBindingsByServiceName(description.getServiceInstanceName())
+          .stream()
+          .forEach(
+              r -> {
+                map.put(r.getMetadata().getGuid(), r.getEntity());
+              });
+
+      // make sure that the bindings are only to sg's that belong to the spinnaker application
+      // before deleting, or else throw
+      for (ServiceBinding sb : map.values()) {
+        CloudFoundryServerGroup sg =
+            description.getClient().getApplications().findById(sb.getAppGuid());
+        String appName = description.getApplications().stream().findFirst().get();
+        if (sg == null || !sg.getName().startsWith(appName)) {
+          throw new IllegalArgumentException(
+              "Unable to unbind server group '"
+                  + sg
+                  + "' from "
+                  + description.getServiceInstanceName()
+                  + " because it doesn't belong to Spinnaker Application:  "
+                  + appName);
+        }
+      }
+
+      // delete the service binding
+      for (String sbKey : map.keySet()) {
+        description.getClient().getServiceInstances().deleteServiceBinding(sbKey);
+      }
+    }
+
     ServiceInstanceResponse response =
         description
             .getClient()


### PR DESCRIPTION
Adding a new flag to the destroy service stage that will attempt to unbind any applications prior to destroying the service. It will only allow unbinding server groups that belong to the spinnaker application running the pipeline.