### PR TITLE
feat(artifacts): support tokenFile for GitRepoArtifactCredentials and reload auth headers

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/BaseHttpArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/BaseHttpArtifactCredentials.java
@@ -24,13 +24,12 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public abstract class BaseHttpArtifactCredentials<T extends ArtifactAccount> {
-  @JsonIgnore private final Headers headers;
-
   @JsonIgnore private final OkHttpClient okHttpClient;
+  @JsonIgnore private final T account;
 
   protected BaseHttpArtifactCredentials(OkHttpClient okHttpClient, T account) {
     this.okHttpClient = okHttpClient;
-    this.headers = getHeaders(account);
+    this.account = account;
   }
 
   private Optional<String> getAuthHeader(ArtifactAccount account) {
@@ -73,8 +72,7 @@ public abstract class BaseHttpArtifactCredentials<T extends ArtifactAccount> {
   }
 
   protected ResponseBody fetchUrl(HttpUrl url) throws IOException {
-    Request request = new Request.Builder().headers(headers).url(url).build();
-
+    Request request = new Request.Builder().headers(getHeaders(account)).url(url).build();
     Response downloadResponse = okHttpClient.newCall(request).execute();
     if (!downloadResponse.isSuccessful()) {
       downloadResponse.body().close();

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitJobExecutor.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitJobExecutor.java
@@ -68,7 +68,7 @@ public class GitJobExecutor {
     if (!StringUtils.isEmpty(account.getUsername())
         && !StringUtils.isEmpty(account.getPassword())) {
       authType = AuthType.USER_PASS;
-    } else if (!StringUtils.isEmpty(account.getToken())) {
+    } else if (!StringUtils.isEmpty(account.getTokenAsString())) {
       authType = AuthType.TOKEN;
     } else if (!StringUtils.isEmpty(account.getSshPrivateKeyFilePath())) {
       authType = AuthType.SSH;
@@ -346,7 +346,15 @@ public class GitJobExecutor {
         result.put("GIT_PASS", encodeURIComponent(account.getPassword()));
         break;
       case TOKEN:
-        result.put("GIT_TOKEN", encodeURIComponent(account.getToken()));
+        result.put(
+            "GIT_TOKEN",
+            encodeURIComponent(
+                account
+                    .getTokenAsString()
+                    .orElseThrow(
+                        () ->
+                            new IllegalArgumentException(
+                                "Token or TokenFile must be present if using token auth."))));
         break;
       case SSH:
         result.put("GIT_SSH_COMMAND", buildSshCommand());

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitJobExecutor.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitJobExecutor.java
@@ -68,7 +68,8 @@ public class GitJobExecutor {
     if (!StringUtils.isEmpty(account.getUsername())
         && !StringUtils.isEmpty(account.getPassword())) {
       authType = AuthType.USER_PASS;
-    } else if (!StringUtils.isEmpty(account.getTokenAsString())) {
+    } else if (account.getTokenAsString().isPresent()
+        && !StringUtils.isEmpty(account.getTokenAsString())) {
       authType = AuthType.TOKEN;
     } else if (!StringUtils.isEmpty(account.getSshPrivateKeyFilePath())) {
       authType = AuthType.SSH;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactAccount.java
@@ -18,7 +18,9 @@ package com.netflix.spinnaker.clouddriver.artifacts.gitRepo;
 
 import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
+import com.netflix.spinnaker.clouddriver.artifacts.config.TokenAuth;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.Optional;
 import javax.annotation.ParametersAreNullableByDefault;
 import lombok.Builder;
 import lombok.Value;
@@ -26,11 +28,12 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-public class GitRepoArtifactAccount implements ArtifactAccount {
+public class GitRepoArtifactAccount implements ArtifactAccount, TokenAuth {
   private final String name;
   private final String username;
   private final String password;
-  private final String token;
+  private final Optional<String> token;
+  private final Optional<String> tokenFile;
   private final String sshPrivateKeyFilePath;
   private final String sshPrivateKeyPassphrase;
   private final String sshPrivateKeyPassphraseCmd;
@@ -45,6 +48,7 @@ public class GitRepoArtifactAccount implements ArtifactAccount {
       String username,
       String password,
       String token,
+      String tokenFile,
       String sshPrivateKeyFilePath,
       String sshPrivateKeyPassphrase,
       String sshPrivateKeyPassphraseCmd,
@@ -53,7 +57,8 @@ public class GitRepoArtifactAccount implements ArtifactAccount {
     this.name = Strings.nullToEmpty(name);
     this.username = Strings.nullToEmpty(username);
     this.password = Strings.nullToEmpty(password);
-    this.token = Strings.nullToEmpty(token);
+    this.token = Optional.ofNullable(Strings.emptyToNull(token));
+    this.tokenFile = Optional.ofNullable(Strings.emptyToNull(tokenFile));
     this.sshPrivateKeyFilePath = Strings.nullToEmpty(sshPrivateKeyFilePath);
     this.sshPrivateKeyPassphrase = Strings.nullToEmpty(sshPrivateKeyPassphrase);
     this.sshPrivateKeyPassphraseCmd = Strings.nullToEmpty(sshPrivateKeyPassphraseCmd);

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactAccountTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactAccountTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.gitRepo;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.TempDirectory;
+
+@ExtendWith({TempDirectory.class})
+public class GitRepoArtifactAccountTest {
+
+  @Test
+  void shouldGetTokenFromFile(@TempDirectory.TempDir Path tempDir) throws IOException {
+    Path authFile = tempDir.resolve("auth-file");
+    Files.write(authFile, "zzz".getBytes());
+
+    GitRepoArtifactAccount account =
+        GitRepoArtifactAccount.builder()
+            .name("gitRepo-account")
+            .tokenFile(authFile.toAbsolutePath().toString())
+            .build();
+
+    assertThat(account.getTokenAsString().get()).isEqualTo("zzz");
+  }
+
+  @Test
+  void shouldGetTokenFromProperty() {
+    GitRepoArtifactAccount account =
+        GitRepoArtifactAccount.builder().name("gitRepo-account").token("tokentoken").build();
+
+    assertThat(account.getTokenAsString().get()).isEqualTo("tokentoken");
+  }
+}

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/github/GithubArtifactCredentialsTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/github/GithubArtifactCredentialsTest.java
@@ -69,6 +69,26 @@ class GithubArtifactCredentialsTest {
   }
 
   @Test
+  void downloadWithTokenFromFileWithReloadHeaders(
+      @TempDirectory.TempDir Path tempDir, @WiremockResolver.Wiremock WireMockServer server)
+      throws IOException {
+    Path authFile = tempDir.resolve("auth-file");
+    Files.write(authFile, "zzz".getBytes());
+
+    GitHubArtifactAccount account =
+        GitHubArtifactAccount.builder()
+            .name("my-github-account")
+            .tokenFile(authFile.toAbsolutePath().toString())
+            .build();
+
+    runTestCase(server, account, m -> m.withHeader("Authorization", equalTo("token zzz")));
+
+    Files.write(authFile, "aaa".getBytes());
+
+    runTestCase(server, account, m -> m.withHeader("Authorization", equalTo("token aaa")));
+  }
+
+  @Test
   void downloadWithBasicAuth(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
     GitHubArtifactAccount account =
         GitHubArtifactAccount.builder()

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/service/config/LambdaServiceConfig.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/service/config/LambdaServiceConfig.java
@@ -25,8 +25,8 @@ import org.springframework.stereotype.Component;
 @Data
 public class LambdaServiceConfig {
 
-  private Retry retry;
-  private Concurrency concurrency;
+  private Retry retry = new Retry();
+  private Concurrency concurrency = new Concurrency();
 
   @Data
   public static class Retry {


### PR DESCRIPTION
Added support for tokenAuth with gitRepoArtifactCredentials and made BasicHttpArtifactCredentials reload auth headers for every call instead of during object instantiation. 