### PR TITLE
feat(aws): provide an option to bypass account health check

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfigurationProperties.groovy
@@ -50,10 +50,23 @@ class AwsConfigurationProperties {
     boolean changeSetsIncludeNestedStacks = false
   }
 
+  /**
+   * health check related config settings
+   */
+  @Canonical
+  static class HealthConfig {
+    /**
+     * flag to toggle verifying account health check. by default, account health check is enabled.
+     */
+    boolean verifyAccountHealth = true
+  }
+
   @NestedConfigurationProperty
   final ClientConfig client = new ClientConfig()
   @NestedConfigurationProperty
   final CleanupConfig cleanup = new CleanupConfig()
   @NestedConfigurationProperty
   final CloudFormationConfig cloudformation = new CloudFormationConfig()
+  @NestedConfigurationProperty
+  final HealthConfig health = new HealthConfig()
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/config/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/config/AwsConfiguration.groovy
@@ -158,11 +158,18 @@ class AwsConfiguration {
   }
 
   @Bean
+  AwsConfigurationProperties awsConfigurationProperties() {
+    return new AwsConfigurationProperties()
+  }
+
+  @Bean
   AmazonHealthIndicator amazonHealthIndicator(
     Registry registry,
     CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
-    AmazonClientProvider amazonClientProvider) {
-    return new AmazonHealthIndicator(registry, credentialsRepository, amazonClientProvider)
+    AmazonClientProvider amazonClientProvider,
+    AwsConfigurationProperties awsConfigurationProperties
+  ) {
+    return new AmazonHealthIndicator(registry, credentialsRepository, amazonClientProvider, awsConfigurationProperties)
   }
 
   public static class DeployDefaults {

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/health/AmazonHealthIndicator.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/health/AmazonHealthIndicator.java
@@ -3,25 +3,31 @@ package com.netflix.spinnaker.clouddriver.aws.health;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.core.AccountHealthIndicator;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class AmazonHealthIndicator extends AccountHealthIndicator<NetflixAmazonCredentials> {
 
   private static final String ID = "aws";
   private final CredentialsRepository<NetflixAmazonCredentials> credentialsRepository;
   private final AmazonClientProvider amazonClientProvider;
+  private final AwsConfigurationProperties awsConfigurationProperties;
 
   public AmazonHealthIndicator(
       Registry registry,
       CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
-      AmazonClientProvider amazonClientProvider) {
+      AmazonClientProvider amazonClientProvider,
+      AwsConfigurationProperties awsConfigurationProperties) {
     super(ID, registry);
     this.credentialsRepository = credentialsRepository;
     this.amazonClientProvider = amazonClientProvider;
+    this.awsConfigurationProperties = awsConfigurationProperties;
   }
 
   @Override
@@ -31,25 +37,32 @@ public class AmazonHealthIndicator extends AccountHealthIndicator<NetflixAmazonC
 
   @Override
   protected Optional<String> accountHealth(NetflixAmazonCredentials account) {
-    try {
-      AmazonEC2 ec2 =
-          amazonClientProvider.getAmazonEC2(account, AmazonClientProvider.DEFAULT_REGION, true);
-      if (ec2 == null) {
-        return Optional.of(
-            String.format("Could not create Amazon client for '%s'", account.getName()));
+    if (awsConfigurationProperties.getHealth().getVerifyAccountHealth()) {
+      log.info(
+          "aws.health.verifyAccountHealth flag is enabled - verifying connection to the EC2 accounts");
+      try {
+        AmazonEC2 ec2 =
+            amazonClientProvider.getAmazonEC2(account, AmazonClientProvider.DEFAULT_REGION, true);
+        if (ec2 == null) {
+          return Optional.of(
+              String.format("Could not create Amazon client for '%s'", account.getName()));
+        }
+
+        ec2.describeAccountAttributes();
+
+      } catch (AmazonServiceException e) {
+        String errorCode = e.getErrorCode();
+
+        if (!"RequestLimitExceeded".equalsIgnoreCase(errorCode)) {
+          return Optional.of(
+              String.format(
+                  "Failed to describe account attributes for '%s'. Message: '%s'",
+                  account.getName(), e.getMessage()));
+        }
       }
-
-      ec2.describeAccountAttributes();
-
-    } catch (AmazonServiceException e) {
-      String errorCode = e.getErrorCode();
-
-      if (!"RequestLimitExceeded".equalsIgnoreCase(errorCode)) {
-        return Optional.of(
-            String.format(
-                "Failed to describe account attributes for '%s'. Message: '%s'",
-                account.getName(), e.getMessage()));
-      }
+    } else {
+      log.info(
+          "aws.health.verifyAccountHealth flag is disabled - not verifying connection to the EC2 accounts");
     }
 
     return Optional.empty();


### PR DESCRIPTION
## Purpose
- This PR implements the third fix from this issue: https://github.com/spinnaker/spinnaker/issues/6528. 
- We have 500+ aws accounts in our setup. Even after the clouddriver app starts up, the pod is not marked as ready by kubernetes until the health check is successful. This health check involves looking at the health of the various cloud providers, db and other resources. We have seen that in our setup, the aws health check takes a long time to complete since it  attempts to load all the declared namespaces for each of these accounts by making a live API call to the cluster. Also, if there is any exception occurring while this health check is performed, then it prevents clouddriver from starting up.

- Since users may be relying on this capability, and would not like this to be disabled by default, we have made this an opt-in capability. By default, this health check will be performed. If someone wants to opt out of it, they can set 
`aws.health.verifyAccountHealth: false`

## Changes:
- provides an option to skip verifying aws account health check.
