### PR TITLE
chore(build): remove repository declarations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,6 @@ plugins {
 }
 
 allprojects {
-  repositories {
-    mavenCentral()
-    jcenter()
-  }
   apply plugin: 'io.spinnaker.project'
 }
 

--- a/gradle/spek.gradle
+++ b/gradle/spek.gradle
@@ -18,7 +18,6 @@ apply plugin: "org.junit.platform.gradle.plugin"
 
 repositories {
   mavenCentral()
-  jcenter()
   maven { url "https://dl.bintray.com/jetbrains/spek" }
 }
 


### PR DESCRIPTION
jcenter because it's no longer alive (https://status.bintray.com/) and mavenCentral
because the io.spinnaker.project plugin handles repository declaration.
