### PR TITLE
feat(cloudfoundry): add versioning to cf services

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
@@ -159,8 +159,9 @@ public class ServiceInstances {
     return serviceInstances;
   }
 
-  public List<Resource<? extends AbstractServiceInstance>> findAllVersionedServiceInstancesBySpace(
-      CloudFoundrySpace space, String serviceInstanceName) {
+  public List<Resource<? extends AbstractServiceInstance>>
+      findAllVersionedServiceInstancesBySpaceAndName(
+          CloudFoundrySpace space, String serviceInstanceName) {
     List<String> serviceInstanceQuery =
         Arrays.asList(
             "name>=" + serviceInstanceName,

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
@@ -159,6 +159,22 @@ public class ServiceInstances {
     return serviceInstances;
   }
 
+  public List<Resource<? extends AbstractServiceInstance>> findAllVersionedServiceInstancesBySpace(
+      CloudFoundrySpace space, String serviceInstanceName) {
+    List<String> serviceInstanceQuery =
+        Arrays.asList(
+            "name>=" + serviceInstanceName,
+            "organization_guid:" + space.getOrganization().getId(),
+            "space_guid:" + space.getId());
+    List<Resource<? extends AbstractServiceInstance>> serviceInstances = new ArrayList<>();
+    serviceInstances.addAll(
+        collectPageResources("service instances", pg -> api.all(pg, serviceInstanceQuery)));
+    serviceInstances.addAll(
+        collectPageResources(
+            "service instances", pg -> api.allUserProvided(pg, serviceInstanceQuery)));
+    return serviceInstances;
+  }
+
   // Visible for testing
   CloudFoundryServiceInstance getOsbServiceInstanceByRegion(
       String region, String serviceInstanceName) {

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/ServiceInstanceResponse.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/ServiceInstanceResponse.java
@@ -24,4 +24,5 @@ public class ServiceInstanceResponse {
   private String serviceInstanceName;
   private LastOperation.Type type;
   private LastOperation.State state;
+  private String previousInstanceName;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverter.java
@@ -24,8 +24,11 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryOperation;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryApiException;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeployCloudFoundryServiceDescription;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops.DeployCloudFoundryServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.security.CloudFoundryCredentials;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
@@ -33,6 +36,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
@@ -46,6 +52,8 @@ public class DeployCloudFoundryServiceAtomicOperationConverter
       new ObjectMapper()
           .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE)
           .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+  private final Pattern r = Pattern.compile(".*?-v(\\d+)");
 
   public DeployCloudFoundryServiceAtomicOperationConverter() {}
 
@@ -73,10 +81,89 @@ public class DeployCloudFoundryServiceAtomicOperationConverter
     if (converted.isUserProvided()) {
       converted.setUserProvidedServiceAttributes(
           convertUserProvidedServiceManifest(manifest.stream().findFirst().orElse(null)));
+      if (converted.getUserProvidedServiceAttributes() != null
+          && converted.getUserProvidedServiceAttributes().isVersioned()) {
+        DeployCloudFoundryServiceDescription.UserProvidedServiceAttributes attributes =
+            converted.getUserProvidedServiceAttributes();
+        attributes.setPreviousInstanceName(
+            getLatestInstanceName(
+                attributes.getServiceInstanceName(), converted.getClient(), converted.getSpace()));
+        attributes.setServiceInstanceName(
+            getNextInstanceName(
+                attributes.getServiceInstanceName(), attributes.getPreviousInstanceName()));
+        converted.setUserProvidedServiceAttributes(attributes);
+      }
     } else {
       converted.setServiceAttributes(convertManifest(manifest.stream().findFirst().orElse(null)));
+      if (converted.getServiceAttributes() != null
+          && converted.getServiceAttributes().isVersioned()) {
+        DeployCloudFoundryServiceDescription.ServiceAttributes attributes =
+            converted.getServiceAttributes();
+        attributes.setPreviousInstanceName(
+            getLatestInstanceName(
+                attributes.getServiceInstanceName(), converted.getClient(), converted.getSpace()));
+        attributes.setServiceInstanceName(
+            getNextInstanceName(
+                attributes.getServiceInstanceName(), attributes.getPreviousInstanceName()));
+        converted.setServiceAttributes(attributes);
+      }
     }
     return converted;
+  }
+
+  @Nullable
+  private String getLatestInstanceName(
+      String serviceInstanceName, CloudFoundryClient client, CloudFoundrySpace space) {
+    if (serviceInstanceName == null || serviceInstanceName.isEmpty()) {
+      throw new IllegalArgumentException("Service Instance Name must not be null or empty.");
+    }
+    List<String> serviceInstances =
+        client
+            .getServiceInstances()
+            .findAllVersionedServiceInstancesBySpace(
+                space, String.format("%s-v%03d", serviceInstanceName, 0))
+            .stream()
+            .filter(n -> n.getEntity().getName().startsWith(serviceInstanceName))
+            .map(rs -> rs.getEntity().getName())
+            .filter(n -> isVersioned(n))
+            .collect(Collectors.toList());
+
+    if (serviceInstances.isEmpty()) {
+      return null;
+    }
+
+    Integer latestVersion =
+        serviceInstances.stream()
+            .map(
+                v -> {
+                  Matcher m = r.matcher(v);
+                  m.find();
+                  return Integer.parseInt(m.group(1));
+                })
+            .mapToInt(n -> n)
+            .max()
+            .orElseThrow(
+                () ->
+                    new CloudFoundryApiException(
+                        "Unable to determine latest version for service instance: "
+                            + serviceInstanceName));
+
+    return String.format("%s-v%03d", serviceInstanceName, latestVersion);
+  }
+
+  private String getNextInstanceName(String serviceInstanceName, String latestInstanceName) {
+    if (latestInstanceName == null) {
+      return String.format("%s-v%03d", serviceInstanceName, 0);
+    }
+    Matcher m = r.matcher(latestInstanceName);
+    m.find();
+    int latestVersion = Integer.parseInt(m.group(1));
+    return String.format("%s-v%03d", serviceInstanceName, latestVersion + 1);
+  }
+
+  private boolean isVersioned(String name) {
+    Matcher m = r.matcher(name);
+    return m.find();
   }
 
   // visible for testing
@@ -99,6 +186,7 @@ public class DeployCloudFoundryServiceAtomicOperationConverter
     attrs.setServicePlan(manifest.getServicePlan());
     attrs.setTags(manifest.getTags());
     attrs.setUpdatable(manifest.isUpdatable());
+    attrs.setVersioned(manifest.isVersioned());
     attrs.setParameterMap(manifest.getParameters());
     return attrs;
   }
@@ -121,6 +209,7 @@ public class DeployCloudFoundryServiceAtomicOperationConverter
     attrs.setRouteServiceUrl(manifest.getRouteServiceUrl());
     attrs.setTags(manifest.getTags());
     attrs.setUpdatable(manifest.isUpdatable());
+    attrs.setVersioned(manifest.isVersioned());
     attrs.setCredentials(manifest.getCredentials());
     return attrs;
   }
@@ -129,6 +218,7 @@ public class DeployCloudFoundryServiceAtomicOperationConverter
   private static class ServiceManifest {
     private String service;
     private boolean updatable = true;
+    private boolean versioned = false;
 
     @JsonAlias({"service_instance_name", "serviceInstanceName"})
     private String serviceInstanceName;
@@ -146,6 +236,7 @@ public class DeployCloudFoundryServiceAtomicOperationConverter
   @Data
   private static class UserProvidedServiceManifest {
     private boolean updatable = true;
+    private boolean versioned = false;
 
     @JsonAlias({"service_instance_name", "serviceInstanceName"})
     private String serviceInstanceName;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverter.java
@@ -120,7 +120,7 @@ public class DeployCloudFoundryServiceAtomicOperationConverter
     List<String> serviceInstances =
         client
             .getServiceInstances()
-            .findAllVersionedServiceInstancesBySpace(
+            .findAllVersionedServiceInstancesBySpaceAndName(
                 space, String.format("%s-v%03d", serviceInstanceName, 0))
             .stream()
             .filter(n -> n.getEntity().getName().startsWith(serviceInstanceName))

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServiceDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServiceDescription.java
@@ -41,16 +41,20 @@ public class DeployCloudFoundryServiceDescription extends AbstractCloudFoundrySe
     String serviceInstanceName;
     String servicePlan;
     boolean updatable = true;
+    boolean versioned = false;
 
     @Nullable Set<String> tags;
 
     @Nullable Map<String, Object> parameterMap;
+
+    @JsonIgnore String previousInstanceName;
   }
 
   @Data
   public static class UserProvidedServiceAttributes {
     String serviceInstanceName;
     boolean updatable = true;
+    boolean versioned = false;
 
     @Nullable Set<String> tags;
 
@@ -59,5 +63,7 @@ public class DeployCloudFoundryServiceDescription extends AbstractCloudFoundrySe
     @Nullable Map<String, Object> credentials;
 
     @Nullable String routeServiceUrl;
+
+    @JsonIgnore String previousInstanceName;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServiceAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServiceAtomicOperation.java
@@ -58,6 +58,7 @@ public class DeployCloudFoundryServiceAtomicOperation
                   serviceAttributes.isUpdatable(),
                   description.getSpace());
       String gerund = serviceInstanceResponse.getType() == UPDATE ? "Updating" : "Creating";
+      serviceInstanceResponse.setPreviousInstanceName(serviceAttributes.getPreviousInstanceName());
       task.updateStatus(
           PHASE,
           gerund
@@ -86,6 +87,8 @@ public class DeployCloudFoundryServiceAtomicOperation
                   userProvidedServiceAttributes.isUpdatable(),
                   description.getSpace());
       String verb = serviceInstanceResponse.getType() == UPDATE ? "Updated" : "Created";
+      serviceInstanceResponse.setPreviousInstanceName(
+          userProvidedServiceAttributes.getPreviousInstanceName());
       task.updateStatus(
           PHASE, verb + " user-provided service instance '" + serviceInstanceName + "'");
     }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
@@ -30,6 +30,9 @@ import com.netflix.spinnaker.clouddriver.cloudfoundry.artifacts.ArtifactCredenti
 import com.netflix.spinnaker.clouddriver.cloudfoundry.cache.CacheRepository;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.MockCloudFoundryClient;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.AbstractServiceInstance;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Resource;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ServiceInstance;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.config.CloudFoundryConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeployCloudFoundryServiceDescription;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryOrganization;
@@ -39,10 +42,7 @@ import com.netflix.spinnaker.clouddriver.cloudfoundry.security.CloudFoundryCrede
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository;
 import com.netflix.spinnaker.credentials.NoopCredentialsLifecycleHandler;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.ForkJoinPool;
 import javax.annotation.Nullable;
 import okhttp3.OkHttpClient;
@@ -266,6 +266,53 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
                 .setRouteServiceUrl("http://routeServiceUrl.io")
                 .setTags(Collections.singleton("my-tag"))
                 .setUpdatable(true)
+                .setCredentials(Map.of("foo", "bar")));
+  }
+
+  @Test
+  void convertDescriptionWithUserProvidedInputAndVersioned() {
+    final Map input =
+        Map.of(
+            "credentials",
+            "test",
+            "region",
+            "org > space",
+            "userProvided",
+            true,
+            "manifest",
+            Collections.singletonList(
+                Map.of(
+                    "serviceInstanceName", "userProvidedServiceName",
+                    "tags", Collections.singletonList("my-tag"),
+                    "syslogDrainUrl", "http://syslogDrainUrl.io",
+                    "credentials", "{\"foo\": \"bar\"}",
+                    "versioned", "true",
+                    "updatable", "false",
+                    "routeServiceUrl", "http://routeServiceUrl.io")));
+
+    ServiceInstance si = new ServiceInstance();
+    si.setName("userProvidedServiceName-v000");
+    Resource<ServiceInstance> resource = new Resource<>();
+    resource.setEntity(si);
+    List<Resource<? extends AbstractServiceInstance>> serviceInstances = List.of(resource);
+
+    when(cloudFoundryClient
+            .getServiceInstances()
+            .findAllVersionedServiceInstancesBySpaceAndName(any(), any()))
+        .thenReturn(serviceInstances);
+
+    final DeployCloudFoundryServiceDescription result = converter.convertDescription(input);
+    assertThat(result.getServiceAttributes()).isNull();
+    assertThat(result.getUserProvidedServiceAttributes())
+        .isEqualToComparingFieldByFieldRecursively(
+            new DeployCloudFoundryServiceDescription.UserProvidedServiceAttributes()
+                .setServiceInstanceName("userProvidedServiceName-v001")
+                .setPreviousInstanceName("userProvidedServiceName-v000")
+                .setSyslogDrainUrl("http://syslogDrainUrl.io")
+                .setRouteServiceUrl("http://routeServiceUrl.io")
+                .setTags(Collections.singleton("my-tag"))
+                .setUpdatable(false)
+                .setVersioned(true)
                 .setCredentials(Map.of("foo", "bar")));
   }
 


### PR DESCRIPTION
This is a new flag that will allow cloudfoundry services to be versioned similar to how spinnaker handles applications. If this flag is checked, a version will be appended to the service name. I.e. servicename-v001. We are also returning the previous version name via a field called previousInstanceName to the stage so that a following stage can delete, etc. 
consolidates: https://github.com/spinnaker/clouddriver/pull/5422 and https://github.com/spinnaker/clouddriver/pull/5418