### PR TITLE
feat(cloudfoundry): onlySpinnakerManaged flag for server groups

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
@@ -75,6 +75,7 @@ public class HttpCloudFoundryClient implements CloudFoundryClient {
       String password,
       boolean useHttps,
       boolean skipSslValidation,
+      boolean onlySpinnakerManaged,
       Integer resultsPerPage,
       ForkJoinPool forkJoinPool,
       OkHttpClient.Builder okHttpClientBuilder,
@@ -134,6 +135,7 @@ public class HttpCloudFoundryClient implements CloudFoundryClient {
             spaces,
             processes,
             resultsPerPage,
+            onlySpinnakerManaged,
             forkJoinPool);
     this.domains = new Domains(retrofit.create(DomainService.class), organizations);
     this.serviceInstances =

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/config/CloudFoundryConfigurationProperties.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/config/CloudFoundryConfigurationProperties.java
@@ -64,6 +64,7 @@ public class CloudFoundryConfigurationProperties implements DisposableBean {
     private String password;
     private String environment;
     private boolean skipSslValidation;
+    private boolean onlySpinnakerManaged;
     private Integer resultsPerPage;
 
     @Deprecated

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
@@ -77,17 +77,21 @@ public class CloudFoundryServerGroupCachingAgent extends AbstractCloudFoundryCac
         this.getCredentials().getFilteredSpaces().stream()
             .map(s -> s.getId())
             .collect(Collectors.toList());
+
     List<CloudFoundryApplication> apps = this.getClient().getApplications().all(spaceFilters);
     List<CloudFoundryCluster> clusters =
         apps.stream().flatMap(app -> app.getClusters().stream()).collect(Collectors.toList());
+
     List<CloudFoundryServerGroup> serverGroups =
         clusters.stream()
             .flatMap(cluster -> cluster.getServerGroups().stream())
             .collect(Collectors.toList());
+
     List<CloudFoundryInstance> instances =
         serverGroups.stream()
             .flatMap(serverGroup -> serverGroup.getInstances().stream())
             .collect(Collectors.toList());
+
     Collection<CacheData> onDemandCacheData =
         providerCache.getAll(
             ON_DEMAND.getNs(),

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/config/CloudFoundryProviderConfig.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/config/CloudFoundryProviderConfig.java
@@ -96,6 +96,7 @@ public class CloudFoundryProviderConfig {
                 a.getPassword(),
                 a.getEnvironment(),
                 a.isSkipSslValidation(),
+                a.isOnlySpinnakerManaged(),
                 a.getResultsPerPage(),
                 cacheRepository,
                 a.getPermissions().build(),

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
@@ -62,17 +62,16 @@ public class CloudFoundryCredentials extends AbstractAccountCredentials<CloudFou
   private final String apiHost;
   private final String userName;
   private final String password;
+  private final boolean skipSslValidation;
+  private final boolean onlySpinnakerManaged;
 
   @Nullable private final String environment;
+  @Nullable private final Integer resultsPerPage;
 
   private final String accountType = "cloudfoundry";
-
   private final String cloudProvider = "cloudfoundry";
 
   @Deprecated private final List<String> requiredGroupMembership = Collections.emptyList();
-  private final boolean skipSslValidation;
-
-  @Nullable private final Integer resultsPerPage;
 
   private final Supplier<List<CloudFoundrySpace>> spaceSupplier =
       Memoizer.memoizeWithExpiration(this::spaceSupplier, SPACE_EXPIRY_SECONDS, TimeUnit.SECONDS);
@@ -96,6 +95,7 @@ public class CloudFoundryCredentials extends AbstractAccountCredentials<CloudFou
       String password,
       String environment,
       boolean skipSslValidation,
+      boolean onlySpinnakerManaged,
       Integer resultsPerPage,
       CacheRepository cacheRepository,
       Permissions permissions,
@@ -111,6 +111,7 @@ public class CloudFoundryCredentials extends AbstractAccountCredentials<CloudFou
     this.password = password;
     this.environment = Optional.ofNullable(environment).orElse("dev");
     this.skipSslValidation = skipSslValidation;
+    this.onlySpinnakerManaged = onlySpinnakerManaged;
     this.resultsPerPage = Optional.ofNullable(resultsPerPage).orElse(100);
     this.cacheRepository = cacheRepository;
     this.permissions = permissions == null ? Permissions.EMPTY : permissions;
@@ -125,6 +126,7 @@ public class CloudFoundryCredentials extends AbstractAccountCredentials<CloudFou
             password,
             true,
             skipSslValidation,
+            onlySpinnakerManaged,
             resultsPerPage,
             forkJoinPool,
             okHttpClient.newBuilder(),

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepositoryTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepositoryTest.java
@@ -121,6 +121,7 @@ class CacheRepositoryTest {
         "pwd-" + name,
         null,
         false,
+        false,
         null,
         repo,
         null,

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClientTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClientTest.java
@@ -243,6 +243,7 @@ class HttpCloudFoundryClientTest {
         "password",
         false,
         true,
+        false,
         500,
         ForkJoinPool.commonPool(),
         new OkHttpClient.Builder(),

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractLoadBalancersAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractLoadBalancersAtomicOperationConverterTest.java
@@ -99,6 +99,7 @@ class AbstractLoadBalancersAtomicOperationConverterTest {
           "password",
           "environment",
           false,
+          false,
           500,
           cacheRepository,
           null,

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/CreateCloudFoundryServiceKeyAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/CreateCloudFoundryServiceKeyAtomicOperationConverterTest.java
@@ -66,6 +66,7 @@ class CreateCloudFoundryServiceKeyAtomicOperationConverterTest {
           "password",
           "environment",
           false,
+          false,
           500,
           cacheRepository,
           null,

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeleteCloudFoundryServiceKeyAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeleteCloudFoundryServiceKeyAtomicOperationConverterTest.java
@@ -71,6 +71,7 @@ class DeleteCloudFoundryServiceKeyAtomicOperationConverterTest {
           "password",
           "environment",
           false,
+          false,
           500,
           cacheRepository,
           null,

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -99,6 +99,7 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
         "password",
         "environment",
         false,
+        false,
         500,
         cacheRepository,
         null,

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
@@ -86,6 +86,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
           "password",
           "environment",
           false,
+          false,
           500,
           cacheRepository,
           null,

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/ScaleCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/ScaleCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -57,6 +57,7 @@ class ScaleCloudFoundryServerGroupAtomicOperationConverterTest {
           "password",
           "environment",
           false,
+          false,
           500,
           cacheRepository,
           null,

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsTest.java
@@ -132,6 +132,7 @@ public class CloudFoundryCredentialsTest {
         "password",
         "environment",
         false,
+        false,
         500,
         cacheRepository,
         null,


### PR DESCRIPTION
Adds a flag to Cloud Foundry accounts "onlySpinnakerManaged" that is disabled by default. When enabled any application in the foundation that does not end in "vXXX" (i.e. was not deployed by Spinnaker) will be ignored.

This is useful when foundations have historically been deployed to by other tooling. Since Spinnaker creates unconfigured applications for server groups it can see, these non-Spinnaker apps block the creation of the same app name in Spinnaker.

Whilst checking the app name ends in a version is a bit of a hack, unfortunately other avenues are unavailable:
* Metadata endpoints can't be supported until the minimum supported version for CF is bumped.
* Environment variable endpoints may be restricted for security reasons (so we can't check for the pipeline ID env variable)