### PR TITLE
fix(kubernetes): support options.cascading in delete manifest pipelines

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesDeleteManifestDescription.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesDeleteManifestDescription.java
@@ -22,9 +22,9 @@ import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomicOperationDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesSelectorList;
-import io.kubernetes.client.openapi.models.V1DeleteOptions;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -32,7 +32,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class KubernetesDeleteManifestDescription extends KubernetesAtomicOperationDescription {
-  private V1DeleteOptions options;
+  private Map<String, String> options;
   private String manifestName;
   private String location;
   private List<String> kinds = new ArrayList<>();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeleteManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeleteManifestOperation.java
@@ -26,7 +26,10 @@ import com.netflix.spinnaker.clouddriver.kubernetes.op.OperationResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import io.kubernetes.client.openapi.models.V1DeleteOptions;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class KubernetesDeleteManifestOperation implements AtomicOperation<OperationResult> {
   private final KubernetesDeleteManifestDescription description;
@@ -53,6 +56,19 @@ public class KubernetesDeleteManifestOperation implements AtomicOperation<Operat
       coordinates = ImmutableList.of(description.getPointCoordinates());
     }
 
+    // If "orphanDependents" is strictly defined by the stage then the cascade flag of kubectl
+    // delete will honor the setting
+    // If orphanDependents isn't set, then look at the value of the "Cascading" delete checkbox in
+    // the UI
+    V1DeleteOptions deleteOptions = new V1DeleteOptions();
+    Map<String, String> options =
+        description.getOptions() == null ? new HashMap<>() : description.getOptions();
+    if (options.containsKey("orphanDependents")) {
+      deleteOptions.setOrphanDependents(options.get("orphanDependents").equalsIgnoreCase("true"));
+    } else if (options.containsKey("cascading")) {
+      deleteOptions.setOrphanDependents(options.get("cascading").equalsIgnoreCase("false"));
+    }
+
     OperationResult result = new OperationResult();
     coordinates.forEach(
         c -> {
@@ -67,7 +83,9 @@ public class KubernetesDeleteManifestOperation implements AtomicOperation<Operat
                   c.getNamespace(),
                   c.getName(),
                   description.getLabelSelectors(),
-                  description.getOptions()));
+                  deleteOptions));
+          getTask()
+              .updateStatus(OP_NAME, " delete operation completed successfully for " + c.getName());
         });
 
     return result;

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeleteManifestOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeleteManifestOperationTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2021 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.op;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.MapType;
+import com.google.common.collect.ImmutableList;
+import com.netflix.spinnaker.clouddriver.data.task.DefaultTask;
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.converter.manifest.KubernetesDeleteManifestConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.GlobalResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.ResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesDeleteManifestDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesReplicaSetHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesServiceHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesUnregisteredCustomResourceHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesDeleteManifestOperation;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesSelectorList;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import io.kubernetes.client.openapi.models.V1DeleteOptions;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * Testing the orphanDependant and cascading Pipeline Options
+ *
+ * <p>Based on DeleteOptions KubectlJobExecutor.delete will determine whether the --cascade flag is
+ * set. If deleteOptions.OrphanDependents is false or null -> --cascade is true. If
+ * deleteOptions.OrphanDependents is true -> --cascade is false. (Ex. kubectl delete replicaset
+ * my-repset --cascade=false)
+ */
+@RunWith(JUnitPlatform.class)
+public class KubernetesDeleteManifestOperationTest {
+  private static final ResourcePropertyRegistry resourcePropertyRegistry =
+      new GlobalResourcePropertyRegistry(
+          ImmutableList.of(new KubernetesReplicaSetHandler(), new KubernetesServiceHandler()),
+          new KubernetesUnregisteredCustomResourceHandler());
+  private static KubernetesDeleteManifestConverter converter;
+  private static ObjectMapper mapper;
+  private static MapType mapType;
+
+  @BeforeAll
+  static void setup() {
+    CredentialsRepository<KubernetesNamedAccountCredentials> credentialsRepository =
+        Mockito.mock(CredentialsRepository.class);
+    when(credentialsRepository.getOne(any(String.class)))
+        .thenReturn(Mockito.mock(KubernetesNamedAccountCredentials.class));
+
+    converter = new KubernetesDeleteManifestConverter();
+    converter.setCredentialsRepository(credentialsRepository);
+
+    mapper = converter.getObjectMapper();
+    mapType = mapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class);
+  }
+
+  @BeforeEach
+  void setupTest() {
+    // Store a Mock Task in a thread before each test
+    // so TaskRepository will be able to get it during delete to update the Task
+    TaskRepository.threadLocalTask.set(new DefaultTask("task-id"));
+  }
+
+  @Test
+  public void orphanDependentsTrueTest() throws IOException {
+    String pipelineJSON =
+        "{ "
+            + " \"account\": \"kubernetes-account\","
+            + "  \"kinds\": ["
+            + "    \"deployment\""
+            + "  ],"
+            + "  \"options\": {"
+            + "    \"orphanDependents\": \"true\""
+            + "  }"
+            + "}";
+    Map<String, Object> pipeline = mapper.readValue(pipelineJSON, mapType);
+
+    KubernetesDeleteManifestDescription description = buildDeleteManifestDescription(pipeline);
+
+    V1DeleteOptions deleteOptions = deleteAndCaptureDeleteOptions(description);
+    assertTrue(deleteOptions.getOrphanDependents());
+  }
+
+  @Test
+  public void orphanDependentsFalseTest() throws IOException {
+    String pipelineJSON =
+        "{ "
+            + " \"account\": \"kubernetes-account\","
+            + "  \"kinds\": [ \"deployment\" ],"
+            + "  \"options\": {"
+            + "    \"orphanDependents\": \"false\""
+            + "  }"
+            + "}";
+    Map<String, Object> pipeline = mapper.readValue(pipelineJSON, mapType);
+
+    KubernetesDeleteManifestDescription description = buildDeleteManifestDescription(pipeline);
+
+    V1DeleteOptions deleteOptions = deleteAndCaptureDeleteOptions(description);
+    assertFalse(deleteOptions.getOrphanDependents());
+  }
+
+  @Test
+  public void noOptionsDefaultTest() throws IOException {
+    String pipelineJSON =
+        "{ \"account\": \"kubernetes-account\"," + "  \"kinds\": [ \"deployment\" ]" + "}";
+    Map<String, Object> pipeline = mapper.readValue(pipelineJSON, mapType);
+
+    KubernetesDeleteManifestDescription description = buildDeleteManifestDescription(pipeline);
+
+    V1DeleteOptions deleteOptions = deleteAndCaptureDeleteOptions(description);
+    assertNull(deleteOptions.getOrphanDependents());
+  }
+
+  @Test()
+  public void cascadingTrueSetOrphanDependentsFalseTest() throws IOException {
+    String pipelineJSON =
+        "{ "
+            + " \"account\": \"kubernetes-account\","
+            + "  \"kinds\": [ \"deployment\" ],"
+            + "  \"options\": {"
+            + "    \"cascading\": \"true\""
+            + "  }"
+            + "}";
+    Map<String, Object> pipeline = mapper.readValue(pipelineJSON, mapType);
+
+    KubernetesDeleteManifestDescription description = buildDeleteManifestDescription(pipeline);
+
+    V1DeleteOptions deleteOptions = deleteAndCaptureDeleteOptions(description);
+    assertFalse(deleteOptions.getOrphanDependents());
+  }
+
+  @Test()
+  public void cascadingFalseSetOrphanDependentsTrueTest() throws IOException {
+    String pipelineJSON =
+        "{ "
+            + " \"account\": \"kubernetes-account\","
+            + "  \"kinds\": [ \"deployment\" ],"
+            + "  \"options\": {"
+            + "    \"cascading\": \"false\""
+            + "  }"
+            + "}";
+    Map<String, Object> pipeline = mapper.readValue(pipelineJSON, mapType);
+
+    KubernetesDeleteManifestDescription description = buildDeleteManifestDescription(pipeline);
+
+    V1DeleteOptions deleteOptions = deleteAndCaptureDeleteOptions(description);
+    assertTrue(deleteOptions.getOrphanDependents());
+  }
+
+  @Test()
+  // Set both orphanDependents and cascading options and show that
+  // the orphanDependents options has precedence
+  public void showTrueOrphanDependentsPrecedenceTest() throws IOException {
+    String pipelineJSON =
+        "{ "
+            + " \"account\": \"kubernetes-account\","
+            + "  \"kinds\": [ \"deployment\" ],"
+            + "  \"options\": {"
+            + "    \"cascading\": \"true\","
+            + "    \"orphanDependents\": \"true\""
+            + "  }"
+            + "}";
+    Map<String, Object> pipeline = mapper.readValue(pipelineJSON, mapType);
+
+    KubernetesDeleteManifestDescription description = buildDeleteManifestDescription(pipeline);
+
+    V1DeleteOptions deleteOptions = deleteAndCaptureDeleteOptions(description);
+    assertTrue(deleteOptions.getOrphanDependents());
+  }
+
+  @Test()
+  public void showFalseOrphanDependentsPrecedenceTest() throws IOException {
+    String pipelineJSON =
+        "{ "
+            + " \"account\": \"kubernetes-account\","
+            + "  \"kinds\": [ \"deployment\" ],"
+            + "  \"options\": {"
+            + "    \"cascading\": \"false\","
+            + "    \"orphanDependents\": \"false\""
+            + "  }"
+            + "}";
+    Map<String, Object> pipeline = mapper.readValue(pipelineJSON, mapType);
+
+    KubernetesDeleteManifestDescription description = buildDeleteManifestDescription(pipeline);
+
+    V1DeleteOptions deleteOptions = deleteAndCaptureDeleteOptions(description);
+    assertFalse(deleteOptions.getOrphanDependents());
+  }
+
+  private static V1DeleteOptions deleteAndCaptureDeleteOptions(
+      KubernetesDeleteManifestDescription description) {
+    KubernetesCredentials mockKubernetesCreds = description.getCredentials().getCredentials();
+
+    new KubernetesDeleteManifestOperation(description).operate(ImmutableList.of());
+    ArgumentCaptor<V1DeleteOptions> deleteOptionsCaptor =
+        ArgumentCaptor.forClass(V1DeleteOptions.class);
+    verify(mockKubernetesCreds)
+        .delete(
+            any(KubernetesKind.class),
+            anyString(),
+            anyString(),
+            any(KubernetesSelectorList.class),
+            deleteOptionsCaptor.capture());
+    return deleteOptionsCaptor.getValue();
+  }
+
+  private static KubernetesDeleteManifestDescription buildDeleteManifestDescription(
+      Map<String, Object> inputMap) {
+    KubernetesDeleteManifestDescription description = converter.convertDescription(inputMap);
+    description.setCredentials(getNamedAccountCredentials());
+    return description;
+  }
+
+  private static KubernetesNamedAccountCredentials getNamedAccountCredentials() {
+    KubernetesConfigurationProperties.ManagedAccount managedAccount =
+        new KubernetesConfigurationProperties.ManagedAccount();
+    managedAccount.setName("my-account");
+
+    KubernetesCredentials mockCredentials = mock(KubernetesCredentials.class);
+    when(mockCredentials.getResourcePropertyRegistry()).thenReturn(resourcePropertyRegistry);
+
+    KubernetesCredentials.Factory credentialFactory = mock(KubernetesCredentials.Factory.class);
+    when(credentialFactory.build(managedAccount)).thenReturn(mockCredentials);
+
+    return new KubernetesNamedAccountCredentials(managedAccount, credentialFactory);
+  }
+}


### PR DESCRIPTION
Previously, setting options.cascading in a delete manifest pipeline was a no-op. Now, it's another way (in addition to options.orphanDependents) to control whether kubernetes performs a cascading delete. If both
orphanDependents and cascading are specified, orphanDependents takes precedence. 

This fix will now look at the value of the "cascading" option in the Deck UI (which was not happening previously). 

The change was tested using unit tests with different pipelines as test cases. (as seen in `clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeleteManifestOperationTest.java`) This fix was also 

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
