### PR TITLE
fix(titus/build): use version 1.37.1 of io.grpc.* to fix compiler errors (#5487)

### DIFF
--- a/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver-titus/clouddriver-titus.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.google.protobuf"
 
 ext {
   protobufVersion = '[3.2.0,)'
-  grpcVersion = '1.37.1'
+  grpcVersion = '1.29.0'
 }
 
 repositories {

--- a/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver-titus/clouddriver-titus.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.google.protobuf"
 
 ext {
   protobufVersion = '[3.2.0,)'
-  grpcVersion = '[1.10.0,)'
+  grpcVersion = '1.37.1'
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,5 @@
 fiatVersion=1.28.0
-<<<<<<< HEAD
 korkVersion=7.115.0
-=======
-korkVersion=7.117.0
->>>>>>> 71f8f0d78 (fix(titus/build): use version 1.37.1 of io.grpc.* to fix compiler errors (#5487))
 org.gradle.parallel=true
 spinnakerGradleVersion=8.15.0
 targetJava11=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,9 @@
 fiatVersion=1.28.0
+<<<<<<< HEAD
 korkVersion=7.115.0
+=======
+korkVersion=7.117.0
+>>>>>>> 71f8f0d78 (fix(titus/build): use version 1.37.1 of io.grpc.* to fix compiler errors (#5487))
 org.gradle.parallel=true
 spinnakerGradleVersion=8.15.0
 targetJava11=true


### PR DESCRIPTION
Fix in favor of https://github.com/spinnaker/clouddriver/pull/5514. The guava version being pulled in was causing issues. 