### PR TITLE
fix(clouddriver-lambda): flakey test

### DIFF
--- a/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgentTest.java
+++ b/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgentTest.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfiguration;
 import com.netflix.spinnaker.clouddriver.lambda.cache.Keys;
 import com.netflix.spinnaker.clouddriver.lambda.service.config.LambdaServiceConfig;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -124,8 +125,9 @@ public class LambdaCachingAgentTest {
 
   @Test
   public void buildCacheDataShouldAddInfo() {
-    HashMap<String, CacheData> lambdaCacheData = new HashMap<>();
-    HashMap<String, Collection<String>> appLambdaRelationships = new HashMap<>();
+    ConcurrentHashMap<String, CacheData> lambdaCacheData = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Collection<String>> appLambdaRelationships =
+        new ConcurrentHashMap<>();
     List<Map<String, Object>> allLambdas =
         List.of(
             Map.of("functionName", "appName-functionName-something"),


### PR DESCRIPTION
buildCacheData uses parallel stream, so passing in anything other than a
concurrent hashmap results in race conditions. In this case, the test
was passing in a plain hashmap when it should have been a concurrent
hashmap

Signed-off-by: benjamin_j_powell <benjamin_j_powell@apple.com>