### PR TITLE
fix(lambda): initialize evictions map with a mutable map

### DIFF
--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgent.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgent.java
@@ -310,7 +310,7 @@ public class LambdaCachingAgent implements CachingAgent, AccountAware, OnDemandA
 
     Map<String, Object> attributes = new HashMap<String, Object>();
     attributes.put("name", appName);
-    Map<String, Collection<String>> evictions = Collections.emptyMap();
+    Map<String, Collection<String>> evictions = new HashMap<>();
 
     Collection<String> existingFunctionRel = null;
 


### PR DESCRIPTION
This bug would cause the lambda caching agent ondemand cache to fail because it would initialize the evictions map with an immutable Map and then try to put a key/value pair to it, resulting in an error and failing the caching agent. This fix changes the map to an empty HashMap.
