### PR TITLE
chore(build): don't use the cache in PR builds to see if gradle stops…

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,11 +13,5 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
-    - uses: actions/cache@v1
-      with:
-        path: ~/.gradle
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
     - name: Build
       run: ./gradlew build

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 fiatVersion=1.27.0
 korkVersion=7.110.0
 org.gradle.parallel=true
-spinnakerGradleVersion=8.12.0
+spinnakerGradleVersion=8.13.0
 targetJava11=true
 kotlinVersion=1.4.10
 


### PR DESCRIPTION
… looking in bintray
