### PR TITLE
refactor(aws): refactor accounts

### DIFF
--- a/clouddriver-aws/src/integration/java/com/netflix/spinnaker/clouddriver/aws/AwsTestConfiguration.java
+++ b/clouddriver-aws/src/integration/java/com/netflix/spinnaker/clouddriver/aws/AwsTestConfiguration.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
-import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig;
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 import com.netflix.spinnaker.credentials.CompositeCredentialsRepository;
 import com.netflix.spinnaker.credentials.definition.CredentialsParser;
@@ -61,8 +61,8 @@ public class AwsTestConfiguration {
         .thenAnswer(
             (Answer<NetflixAmazonCredentials>)
                 invocation -> {
-                  CredentialsConfig.Account account =
-                      invocation.getArgument(0, CredentialsConfig.Account.class);
+                  AccountsConfiguration.Account account =
+                      invocation.getArgument(0, AccountsConfiguration.Account.class);
                   return TestCredential.named(account.getName());
                 });
     return parser;

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoader.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoader.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.aws.security;
 import com.amazonaws.SDKGlobalConfiguration;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.util.CollectionUtils;
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration;
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.credentials.definition.BasicCredentialsLoader;
@@ -30,9 +31,10 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 public class AmazonBasicCredentialsLoader<
-        T extends CredentialsConfig.Account, U extends NetflixAmazonCredentials>
+        T extends AccountsConfiguration.Account, U extends NetflixAmazonCredentials>
     extends BasicCredentialsLoader<T, U> {
   protected final CredentialsConfig credentialsConfig;
+  protected final AccountsConfiguration accountsConfig;
   protected final DefaultAccountConfigurationProperties defaultAccountConfigurationProperties;
   protected String defaultEnvironment;
   protected String defaultAccountType;
@@ -42,9 +44,11 @@ public class AmazonBasicCredentialsLoader<
       CredentialsParser<T, U> parser,
       CredentialsRepository<U> credentialsRepository,
       CredentialsConfig credentialsConfig,
+      AccountsConfiguration accountsConfig,
       DefaultAccountConfigurationProperties defaultAccountConfigurationProperties) {
     super(definitionSource, parser, credentialsRepository);
     this.credentialsConfig = credentialsConfig;
+    this.accountsConfig = accountsConfig;
     this.defaultAccountConfigurationProperties = defaultAccountConfigurationProperties;
     this.defaultEnvironment =
         defaultAccountConfigurationProperties.getEnvironment() != null
@@ -67,11 +71,11 @@ public class AmazonBasicCredentialsLoader<
 
   @Override
   public void load() {
-    if (CollectionUtils.isNullOrEmpty(credentialsConfig.getAccounts())
+    if (CollectionUtils.isNullOrEmpty(accountsConfig.getAccounts())
         && (StringUtils.isEmpty(credentialsConfig.getDefaultAssumeRole()))) {
-      credentialsConfig.setAccounts(
+      accountsConfig.setAccounts(
           Collections.singletonList(
-              new CredentialsConfig.Account() {
+              new AccountsConfiguration.Account() {
                 {
                   setName(defaultAccountConfigurationProperties.getEnv());
                   setEnvironment(defaultEnvironment);

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/AccountsConfiguration.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/AccountsConfiguration.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.config;
+
+import static lombok.EqualsAndHashCode.Include;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Previously, accounts were stored in the {@link CredentialsConfig} class. If there are loads of
+ * accounts defined in a configuration properties file, then letting Spring boot read and bind them
+ * is a fairly time-consuming process. For 400 accounts, we observed that it took ~3-5m to load
+ * them, with the variance depending on the node configuration.
+ *
+ * <p>To speed this up, a feature-flagged change will be introduced in a follow up PR to let us do a
+ * manual binding of the properties directly, instead of letting spring boot do it. This results in
+ * the load times dropping to ~1-2s. But the main drawback of this manual binding is the fact that
+ * we have to explicitly define all the properties that we need to bind. For example, if accounts
+ * are defined in one configuration file and the other properties are defined in a different file,
+ * those other properties will not be loaded unless they are defined in the same configuration file.
+ * Also, for that to work, we have to explicitly bind these properties to the target class.
+ *
+ * <p>By moving accounts out of the {@link CredentialsConfig} class, we don't need to do any manual
+ * binding for those other properties. And we do the manual binding for accounts only, which makes
+ * it more maintainable.
+ */
+public class AccountsConfiguration {
+
+  @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+  public static class Account implements CredentialsDefinition {
+    @Include private String name;
+    @Include private String environment;
+    @Include private String accountType;
+    @Include private String accountId;
+    @Include private String defaultKeyPair;
+    @Include private Boolean enabled;
+    @Include private List<CredentialsConfig.Region> regions;
+    @Include private List<String> defaultSecurityGroups;
+    private List<String> requiredGroupMembership;
+    @Include private Permissions.Builder permissions;
+    @Include private String edda;
+    @Include private Boolean eddaEnabled;
+    @Include private Boolean lambdaEnabled;
+    @Include private String discovery;
+    @Include private Boolean discoveryEnabled;
+    @Include private String front50;
+    @Include private Boolean front50Enabled;
+    @Include private String bastionHost;
+    @Include private Boolean bastionEnabled;
+    @Include private String assumeRole;
+    @Include private String sessionName;
+    @Include private String externalId;
+    @Include private List<CredentialsConfig.LifecycleHook> lifecycleHooks;
+    @Include private boolean allowPrivateThirdPartyImages;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getEnvironment() {
+      return environment;
+    }
+
+    public void setEnvironment(String environment) {
+      this.environment = environment;
+    }
+
+    public String getAccountType() {
+      return accountType;
+    }
+
+    public void setAccountType(String accountType) {
+      this.accountType = accountType;
+    }
+
+    public String getAccountId() {
+      return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+      this.accountId = accountId;
+    }
+
+    public String getDefaultKeyPair() {
+      return defaultKeyPair;
+    }
+
+    public void setDefaultKeyPair(String defaultKeyPair) {
+      this.defaultKeyPair = defaultKeyPair;
+    }
+
+    public Boolean getEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public List<CredentialsConfig.Region> getRegions() {
+      return regions;
+    }
+
+    public void setRegions(List<CredentialsConfig.Region> regions) {
+      if (regions != null) {
+        regions.sort(Comparator.comparing(CredentialsConfig.Region::getName));
+      }
+      this.regions = regions;
+    }
+
+    public List<String> getDefaultSecurityGroups() {
+      return defaultSecurityGroups;
+    }
+
+    public void setDefaultSecurityGroups(List<String> defaultSecurityGroups) {
+      if (defaultSecurityGroups != null) {
+        Collections.sort(defaultSecurityGroups);
+      }
+      this.defaultSecurityGroups = defaultSecurityGroups;
+    }
+
+    public List<String> getRequiredGroupMembership() {
+      return requiredGroupMembership;
+    }
+
+    public void setRequiredGroupMembership(List<String> requiredGroupMembership) {
+      this.requiredGroupMembership = requiredGroupMembership;
+    }
+
+    public Permissions.Builder getPermissions() {
+      return permissions;
+    }
+
+    public void setPermissions(Permissions.Builder permissions) {
+      this.permissions = permissions;
+    }
+
+    public String getEdda() {
+      return edda;
+    }
+
+    public void setEdda(String edda) {
+      this.edda = edda;
+    }
+
+    public Boolean getEddaEnabled() {
+      return eddaEnabled;
+    }
+
+    public void setEddaEnabled(Boolean eddaEnabled) {
+      this.eddaEnabled = eddaEnabled;
+    }
+
+    public String getDiscovery() {
+      return discovery;
+    }
+
+    public void setDiscovery(String discovery) {
+      this.discovery = discovery;
+    }
+
+    public Boolean getDiscoveryEnabled() {
+      return discoveryEnabled;
+    }
+
+    public void setDiscoveryEnabled(Boolean discoveryEnabled) {
+      this.discoveryEnabled = discoveryEnabled;
+    }
+
+    public String getFront50() {
+      return front50;
+    }
+
+    public void setFront50(String front50) {
+      this.front50 = front50;
+    }
+
+    public Boolean getFront50Enabled() {
+      return front50Enabled;
+    }
+
+    public void setFront50Enabled(Boolean front50Enabled) {
+      this.front50Enabled = front50Enabled;
+    }
+
+    public String getBastionHost() {
+      return bastionHost;
+    }
+
+    public void setBastionHost(String bastionHost) {
+      this.bastionHost = bastionHost;
+    }
+
+    public Boolean getBastionEnabled() {
+      return bastionEnabled;
+    }
+
+    public void setBastionEnabled(Boolean bastionEnabled) {
+      this.bastionEnabled = bastionEnabled;
+    }
+
+    public String getAssumeRole() {
+      return assumeRole;
+    }
+
+    public void setAssumeRole(String assumeRole) {
+      this.assumeRole = assumeRole;
+    }
+
+    public String getSessionName() {
+      return sessionName;
+    }
+
+    public void setSessionName(String sessionName) {
+      this.sessionName = sessionName;
+    }
+
+    public String getExternalId() {
+      return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+      this.externalId = externalId;
+    }
+
+    public List<CredentialsConfig.LifecycleHook> getLifecycleHooks() {
+      return lifecycleHooks;
+    }
+
+    public void setLifecycleHooks(List<CredentialsConfig.LifecycleHook> lifecycleHooks) {
+      this.lifecycleHooks = lifecycleHooks;
+    }
+
+    public Boolean getAllowPrivateThirdPartyImages() {
+      return allowPrivateThirdPartyImages;
+    }
+
+    public void setAllowPrivateThirdPartyImages(Boolean allowPrivateThirdPartyImages) {
+      this.allowPrivateThirdPartyImages = allowPrivateThirdPartyImages;
+    }
+
+    public Boolean getLambdaEnabled() {
+      return lambdaEnabled;
+    }
+
+    public void setLambdaEnabled(Boolean lambdaEnabled) {
+      this.lambdaEnabled = lambdaEnabled;
+    }
+  }
+
+  private List<Account> accounts;
+
+  public List<Account> getAccounts() {
+    return accounts;
+  }
+
+  public void setAccounts(List<Account> accounts) {
+    this.accounts = accounts;
+  }
+}

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsConfig.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsConfig.java
@@ -18,10 +18,6 @@ package com.netflix.spinnaker.clouddriver.aws.security.config;
 
 import static lombok.EqualsAndHashCode.Include;
 
-import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
-import com.netflix.spinnaker.fiat.model.resources.Permissions;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 
@@ -138,232 +134,6 @@ public class CredentialsConfig {
     }
   }
 
-  @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-  public static class Account implements CredentialsDefinition {
-    @Include private String name;
-    @Include private String environment;
-    @Include private String accountType;
-    @Include private String accountId;
-    @Include private String defaultKeyPair;
-    @Include private Boolean enabled;
-    @Include private List<Region> regions;
-    @Include private List<String> defaultSecurityGroups;
-    private List<String> requiredGroupMembership;
-    @Include private Permissions.Builder permissions;
-    @Include private String edda;
-    @Include private Boolean eddaEnabled;
-    @Include private Boolean lambdaEnabled;
-    @Include private String discovery;
-    @Include private Boolean discoveryEnabled;
-    @Include private String front50;
-    @Include private Boolean front50Enabled;
-    @Include private String bastionHost;
-    @Include private Boolean bastionEnabled;
-    @Include private String assumeRole;
-    @Include private String sessionName;
-    @Include private String externalId;
-    @Include private List<LifecycleHook> lifecycleHooks;
-    @Include private boolean allowPrivateThirdPartyImages;
-
-    public String getName() {
-      return name;
-    }
-
-    public void setName(String name) {
-      this.name = name;
-    }
-
-    public String getEnvironment() {
-      return environment;
-    }
-
-    public void setEnvironment(String environment) {
-      this.environment = environment;
-    }
-
-    public String getAccountType() {
-      return accountType;
-    }
-
-    public void setAccountType(String accountType) {
-      this.accountType = accountType;
-    }
-
-    public String getAccountId() {
-      return accountId;
-    }
-
-    public void setAccountId(String accountId) {
-      this.accountId = accountId;
-    }
-
-    public String getDefaultKeyPair() {
-      return defaultKeyPair;
-    }
-
-    public void setDefaultKeyPair(String defaultKeyPair) {
-      this.defaultKeyPair = defaultKeyPair;
-    }
-
-    public Boolean getEnabled() {
-      return enabled;
-    }
-
-    public void setEnabled(Boolean enabled) {
-      this.enabled = enabled;
-    }
-
-    public List<Region> getRegions() {
-      return regions;
-    }
-
-    public void setRegions(List<Region> regions) {
-      if (regions != null) {
-        regions.sort(Comparator.comparing(Region::getName));
-      }
-      this.regions = regions;
-    }
-
-    public List<String> getDefaultSecurityGroups() {
-      return defaultSecurityGroups;
-    }
-
-    public void setDefaultSecurityGroups(List<String> defaultSecurityGroups) {
-      if (defaultSecurityGroups != null) {
-        Collections.sort(defaultSecurityGroups);
-      }
-      this.defaultSecurityGroups = defaultSecurityGroups;
-    }
-
-    public List<String> getRequiredGroupMembership() {
-      return requiredGroupMembership;
-    }
-
-    public void setRequiredGroupMembership(List<String> requiredGroupMembership) {
-      this.requiredGroupMembership = requiredGroupMembership;
-    }
-
-    public Permissions.Builder getPermissions() {
-      return permissions;
-    }
-
-    public void setPermissions(Permissions.Builder permissions) {
-      this.permissions = permissions;
-    }
-
-    public String getEdda() {
-      return edda;
-    }
-
-    public void setEdda(String edda) {
-      this.edda = edda;
-    }
-
-    public Boolean getEddaEnabled() {
-      return eddaEnabled;
-    }
-
-    public void setEddaEnabled(Boolean eddaEnabled) {
-      this.eddaEnabled = eddaEnabled;
-    }
-
-    public String getDiscovery() {
-      return discovery;
-    }
-
-    public void setDiscovery(String discovery) {
-      this.discovery = discovery;
-    }
-
-    public Boolean getDiscoveryEnabled() {
-      return discoveryEnabled;
-    }
-
-    public void setDiscoveryEnabled(Boolean discoveryEnabled) {
-      this.discoveryEnabled = discoveryEnabled;
-    }
-
-    public String getFront50() {
-      return front50;
-    }
-
-    public void setFront50(String front50) {
-      this.front50 = front50;
-    }
-
-    public Boolean getFront50Enabled() {
-      return front50Enabled;
-    }
-
-    public void setFront50Enabled(Boolean front50Enabled) {
-      this.front50Enabled = front50Enabled;
-    }
-
-    public String getBastionHost() {
-      return bastionHost;
-    }
-
-    public void setBastionHost(String bastionHost) {
-      this.bastionHost = bastionHost;
-    }
-
-    public Boolean getBastionEnabled() {
-      return bastionEnabled;
-    }
-
-    public void setBastionEnabled(Boolean bastionEnabled) {
-      this.bastionEnabled = bastionEnabled;
-    }
-
-    public String getAssumeRole() {
-      return assumeRole;
-    }
-
-    public void setAssumeRole(String assumeRole) {
-      this.assumeRole = assumeRole;
-    }
-
-    public String getSessionName() {
-      return sessionName;
-    }
-
-    public void setSessionName(String sessionName) {
-      this.sessionName = sessionName;
-    }
-
-    public String getExternalId() {
-      return externalId;
-    }
-
-    public void setExternalId(String externalId) {
-      this.externalId = externalId;
-    }
-
-    public List<LifecycleHook> getLifecycleHooks() {
-      return lifecycleHooks;
-    }
-
-    public void setLifecycleHooks(List<LifecycleHook> lifecycleHooks) {
-      this.lifecycleHooks = lifecycleHooks;
-    }
-
-    public Boolean getAllowPrivateThirdPartyImages() {
-      return allowPrivateThirdPartyImages;
-    }
-
-    public void setAllowPrivateThirdPartyImages(Boolean allowPrivateThirdPartyImages) {
-      this.allowPrivateThirdPartyImages = allowPrivateThirdPartyImages;
-    }
-
-    public Boolean getLambdaEnabled() {
-      return lambdaEnabled;
-    }
-
-    public void setLambdaEnabled(Boolean lambdaEnabled) {
-      this.lambdaEnabled = lambdaEnabled;
-    }
-  }
-
   private String accessKeyId;
   private String secretAccessKey;
   private String defaultKeyPairTemplate;
@@ -378,8 +148,6 @@ public class CredentialsConfig {
   private String defaultSessionName;
   private String defaultLifecycleHookRoleARNTemplate;
   private String defaultLifecycleHookNotificationTargetARNTemplate;
-
-  private List<Account> accounts;
 
   public String getDefaultKeyPairTemplate() {
     return defaultKeyPairTemplate;
@@ -451,14 +219,6 @@ public class CredentialsConfig {
 
   public void setDefaultSessionName(String defaultSessionName) {
     this.defaultSessionName = defaultSessionName;
-  }
-
-  public List<Account> getAccounts() {
-    return accounts;
-  }
-
-  public void setAccounts(List<Account> accounts) {
-    this.accounts = accounts;
   }
 
   public List<LifecycleHook> getDefaultLifecycleHooks() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoaderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoaderSpec.groovy
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.clouddriver.aws.security
 
 import com.amazonaws.SDKGlobalConfiguration
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration.Account
 import com.netflix.spinnaker.credentials.CredentialsRepository
 import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource
 import spock.lang.Shared
@@ -41,16 +43,19 @@ class AmazonBasicCredentialsLoaderSpec extends Specification{
     getCredentialsDefinitions() >> []
   }
 
+  @Shared
+  def accountsConfig = new AccountsConfiguration()
+
   def 'should set defaults'() {
-    def loader = new AmazonBasicCredentialsLoader<CredentialsConfig.Account, NetflixAmazonCredentials>(
-      definitionSource, null, credentialsRepository, credentialsConfig, defaultAccountConfigurationProperties
+    def loader = new AmazonBasicCredentialsLoader<Account, NetflixAmazonCredentials>(
+      definitionSource, null, credentialsRepository, credentialsConfig, accountsConfig, defaultAccountConfigurationProperties
     )
 
     when:
     loader.load()
 
     then:
-    credentialsConfig.getAccounts().size() == 1
+    accountsConfig.getAccounts().size() == 1
     credentialsConfig.getDefaultRegions().size() == 4
     System.getProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY) == "accessKey"
     System.getProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY) == "secret"

--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/EcsTestConfiguration.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/EcsTestConfiguration.java
@@ -20,7 +20,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
-import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig;
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration;
 import com.netflix.spinnaker.clouddriver.ecs.security.NetflixAssumeRoleEcsCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.security.NetflixECSCredentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
@@ -75,8 +75,8 @@ public class EcsTestConfiguration {
         .thenAnswer(
             (Answer<NetflixAmazonCredentials>)
                 invocation -> {
-                  CredentialsConfig.Account account =
-                      invocation.getArgument(0, CredentialsConfig.Account.class);
+                  AccountsConfiguration.Account account =
+                      invocation.getArgument(0, AccountsConfiguration.Account.class);
                   return TestCredential.assumeRoleNamed(account.getName());
                 });
     return parser;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsAccountBuilder.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsAccountBuilder.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.ecs.security;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAssumeRoleAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration.Account;
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
@@ -27,9 +28,9 @@ import java.util.List;
 
 public class EcsAccountBuilder {
 
-  public static CredentialsConfig.Account build(
+  public static Account build(
       NetflixAmazonCredentials netflixAmazonCredentials, String accountName, String accountType) {
-    CredentialsConfig.Account account = new CredentialsConfig.Account();
+    Account account = new Account();
     account.setName(accountName);
     account.setAccountType(accountType);
     account.setAccountId(netflixAmazonCredentials.getAccountId());

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsCredentialsInitializer.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsCredentialsInitializer.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.security;
 
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
-import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig;
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration;
 import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
@@ -63,7 +63,7 @@ public class EcsCredentialsInitializer {
   CredentialsParser<ECSCredentialsConfig.Account, NetflixECSCredentials> ecsCredentialsParser(
       ECSCredentialsConfig ecsCredentialsConfig,
       CompositeCredentialsRepository<AccountCredentials> compositeCredentialsRepository,
-      CredentialsParser<CredentialsConfig.Account, NetflixAmazonCredentials>
+      CredentialsParser<AccountsConfiguration.Account, NetflixAmazonCredentials>
           amazonCredentialsParser,
       NamerRegistry namerRegistry) {
     return new EcsCredentialsParser<>(

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsCredentialsParser.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsCredentialsParser.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.ecs.security;
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAssumeRoleAmazonCredentials;
-import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig;
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration;
 import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
 import com.netflix.spinnaker.clouddriver.ecs.names.EcsResource;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
@@ -41,7 +41,7 @@ public class EcsCredentialsParser<T extends NetflixECSCredentials>
   private final CompositeCredentialsRepository<AccountCredentials> compositeCredentialsRepository;
 
   @Qualifier("amazonCredentialsParser")
-  private final CredentialsParser<CredentialsConfig.Account, NetflixAmazonCredentials>
+  private final CredentialsParser<AccountsConfiguration.Account, NetflixAmazonCredentials>
       amazonCredentialsParser;
 
   private final NamerRegistry namerRegistry;
@@ -53,7 +53,7 @@ public class EcsCredentialsParser<T extends NetflixECSCredentials>
             compositeCredentialsRepository.getCredentials(
                 accountDefinition.getAwsAccount(), AmazonCloudProvider.ID);
 
-    CredentialsConfig.Account account =
+    AccountsConfiguration.Account account =
         EcsAccountBuilder.build(
             netflixAmazonCredentials, accountDefinition.getName(), EcsProvider.NAME);
     NetflixECSCredentials netflixECSCredentials =

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsAccountBuilderTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsAccountBuilderTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
-import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig;
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration.Account;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import org.junit.Test;
 
@@ -38,8 +38,7 @@ public class EcsAccountBuilderTest {
     when(netflixAmazonCredentials.getAccountId()).thenReturn("id-1234567890");
 
     // When
-    CredentialsConfig.Account account =
-        EcsAccountBuilder.build(netflixAmazonCredentials, accountName, accountType);
+    Account account = EcsAccountBuilder.build(netflixAmazonCredentials, accountName, accountType);
 
     // Then
     assertTrue(


### PR DESCRIPTION
* move accounts out of the CredentialsConfig class so that it is easier to custom bind them when reading accounts from a local config file.
This is for the following issue: https://github.com/spinnaker/spinnaker/issues/6492

