### PR TITLE
fix(provider/azure): Allow empty server groups on load balancers

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProvider.groovy
@@ -211,7 +211,7 @@ class AzureLoadBalancerProvider implements LoadBalancerProvider<AzureLoadBalance
 
       loadBalancer.serverGroups.add(new LoadBalancerServerGroup (
         name: serverGroup,
-        isDisabled: asg.isDisabled(),
+        isDisabled: asg?.isDisabled(),
         detachedInstances: [],
         instances: [],
         cloudProvider: AzureCloudProvider.ID


### PR DESCRIPTION
If a server group has been scaled down or deleted, the load balancer
should still be visible in deck, but because of an NPE the whole
page fails to load.

This has been tested against an Azure account.
