### PR TITLE
fix(ecs): handle service names without sequences

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/names/EcsServerGroupNameResolver.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/names/EcsServerGroupNameResolver.java
@@ -71,7 +71,8 @@ public class EcsServerGroupNameResolver {
 
         if (isSameName(currentName.getApp(), moniker.getApp())
             && isSameName(currentName.getDetail(), moniker.getDetail())
-            && isSameName(currentName.getStack(), moniker.getStack())) {
+            && isSameName(currentName.getStack(), moniker.getStack())
+            && moniker.getSequence() != null) {
           takenSequences.add(moniker.getSequence());
         }
       }


### PR DESCRIPTION
The new naming logic for ECS services doesn't cope if the ECS cluster
only contains service names that have no sequence. This change fixes
that by ignoring services without a sequence for the purposes of
calculating the next free sequence number.

Reporting in Slack #ecs channel here https://spinnakerteam.slack.com/archives/C686H9WG7/p1626356252008700