### PR TITLE
fix(cloudfoundry): include final asg when checking taken slots

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -637,7 +637,7 @@ public class Applications {
       getTakenSlots(String clusterName, String spaceId) {
     String finalName = buildFinalAsgName(clusterName);
     List<String> filter =
-        asList("name<" + finalName, "name>=" + clusterName, "space_guid:" + spaceId);
+        asList("name<=" + finalName, "name>=" + clusterName, "space_guid:" + spaceId);
     return collectPageResources("applications", page -> api.listAppsFiltered(page, filter, 10))
         .stream()
         .filter(


### PR DESCRIPTION
The filter for getting existing ASGs didn't include the "final" (v999) ASG. At v998 any subsequent deployment tries to create v999, and fails if that already exists. This means at v999 the cluster name is unusable for further deployments.

To fix this I'm including the final ASG in the query filter, so that v999 is recognised as a "taken slot".