### PR TITLE
fix(provider/azure): Use ApplicationHealthLinux health provider type for Linux OS

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
@@ -46,7 +46,8 @@ class AzureUtilities {
   static final String AZURE_CUSTOM_SCRIPT_EXT_TYPE_WINDOWS="CustomScriptExtension"
   static final String AZURE_CUSTOM_SCRIPT_EXT_PUBLISHER_WINDOWS="Microsoft.Compute"
   static final String AZURE_CUSTOM_SCRIPT_EXT_VERSION_WINDOWS="1.8"
-  static final String AZURE_HEALTH_EXT_TYPE="ApplicationHealthWindows"
+  static final String AZURE_HEALTH_EXT_TYPE_WINDOWS="ApplicationHealthWindows"
+  static final String AZURE_HEALTH_EXT_TYPE_LINUX="ApplicationHealthLinux"
   static final String AZURE_HEALTH_EXT_VERSION="1.0"
   static final String AZURE_HEALTH_EXT_PUBLISHER="Microsoft.ManagedServices"
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
@@ -901,7 +901,7 @@ class AzureServerGroupResourceTemplate {
     HealthExtensionProperty(AzureServerGroupDescription description) {
       settings = new HealthExtensionSettings(description)
       publisher = AzureUtilities.AZURE_HEALTH_EXT_PUBLISHER
-      type = AzureUtilities.AZURE_HEALTH_EXT_TYPE
+      type = description.image?.ostype?.toLowerCase() == "linux" ? AzureUtilities.AZURE_HEALTH_EXT_TYPE_LINUX : AzureUtilities.AZURE_HEALTH_EXT_TYPE_WINDOWS
       typeHandlerVersion = AzureUtilities.AZURE_HEALTH_EXT_VERSION
     }
   }

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/AzureServerGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/AzureServerGroupResourceTemplateSpec.groovy
@@ -3368,7 +3368,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
             "name" : "azureMASM_health_ext",
             "properties" : {
               "publisher" : "Microsoft.ManagedServices",
-              "type" : "ApplicationHealthWindows",
+              "type" : "ApplicationHealthLinux",
               "typeHandlerVersion" : "1.0",
               "autoUpgradeMinorVersion" : true,
               "settings" : {


### PR DESCRIPTION
Regardless of OS type, the health extension for Azure is using ApplicationHealthWindows. This updates the health provider type to ApplicationHealthLinux in the case of Linux.

This is an enhancement/fix for Linux on https://github.com/spinnaker/clouddriver/pull/5256