### PR TITLE
feat(k8s): provide an option to turn off account health check for k8s accounts

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -23,6 +23,9 @@ import lombok.Data;
 public class KubernetesConfigurationProperties {
   private KubernetesJobExecutorProperties jobExecutor = new KubernetesJobExecutorProperties();
 
+  /** flag to toggle account health check. Defaults to true. */
+  private boolean verifyAccountHealth = true;
+
   @Data
   public static class KubernetesJobExecutorProperties {
     private Retries retries = new Retries();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicator.java
@@ -20,22 +20,36 @@ package com.netflix.spinnaker.clouddriver.kubernetes.health;
 import com.google.common.collect.ImmutableList;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.core.AccountHealthIndicator;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Slf4j
 public class KubernetesHealthIndicator
     extends AccountHealthIndicator<KubernetesNamedAccountCredentials> {
   private static final String ID = "kubernetes";
   private final CredentialsRepository<KubernetesNamedAccountCredentials> credentialsRepository;
+  private final KubernetesConfigurationProperties kubernetesConfigurationProperties;
 
   @Autowired
   public KubernetesHealthIndicator(
       Registry registry,
-      CredentialsRepository<KubernetesNamedAccountCredentials> credentialsRepository) {
+      CredentialsRepository<KubernetesNamedAccountCredentials> credentialsRepository,
+      KubernetesConfigurationProperties kubernetesConfigurationProperties) {
     super(ID, registry);
     this.credentialsRepository = credentialsRepository;
+    this.kubernetesConfigurationProperties = kubernetesConfigurationProperties;
+
+    if (kubernetesConfigurationProperties.isVerifyAccountHealth()) {
+      log.info(
+          "kubernetes.verifyAccountHealth flag is enabled - declared namespaces will be retrieved for all accounts");
+    } else {
+      log.warn(
+          "kubernetes.verifyAccountHealth flag is disabled - declared namespaces will not be retrieved for any account");
+    }
   }
 
   @Override
@@ -45,11 +59,14 @@ public class KubernetesHealthIndicator
 
   @Override
   protected Optional<String> accountHealth(KubernetesNamedAccountCredentials accountCredentials) {
-    try {
-      accountCredentials.getCredentials().getDeclaredNamespaces();
-      return Optional.empty();
-    } catch (RuntimeException e) {
-      return Optional.of(e.getMessage());
+    if (kubernetesConfigurationProperties.isVerifyAccountHealth()) {
+      try {
+        accountCredentials.getCredentials().getDeclaredNamespaces();
+        return Optional.empty();
+      } catch (RuntimeException e) {
+        return Optional.of(e.getMessage());
+      }
     }
+    return Optional.empty();
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicator.java
@@ -62,7 +62,6 @@ public class KubernetesHealthIndicator
     if (kubernetesConfigurationProperties.isVerifyAccountHealth()) {
       try {
         accountCredentials.getCredentials().getDeclaredNamespaces();
-        return Optional.empty();
       } catch (RuntimeException e) {
         return Optional.of(e.getMessage());
       }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/config/KubernetesConfiguration.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/config/KubernetesConfiguration.java
@@ -65,8 +65,10 @@ public class KubernetesConfiguration {
   @Bean
   public KubernetesHealthIndicator kubernetesHealthIndicator(
       Registry registry,
-      CredentialsRepository<KubernetesNamedAccountCredentials> credentialsRepository) {
-    return new KubernetesHealthIndicator(registry, credentialsRepository);
+      CredentialsRepository<KubernetesNamedAccountCredentials> credentialsRepository,
+      KubernetesConfigurationProperties kubernetesConfigurationProperties) {
+    return new KubernetesHealthIndicator(
+        registry, credentialsRepository, kubernetesConfigurationProperties);
   }
 
   @Bean


### PR DESCRIPTION
## Purpose
- This PR implements the second fix from this issue: https://github.com/spinnaker/spinnaker/issues/6528. 
- We have more than 2000+ k8s accounts in our setup. Even after the clouddriver app starts up, the pod is not marked as ready by kubernetes until the health check is successful. This health check involves looking at the health of the various cloud providers, db and other resources. We have seen that in our setup, the k8s health check takes a long time to complete since it  attempts to load all the declared namespaces for each of these accounts by making a live API call to the cluster. This can take as much as 35-40 mins, hence disabling it provides us with a lot of benefit.

As seen by the logs below, the clouddriver app started at `2021-09-10 17:45:54.775`:
```
2021-09-10 17:45:54.775  INFO 1 --- [           main] com.netflix.spinnaker.clouddriver.Main   : Started Main in 93.195 seconds (JVM running for 94.675)
```

But the pod was marked as ready at `2021-09-10T18:25:11Z`, which is almost 40 mins later (the time it took for the health check to complete for k8s accounts):
```
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2021-09-10T17:44:19Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2021-09-10T18:25:11Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2021-09-10T18:25:11Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2021-09-10T17:43:48Z"
    status: "True"
    type: PodScheduled
 ```

- Since users may be relying on this capability, and would not like this to be disabled by default, we have made this an opt-in capability. By default, this health check will be performed. If someone wants to opt out of it, they can set 
`kubernetes.verifyAccountHealth: false`

## Changes:
- provides an option to skip verifying k8s account health check.
