### PR TITLE
feat(provider/azure): Use v2-sku for Application Gateways

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescription.groovy
@@ -80,6 +80,8 @@ class AzureAppGatewayDescription extends AzureResourceOpsDescription {
     description.detail = appGateway.tags?.detail ?: parsedName.detail
     description.appName = appGateway.tags?.appName ?: parsedName.app
     description.loadBalancerName = appGateway.name()
+    description.sku = appGateway.sku().name().toString()
+    description.tier = appGateway.sku().tier().toString()
 
     // Get current backend address pool id from the application gateway requested routing rules
     def bapActiveRuleId = appGateway.requestRoutingRules()?.first()?.backendAddressPool()?.id()

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
@@ -98,6 +98,8 @@ class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
         description.serverGroups = appGatewayDescription.serverGroups
         description.trafficEnabledSG = appGatewayDescription.trafficEnabledSG
         description.vnetResourceGroup = appGatewayDescription.vnetResourceGroup
+        description.sku = appGatewayDescription.sku
+        description.tier = appGatewayDescription.tier
 
         Deployment deployment = description.credentials.resourceManagerClient.createResourceFromTemplate(
           AzureAppGatewayResourceTemplate.getTemplate(description),
@@ -109,6 +111,10 @@ class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
         errList = AzureDeploymentOperation.checkDeploymentOperationStatus(task, BASE_PHASE, description.credentials, resourceGroupName, deployment.name())
       } else {
         // We are attempting to create a new application gateway
+        if (description.sku == "Standard_v2") {
+          description.tier = "Standard_v2"
+        }
+
         if (!description.useDefaultVnet) {
           task.updateStatus(BASE_PHASE, "Create ApplicationGateway using virtual network $description.vnet and subnet $description.subnet for server group $description.name")
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureAppGatewayResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureAppGatewayResourceTemplate.groovy
@@ -18,9 +18,9 @@ package com.netflix.spinnaker.clouddriver.azure.templates
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
-import groovy.util.logging.Slf4j
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
+import groovy.util.logging.Slf4j
 
 @Slf4j
 class AzureAppGatewayResourceTemplate {
@@ -63,6 +63,11 @@ class AzureAppGatewayResourceTemplate {
 
       if(description.dnsName){
         def publicIp = new PublicIpResource(properties: new PublicIPPropertiesWithDns())
+        if (description.sku == "Standard_v2") {
+          // publicIp sku must be Standard for Standard_v2 app gateways
+          publicIp.sku = new Sku("Standard")
+          publicIp.properties.publicIPAllocationMethod = 'Static'
+        }
         resources.add(publicIp)
         appGateway.addDependency(publicIp)
       } else {
@@ -89,7 +94,7 @@ class AzureAppGatewayResourceTemplate {
   static final String defaultAppGatewayBeAddrPoolName = "default_BAP0"
 
   static class AppGatewayTemplateVariables {
-    final String apiVersion = "2015-06-15"
+    final String apiVersion = "2018-04-01"
     String appGwName
     String publicIPAddressName
     String dnsNameForLBIP

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/converters/UpsertAzureAppGatewayAtomicOperationConverterSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/converters/UpsertAzureAppGatewayAtomicOperationConverterSpec.groovy
@@ -29,7 +29,6 @@ class UpsertAzureAppGatewayAtomicOperationConverterSpec extends  Specification{
 
   @Shared
   ObjectMapper mapper = new ObjectMapper()
-
   @Shared UpsertAzureLoadBalancerAtomicOperationConverter converter
 
   def setupSpec() {
@@ -44,48 +43,30 @@ class UpsertAzureAppGatewayAtomicOperationConverterSpec extends  Specification{
     setup:
     mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
     mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
-    def input = [
-      name: "testappgw-lb1-d1",
-      loadBalancerName: "testappgw-lb1-d1",
-      loadBalancerType: "Azure Application Gateway",
-      region: "westus",
-      accountName: "myazure-account",
-      cloudProvider: "azure",
-      appName: "testappgw",
-      stack: "lb1",
-      detail: "d1",
-      probes: [
-        [
-          probeName: "healthcheck1",
-          probeProtocol: "HTTP",
-          probePath: "/healthcheck",
-          probeInterval: 120,
-          timeout: 30,
-          unhealthyThreshold: 8
-        ]
-      ],
-      loadBalancingRules: [
-        [
-          ruleName: "lbRule1",
-          protocol: "HTTP",
-          externalPort: 80,
-          backendPort: 8080,
-        ],
-        [
-          ruleName: "lbRule2",
-          protocol: "HTTP",
-          externalPort: 8080,
-          backendPort: 8080,
-        ]
-      ]
-    ]
 
     when:
-    def description = converter.convertDescription(input)
+    def description = converter.convertDescription(basicGatewayInput)
 
     then:
     description instanceof AzureAppGatewayDescription
     mapper.writeValueAsString(description).replace('\r', '') == expectedFullDescription
+  }
+
+  void "Create an AzureAppGatewayDescription from a given input with v2 sku"() {
+    setup:
+    mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+
+    def input = basicGatewayInput
+    input['sku'] = 'Standard_v2'
+    input['tier'] = 'Standard_v2'
+
+    when:
+    def description = converter.convertDescription(basicGatewayInput)
+
+    then:
+    description instanceof AzureAppGatewayDescription
+    mapper.writeValueAsString(description).replace('\r', '') == expectedFullDescriptionV2sku
   }
 
   private static String expectedFullDescription = '''{
@@ -140,4 +121,93 @@ class UpsertAzureAppGatewayAtomicOperationConverterSpec extends  Specification{
   "tier" : "Standard",
   "capacity" : 2
 }'''
+
+  private static String expectedFullDescriptionV2sku = '''{
+  "name" : "testappgw-lb1-d1",
+  "cloudProvider" : "azure",
+  "accountName" : "myazure-account",
+  "appName" : "testappgw",
+  "stack" : "lb1",
+  "detail" : "d1",
+  "credentials" : null,
+  "region" : "westus",
+  "user" : null,
+  "createdTime" : null,
+  "lastReadTime" : 0,
+  "tags" : { },
+  "loadBalancerName" : "testappgw-lb1-d1",
+  "vnet" : null,
+  "subnet" : null,
+  "subnetResourceId" : null,
+  "vnetResourceGroup" : null,
+  "hasNewSubnet" : null,
+  "useDefaultVnet" : false,
+  "securityGroup" : null,
+  "dnsName" : null,
+  "cluster" : null,
+  "serverGroups" : null,
+  "trafficEnabledSG" : null,
+  "publicIpName" : null,
+  "probes" : [ {
+    "probeName" : "healthcheck1",
+    "probeProtocol" : "HTTP",
+    "probePort" : "localhost",
+    "probePath" : "/healthcheck",
+    "probeInterval" : 120,
+    "timeout" : 30,
+    "unhealthyThreshold" : 8
+  } ],
+  "loadBalancingRules" : [ {
+    "ruleName" : "lbRule1",
+    "protocol" : "HTTP",
+    "externalPort" : 80,
+    "backendPort" : 8080,
+    "sslCertificate" : null
+  }, {
+    "ruleName" : "lbRule2",
+    "protocol" : "HTTP",
+    "externalPort" : 8080,
+    "backendPort" : 8080,
+    "sslCertificate" : null
+  } ],
+  "sku" : "Standard_v2",
+  "tier" : "Standard_v2",
+  "capacity" : 2
+}'''
+
+  private static final basicGatewayInput = [
+    name              : "testappgw-lb1-d1",
+    loadBalancerName  : "testappgw-lb1-d1",
+    loadBalancerType  : "Azure Application Gateway",
+    region            : "westus",
+    accountName       : "myazure-account",
+    cloudProvider     : "azure",
+    appName           : "testappgw",
+    stack             : "lb1",
+    detail            : "d1",
+    probes            : [
+      [
+        probeName         : "healthcheck1",
+        probeProtocol     : "HTTP",
+        probePath         : "/healthcheck",
+        probeInterval     : 120,
+        timeout           : 30,
+        unhealthyThreshold: 8
+      ]
+    ],
+    loadBalancingRules: [
+      [
+        ruleName    : "lbRule1",
+        protocol    : "HTTP",
+        externalPort: 80,
+        backendPort : 8080,
+      ],
+      [
+        ruleName    : "lbRule2",
+        protocol    : "HTTP",
+        externalPort: 8080,
+        backendPort : 8080,
+      ]
+    ]
+  ]
 }


### PR DESCRIPTION
In order to be able to store TLS certificates in key-vault and use them on an application gateway, you are required to use a Standard_V2 Application Gateway.

This change, coupled with a change in deck (forthcoming), will allow users to select between Standard_Small (v1) and Standard_V2 SKUs. This change is safe on its own, but not beneficial by itself.

**Summary of changes**

1. Use input `sku` for App Gateway sku
    1. When updating existing App Gateway, keep the same sku
2. Select tier based on input sku (`Standard` for `Standard_Small` sku and `Standard_v2` for `Standard_v2` sku)
3. Select sku of public IP based on SKU of App Gateway
4. Update `apiVersion` to `2018-04-01` to allow v2 App Gateway sku

**Testing Done**

1. Unit tests
2. Tested (together with changes in deck) the following:
    1. Modify existing v1-sku App Gateways
    2. Create new v1-sku App Gateways
    3. Create new v2-sku App Gateways
    4. Delete v1-sku App Gateways
    5. Delete v2-sku App Gateways
    6. Deploy to v1-sku App Gateway
    6. Deploy to v2-sku App Gateway