### PR TITLE
feat(aws): enable custom property binding capability for aws accounts

### DIFF
--- a/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver-aws/clouddriver-aws.gradle
@@ -18,6 +18,7 @@ configurations {
 dependencies {
   implementation project(":cats:cats-core")
   implementation project(":clouddriver-api")
+  implementation project(":clouddriver-configserver")
   implementation project(":clouddriver-core")
   implementation project(":clouddriver-eureka")
   implementation project(":clouddriver-security")
@@ -34,9 +35,11 @@ dependencies {
   implementation "com.netflix.frigga:frigga"
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
   implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
+  implementation "io.spinnaker.kork:kork-cloud-config-server"
   implementation "io.spinnaker.kork:kork-core"
   implementation "io.spinnaker.kork:kork-aws"
   implementation "io.spinnaker.kork:kork-exceptions"
+  implementation "io.spinnaker.kork:kork-secrets"
   implementation "io.spinnaker.kork:kork-security"
   implementation "io.spinnaker.kork:kork-credentials"
   implementation "io.spinnaker.kork:kork-moniker"
@@ -55,6 +58,7 @@ dependencies {
   implementation 'com.aestasit.infrastructure.sshoogr:sshoogr:0.9.25'
   implementation 'com.jcraft:jsch.agentproxy.connector-factory:0.0.9'
   implementation 'com.jcraft:jsch.agentproxy.jsch:0.0.9'
+  implementation "com.github.wnameless.json:json-flattener:0.11.1"
 
   testImplementation "io.spinnaker.kork:kork-exceptions"
   testImplementation "cglib:cglib-nodep"

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCustomBinderConfiguration.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCustomBinderConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security;
+
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration;
+import com.netflix.spinnaker.kork.configserver.CloudConfigResourceService;
+import com.netflix.spinnaker.kork.secrets.SecretManager;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty({"aws.enabled", "aws.custom-property-binding-enabled"})
+public class AmazonCustomBinderConfiguration {
+  @Bean
+  CustomAccountsConfigurationProvider customAccountsConfigurationProvider(
+      ConfigurableApplicationContext context,
+      CloudConfigResourceService configResourceService,
+      SecretManager secretManager) {
+    return new CustomAccountsConfigurationProvider(context, configResourceService, secretManager);
+  }
+
+  @Bean
+  AccountsConfiguration accountsConfiguration(
+      CustomAccountsConfigurationProvider bootstrapCredentialsConfigurationProvider) {
+    return bootstrapCredentialsConfigurationProvider.getConfigurationProperties();
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/CustomAccountsConfigurationProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/CustomAccountsConfigurationProvider.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security;
+
+import com.github.wnameless.json.unflattener.JsonUnflattener;
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration;
+import com.netflix.spinnaker.clouddriver.config.AbstractBootstrapCredentialsConfigurationProvider;
+import com.netflix.spinnaker.kork.configserver.CloudConfigResourceService;
+import com.netflix.spinnaker.kork.secrets.SecretManager;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.bind.BindResult;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * If a configuration properties file has a large number of aws accounts, as-is SpringBoot
+ * implementation of properties binding is inefficient. Hence, a custom logic for binding just the
+ * {@link AccountsConfiguration} is written but it still uses SpringBoot's Binder class. {@link
+ * CustomAccountsConfigurationProvider} class fetches the flattened aws account properties from
+ * Spring Cloud Config's BootstrapPropertySource and creates an {@link AccountsConfiguration}
+ * object.
+ */
+@Slf4j
+public class CustomAccountsConfigurationProvider
+    extends AbstractBootstrapCredentialsConfigurationProvider {
+  private final String FIRST_ACCOUNT_NAME_KEY = "aws.accounts[0].name";
+
+  public CustomAccountsConfigurationProvider(
+      ConfigurableApplicationContext applicationContext,
+      CloudConfigResourceService configResourceService,
+      SecretManager secretManager) {
+    super(applicationContext, configResourceService, secretManager);
+  }
+
+  public AccountsConfiguration getConfigurationProperties() {
+    return getAccounts(getPropertiesMap(FIRST_ACCOUNT_NAME_KEY));
+  }
+
+  @SuppressWarnings("unchecked")
+  private AccountsConfiguration getAccounts(Map<String, Object> credentialsPropertiesMap) {
+    log.info("Started loading aws accounts from the configuration file");
+    AccountsConfiguration accountConfig = new AccountsConfiguration();
+    BindResult<?> result;
+
+    // unflatten
+    Map<String, Object> propertiesMap =
+        (Map<String, Object>) JsonUnflattener.unflattenAsMap(credentialsPropertiesMap).get("aws");
+
+    List<AccountsConfiguration.Account> accounts = new ArrayList<>();
+
+    // loop through each account and bind
+    for (Map<String, Object> unflattendAcc :
+        ((List<Map<String, Object>>) propertiesMap.get("accounts"))) {
+      result = bind(getFlatMap(unflattendAcc), AccountsConfiguration.Account.class);
+      accounts.add((AccountsConfiguration.Account) result.get());
+    }
+    accountConfig.setAccounts(accounts);
+    log.info("Finished loading aws accounts");
+    return accountConfig;
+  }
+}


### PR DESCRIPTION
This PR allows custom property binding support for loading aws accounts from a config file. This is turned off by default, which means that the accounts will be loaded via the default way, which is relying on spring boot to do the binding. 

This is enabled by setting `aws.custom-property-binding-enabled: true`.

This is for the following issue: https://github.com/spinnaker/spinnaker/issues/6492