### PR TITLE
fix(provider/azure): Create RG if no load balancer

### DIFF
--- a/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupWithoutLoadBalancersAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupWithoutLoadBalancersAtomicOperation.groovy
@@ -71,6 +71,8 @@ class CreateAzureServerGroupWithoutLoadBalancersAtomicOperation implements Atomi
       }
 
       resourceGroupName = AzureUtilities.getResourceGroupName(description.application, description.region)
+      // Create corresponding ResourceGroup if it's not created already
+      description.credentials.resourceManagerClient.initializeResourceGroupAndVNet(resourceGroupName, null, description.region)
 
       virtualNetworkName = description.vnet
 


### PR DESCRIPTION
If no load balancer is selected, make sure the resource group exists and create it if not. The ability to deploy an Azure scale set (server group) with no load balancer was introduced in https://github.com/spinnaker/clouddriver/pull/5494.

**Testing Done**:

To recreate problem:

1. Created a new application `fooapp`
2. Created pipeline
3. Added deploy step to pipeline with load balancer null
4. Tried to deploy

Got "Resource group 'fooapp-canadacentral' could not be found."

After fixing problem:

1. Created new application `barapp`
2. Created pipeline
3. Added deploy step to pipeline with load balance null
4. Tried to deploy

Successfully deployed.