### PR TITLE
refactor(aws): Refactoring launch template roll out config

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.deploy.asg.AsgConfigHelper
+import com.netflix.spinnaker.clouddriver.aws.deploy.asg.LaunchTemplateRollOutConfig
 import com.netflix.spinnaker.config.AwsConfiguration
 import com.netflix.spinnaker.config.AwsConfiguration.DeployDefaults
 import com.netflix.spinnaker.clouddriver.aws.deploy.AmiIdResolver
@@ -46,7 +47,6 @@ import com.netflix.spinnaker.clouddriver.deploy.DeployHandler
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
 import com.netflix.spinnaker.clouddriver.orchestration.events.CreateServerGroupEvent
 import com.netflix.spinnaker.credentials.CredentialsRepository
-import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
 
@@ -67,7 +67,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
   private final AwsConfiguration.DeployDefaults deployDefaults
   private final ScalingPolicyCopier scalingPolicyCopier
   private final BlockDeviceConfig blockDeviceConfig
-  private final DynamicConfigService dynamicConfigService
+  private final LaunchTemplateRollOutConfig launchTemplateRollOutConfig
 
   private List<CreateServerGroupEvent> deployEvents = []
 
@@ -77,14 +77,14 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
                            AwsConfiguration.DeployDefaults deployDefaults,
                            ScalingPolicyCopier scalingPolicyCopier,
                            BlockDeviceConfig blockDeviceConfig,
-                           DynamicConfigService dynamicConfigService) {
+                           LaunchTemplateRollOutConfig launchTemplateRollOutConfig) {
     this.regionScopedProviderFactory = regionScopedProviderFactory
     this.accountCredentialsRepository = accountCredentialsRepository
     this.amazonServerGroupProvider = amazonServerGroupProvider
     this.deployDefaults = deployDefaults
     this.scalingPolicyCopier = scalingPolicyCopier
     this.blockDeviceConfig = blockDeviceConfig
-    this.dynamicConfigService = dynamicConfigService
+    this.launchTemplateRollOutConfig = launchTemplateRollOutConfig
   }
 
   @Override
@@ -253,7 +253,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
           desired: description.capacity.desired ?: 0
       )
 
-      def autoScalingWorker = new AutoScalingWorker(regionScopedProvider, dynamicConfigService)
+      def autoScalingWorker = new AutoScalingWorker(regionScopedProvider, launchTemplateRollOutConfig)
 
       // build AsgWorker configuration and then call deploy
       def asgConfig = AutoScalingWorker.AsgConfiguration.builder()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/config/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/config/AwsConfiguration.groovy
@@ -23,6 +23,7 @@ import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties
 import com.netflix.spinnaker.clouddriver.aws.deploy.InstanceTypeUtils.BlockDeviceConfig
+import com.netflix.spinnaker.clouddriver.aws.deploy.asg.LaunchTemplateRollOutConfig
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.BasicAmazonDeployHandler
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory
 import com.netflix.spinnaker.clouddriver.aws.deploy.scalingpolicy.DefaultScalingPolicyCopier
@@ -220,7 +221,7 @@ class AwsConfiguration {
     DeployDefaults deployDefaults,
     ScalingPolicyCopier scalingPolicyCopier,
     BlockDeviceConfig blockDeviceConfig,
-    DynamicConfigService dynamicConfigService,
+    LaunchTemplateRollOutConfig launchTemplateRollOutConfig,
     AmazonServerGroupProvider amazonServerGroupProvider
   ) {
     new BasicAmazonDeployHandler(
@@ -230,8 +231,14 @@ class AwsConfiguration {
       deployDefaults,
       scalingPolicyCopier,
       blockDeviceConfig,
-      dynamicConfigService
+      launchTemplateRollOutConfig
     )
+  }
+
+  @Bean
+  LaunchTemplateRollOutConfig launchTemplateRollOutConfig(
+    DynamicConfigService dynamicConfigService) {
+    new LaunchTemplateRollOutConfig(dynamicConfigService)
   }
 
   @Bean
@@ -262,7 +269,7 @@ class AwsConfiguration {
   @Bean
   @ConditionalOnMissingBean(AfterResizeEventHandler)
   DefaultAfterResizeEventHandler defaultAfterResizeEventHandler() {
-    return new DefaultAfterResizeEventHandler();
+    return new DefaultAfterResizeEventHandler()
   }
 
   class AmazonServerGroupProvider {

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/asg/LaunchTemplateRollOutConfig.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/asg/LaunchTemplateRollOutConfig.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.asg;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+public class LaunchTemplateRollOutConfig {
+  private DynamicConfigService dynamicConfigService;
+
+  public LaunchTemplateRollOutConfig(DynamicConfigService dynamicConfigService) {
+    this.dynamicConfigService = dynamicConfigService;
+  }
+
+  public boolean isIpv6EnabledForEnv(String env) {
+    return dynamicConfigService.isEnabled("aws.features.launch-templates.ipv6." + env, false);
+  }
+
+  /** This is used to gradually roll out launch template. */
+  public boolean shouldUseLaunchTemplateForReq(
+      String applicationInReq, NetflixAmazonCredentials credentialsInReq, String regionInReq) {
+
+    // Property flag to turn off launch template feature. Caching agent might require bouncing the
+    // java process
+    if (!dynamicConfigService.isEnabled("aws.features.launch-templates", false)) {
+      log.debug("Launch Template feature disabled via configuration.");
+      return false;
+    }
+
+    // This is a comma separated list of applications to exclude
+    String excludedApps =
+        dynamicConfigService.getConfig(
+            String.class, "aws.features.launch-templates.excluded-applications", "");
+    for (String excludedApp : excludedApps.split(",")) {
+      if (excludedApp.trim().equals(applicationInReq)) {
+        return false;
+      }
+    }
+
+    // This is a comma separated list of accounts to exclude
+    String excludedAccounts =
+        dynamicConfigService.getConfig(
+            String.class, "aws.features.launch-templates.excluded-accounts", "");
+    for (String excludedAccount : excludedAccounts.split(",")) {
+      if (excludedAccount.trim().equals(credentialsInReq.getName())) {
+        return false;
+      }
+    }
+
+    // Allows everything that is not excluded
+    if (dynamicConfigService.isEnabled("aws.features.launch-templates.all-applications", false)) {
+      return true;
+    }
+
+    // Application allow list with the following format:
+    // app1:account:region1,app2:account:region1
+    // This allows more control over what account and region pairs to enable for this deployment.
+    String allowedApps =
+        dynamicConfigService.getConfig(
+            String.class, "aws.features.launch-templates.allowed-applications", "");
+    if (matchesAppAccountAndRegion(
+        applicationInReq, credentialsInReq.getName(), regionInReq, allowedApps.split(","))) {
+      return true;
+    }
+
+    // An allow list for account/region pairs with the following format:
+    // account:region
+    String allowedAccountsAndRegions =
+        dynamicConfigService.getConfig(
+            String.class, "aws.features.launch-templates.allowed-accounts-regions", "");
+    for (String accountRegion : allowedAccountsAndRegions.split(",")) {
+      if (StringUtils.isNotBlank(accountRegion) && accountRegion.contains(":")) {
+        String[] parts = accountRegion.split(":");
+        String account = parts[0];
+        String region = parts[1];
+        if (account.trim().equals(credentialsInReq.getName())
+            && region.trim().equals(regionInReq)) {
+          return true;
+        }
+      }
+    }
+
+    // This is a comma separated list of accounts to allow
+    String allowedAccounts =
+        dynamicConfigService.getConfig(
+            String.class, "aws.features.launch-templates.allowed-accounts", "");
+    for (String allowedAccount : allowedAccounts.split(",")) {
+      if (allowedAccount.trim().equals(credentialsInReq.getName())) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Helper function to parse and match an array of app:account:region1,...,app:account,region to
+   * the specified application, account and region Used to flag launch template feature and rollout
+   */
+  @VisibleForTesting
+  private boolean matchesAppAccountAndRegion(
+      String application, String accountName, String region, String[] applicationAccountRegions) {
+    if (applicationAccountRegions != null && applicationAccountRegions.length <= 0) {
+      return false;
+    }
+
+    for (String appAccountRegion : applicationAccountRegions) {
+      if (StringUtils.isNotBlank(appAccountRegion) && appAccountRegion.contains(":")) {
+        try {
+          String[] parts = appAccountRegion.split(":");
+          String app = parts[0];
+          String account = parts[1];
+          String regions = parts[2];
+          if (app.equals(application)
+              && account.equals(accountName)
+              && Arrays.asList(regions.split(",")).contains(region)) {
+            return true;
+          }
+        } catch (Exception e) {
+          log.error(
+              "Unable to verify if application is allowed in shouldSetLaunchTemplate: {}",
+              appAccountRegion);
+          return false;
+        }
+      }
+    }
+
+    return false;
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/LaunchTemplateRollOutConfigSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/LaunchTemplateRollOutConfigSpec.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.asg
+
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class LaunchTemplateRollOutConfigSpec extends Specification {
+  def dynamicConfigService = Mock(DynamicConfigService)
+  def launchTemplateRollOutConfig = new LaunchTemplateRollOutConfig(dynamicConfigService)
+
+  void 'isIpv6EnabledForEnv returns expected results'() {
+    when:
+    def res = launchTemplateRollOutConfig.isIpv6EnabledForEnv("foo")
+
+    then:
+    1 * dynamicConfigService.isEnabled('aws.features.launch-templates.ipv6.foo', false) >> enabled
+
+    and:
+    res == enabled
+
+    where:
+    enabled << [true, false]
+  }
+
+  @Unroll
+  void 'shouldUseLaunchTemplateForReq returns expected resultsrr'() {
+    given:
+    def excludedApp = "excludedApp"
+    def excludedAcc = "excludedAcc"
+    def allowAllApps = false
+
+    def allowedApp = "myasg"
+    def allowedAcc = "foo"
+    def allowedReg = "us-east-1"
+
+    when:
+    def res = launchTemplateRollOutConfig.shouldUseLaunchTemplateForReq(app, TestCredential.named(account), region)
+
+    then:
+    callCounts[0] * dynamicConfigService.isEnabled('aws.features.launch-templates', false) >> ltEnabled
+
+    callCounts[1] * dynamicConfigService.getConfig(String.class,"aws.features.launch-templates.excluded-applications", "") >> excludedApp
+    callCounts[2] * dynamicConfigService.getConfig(String.class, "aws.features.launch-templates.excluded-accounts", "") >> excludedAcc
+    callCounts[3] * dynamicConfigService.isEnabled('aws.features.launch-templates.all-applications', false) >> allowAllApps
+    callCounts[4] * dynamicConfigService.getConfig(String.class,"aws.features.launch-templates.allowed-applications", "") >> allowedApp + ":" + allowedAcc + ":" + allowedReg
+    callCounts[5] * dynamicConfigService.getConfig(String.class, "aws.features.launch-templates.allowed-accounts-regions", "") >> allowedAcc + ":" + allowedReg
+    callCounts[6] * dynamicConfigService.getConfig(String.class, "aws.features.launch-templates.allowed-accounts", "") >> allowedAcc
+    0 * dynamicConfigService._
+
+    and:
+    res == result
+
+    where:
+    ltEnabled |     app     |   region     |  account    |   callCounts    || result
+      false   |   "myasg"   |  "us-east-1" |   "foo"     | [1,0,0,0,0,0,0] || false
+      true    |"excludedApp"|  "us-east-1" |   "foo"     | [1,1,0,0,0,0,0] || false
+      true    |   "myasg"   |  "us-east-1" |"excludedAcc"| [1,1,1,0,0,0,0] || false
+      true    |   "myasg"   |  "us-east-1" |   "foo"     | [1,1,1,1,1,0,0] || true
+      true    |   "asg"     |  "us-east-1" |   "foo"     | [1,1,1,1,1,1,0] || true
+      true    |   "asg"     |  "us-west-1" |   "foo"     | [1,1,1,1,1,1,1] || true
+      true    |   "asg"     |  "us-east-1" |   "acc"     | [1,1,1,1,1,1,1] || false
+  }
+
+  @Unroll
+  void "should check if current app, account and region match launch template flag"() {
+    when:
+    def result = launchTemplateRollOutConfig.matchesAppAccountAndRegion(application, accountName, region, applicationAccountRegions)
+
+    then:
+    result == matches
+
+    where:
+    applicationAccountRegions           | application   | accountName | region      || matches
+    "foo:test:us-east-1"                | "foo"         | "test"      | "us-east-1" || true
+    "foo:test:us-east-1,us-west-2"      | "foo"         | "test"      | "eu-west-1" || false
+    "foo:prod:us-east-1"                | "foo"         | "test"      | "us-east-1" || false
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
@@ -46,6 +46,7 @@ import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing
 import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
 import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsResult
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup
+import com.netflix.spinnaker.clouddriver.aws.deploy.asg.LaunchTemplateRollOutConfig
 import com.netflix.spinnaker.clouddriver.aws.services.LaunchTemplateService
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
 import com.netflix.spinnaker.config.AwsConfiguration
@@ -71,7 +72,6 @@ import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactor
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.credentials.CredentialsRepository
-import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -134,7 +134,7 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
       getOne("baz") >> {TestCredential.named("baz")}
     }
     this.handler = new BasicAmazonDeployHandler(
-      rspf, credsRepo, amazonServerGroupProvider, defaults, scalingPolicyCopier, blockDeviceConfig, Mock(DynamicConfigService)
+      rspf, credsRepo, amazonServerGroupProvider, defaults, scalingPolicyCopier, blockDeviceConfig, Mock(LaunchTemplateRollOutConfig)
     ) {
       @Override
       LoadBalancerLookupHelper loadBalancerLookupHelper() {


### PR DESCRIPTION
## Summary
- refactor of launch template roll out config into its own class for reuse and readability

This refactor was done for upcoming PRs for https://github.com/spinnaker/spinnaker/issues/6483 as the dynamic config code path needed to be reused. 

## Testing
- tested with some upcoming changes with unit tests, integration tests and manual testing by creating server groups.  