### PR TITLE
fix(vulnerability): Remove fixed version of commons-io dependency to accommodate safer version from kork.

### DIFF
--- a/clouddriver-docker/clouddriver-docker.gradle
+++ b/clouddriver-docker/clouddriver-docker.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.retrofit:retrofit"
   implementation "org.apache.commons:commons-compress:1.20"
-  implementation "commons-io:commons-io:2.6"
+  implementation "commons-io:commons-io"
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
   implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
 


### PR DESCRIPTION
CVE-2021-29425