### PR TITLE
fix(build): don't bump the version of clouddriver in front50

### DIFF
--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -12,6 +12,6 @@ jobs:
       with:
         ref: ${{ github.event.client_payload.ref }}
         key: clouddriverVersion
-        repositories: front50,halyard
+        repositories: halyard
       env:
         GITHUB_OAUTH: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}


### PR DESCRIPTION
As of
https://github.com/spinnaker/front50/commit/57c9922924edc4f6a737c92e0d59d23f5e3174d6#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19
from August 6, 2020, front50 no longer depends on clouddriver, so don't attempt to bump
clouddriver's version there.

See https://github.com/spinnaker/clouddriver/runs/3334358289?check_suite_focus=true#step:3:11 for an example of the failure message:
```
[main] INFO io.spinnaker.bumpdeps.BumpDeps - Cloning https://github.com/spinnaker/front50 to /tmp/bumpdeps-git-9683647897421732365/front50
[main] ERROR io.spinnaker.bumpdeps.BumpDeps - Exception updating repository front50
java.lang.IllegalArgumentException: Couldn't locate key clouddriverVersion in front50's gradle.properties file
	at io.spinnaker.bumpdeps.BumpDeps.updatePropertiesFile(Main.kt:201)
	at io.spinnaker.bumpdeps.BumpDeps.createModifiedBranch(Main.kt:179)
	at io.spinnaker.bumpdeps.BumpDeps.run(Main.kt:110)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:168)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:16)
	at com.github.ajalt.clikt.core.CliktCommand.parse(CliktCommand.kt:258)
	at com.github.ajalt.clikt.core.CliktCommand.parse$default(CliktCommand.kt:255)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:273)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:298)
	at io.spinnaker.bumpdeps.MainKt.main(Main.kt:266)
```