### PR TITLE
fix(gce) : modified internal load balancer services to fix duplicatio…

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -318,7 +318,10 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
     List<BackendService> regionBackendServicesToUpdate = []
     if (internalLoadBalancers || internalHttpLoadBalancers) {
       List<String> existingRegionalLbs = instanceMetadata[REGIONAL_LOAD_BALANCER_NAMES]?.split(",") ?: []
-      def ilbServices = internalLoadBalancers.collect { it.backendService.name } + (instanceMetadata[REGION_BACKEND_SERVICE_NAMES]?.split(",") as List) ?: []
+      List<String> regionBackendServices = instanceMetadata[REGION_BACKEND_SERVICE_NAMES]?.split(",") as List ?: []
+      def ilbServices = internalLoadBalancers.collect { it.backendService.name }
+      ilbServices.addAll(regionBackendServices)
+      ilbServices.unique{ a, b -> a <=> b }   //to remove duplicate services
       def ilbNames = internalLoadBalancers.collect { it.name } + internalHttpLoadBalancers.collect { it.name }
 
       ilbNames.each { String ilbName ->


### PR DESCRIPTION
This code change is to address the GCE issues [#6136](https://github.com/spinnaker/spinnaker/issues/6136) [#6253](https://github.com/spinnaker/spinnaker/issues/6253)

With modification of of definition of 'ilbServices' both issues are resolved by removing the null values and duplication,
this way deploy stage will be complete in case of both missing 'backend-service' as parameter and when by manually adding valid 'region-backend-service' as parameter