### PR TITLE
fix(provider/azure): Use health extension in instance status

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
@@ -925,12 +925,17 @@ class AzureServerGroupResourceTemplate {
 
   static class HealthExtensionSettings implements IExtensionSettings {
     String protocol
-    String port
+    int port
     String requestPath
 
     HealthExtensionSettings(AzureServerGroupDescription description) {
       protocol = description.healthSettings.protocol
-      port = description.healthSettings.port
+      try {
+        port = Integer.parseInt(description.healthSettings.port)
+      } catch (NumberFormatException ignored) {
+        port = 0
+        throw new IllegalArgumentException("healthSettings.port \"$description.healthSettings.port\" is not a valid integer")
+      }
       requestPath = description.healthSettings.requestPath
     }
   }

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/AzureServerGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/AzureServerGroupResourceTemplateSpec.groovy
@@ -88,7 +88,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
   }
 
   def 'should generate correct ServerGroup resource template health extension is blank'() {
-    description = createHealthDescription("", "", "")
+    description = createHealthDescription("", 0, "")
     String template = AzureServerGroupResourceTemplate.getTemplate(description)
 
     expect:
@@ -212,7 +212,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     template.replaceAll('"createdTime" : "\\d+"', '"createdTime" : "1234567890"').replace('\r', '') == expectedFullTemplateWithUserAssignedIdentities
   }
 
-  private static AzureServerGroupDescription.AzureExtensionHealthSettings createHealthExtension(String protocol = "https", String port = "7000", String requestPath = "localhost") {
+  private static AzureServerGroupDescription.AzureExtensionHealthSettings createHealthExtension(String protocol = "https", int port = 7000, String requestPath = "localhost") {
     AzureServerGroupDescription.AzureExtensionHealthSettings extension = new AzureServerGroupDescription.AzureExtensionHealthSettings()
     extension.protocol = protocol
     extension.port = port
@@ -284,7 +284,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     description
   }
 
-  private static AzureServerGroupDescription createHealthDescription(String protocol = "https", String port = "7000", String requestPath = "localhost") {
+  private static AzureServerGroupDescription createHealthDescription(String protocol = "https", int port = 7000, String requestPath = "localhost") {
     AzureServerGroupDescription description = createDescription()
     description.healthSettings = createHealthExtension(protocol, port, requestPath)
 
@@ -2814,7 +2814,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
               "autoUpgradeMinorVersion" : true,
               "settings" : {
                 "protocol" : "https",
-                "port" : "7000",
+                "port" : 7000,
                 "requestPath" : "localhost"
               }
             }
@@ -3373,7 +3373,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
               "autoUpgradeMinorVersion" : true,
               "settings" : {
                 "protocol" : "https",
-                "port" : "7000",
+                "port" : 7000,
                 "requestPath" : "localhost"
               }
             }
@@ -3564,7 +3564,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
               "autoUpgradeMinorVersion" : true,
               "settings" : {
                 "protocol" : "https",
-                "port" : "7000",
+                "port" : 7000,
                 "requestPath" : "localhost"
               }
             }


### PR DESCRIPTION
This fix fixes two things related to Azure instance health:

1. The health extension couldn't be applied to any instances because the health
   extension required int port (it was a String everywhere)
     - fixed by changing type to int
2. The health extension wasn't being used by the cluster view at all.
     - fixed by adding a health extension check after the default
       "is running" check

This has been tested in two ways:

1. Unit tests
2. Deployment of scale sets to my Azure account
