### PR TITLE
feat(aws): provide a configurable option to parse aws accounts in a multi-threaded fashion

### DIFF
--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoader.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoader.java
@@ -117,6 +117,7 @@ public class AmazonBasicCredentialsLoader<
     log.info("attempting to parse {} amazon accounts provided as input", definitions.size());
     Set<String> definitionNames = definitions.stream().map(T::getName).collect(Collectors.toSet());
 
+    // TODO: make a change in BasicCredentialsLoader in kork to separate this out into a new method
     log.info(
         "removing all the accounts from the credentials repository that are not present in the provided input");
     credentialsRepository.getAll().stream()

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoader.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoader.java
@@ -201,7 +201,12 @@ public class AmazonBasicCredentialsLoader<
           definitions.stream()
               .filter(t -> t.getName().equals(cred.getName()))
               .findFirst()
-              .ifPresent(definition -> loadedDefinitions.put(cred.getName(), definition));
+              .ifPresentOrElse(
+                  definition -> loadedDefinitions.put(cred.getName(), definition),
+                  () ->
+                      log.warn(
+                          "could not find the parsed aws account: '{}' in the input credential definitions.",
+                          cred.getName()));
         }
       } catch (Exception e) {
         // failure to load an account should not prevent clouddriver from starting up.

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoader.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoader.java
@@ -20,16 +20,26 @@ package com.netflix.spinnaker.clouddriver.aws.security;
 import com.amazonaws.SDKGlobalConfiguration;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.util.CollectionUtils;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration;
+import com.netflix.spinnaker.clouddriver.aws.security.config.AmazonCredentialsParser;
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig;
+import com.netflix.spinnaker.credentials.Credentials;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.credentials.definition.BasicCredentialsLoader;
 import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
 import com.netflix.spinnaker.credentials.definition.CredentialsParser;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
+@Slf4j
 public class AmazonBasicCredentialsLoader<
         T extends AccountsConfiguration.Account, U extends NetflixAmazonCredentials>
     extends BasicCredentialsLoader<T, U> {
@@ -100,5 +110,110 @@ public class AmazonBasicCredentialsLoader<
       }
     }
     this.parse(definitionSource.getCredentialsDefinitions());
+  }
+
+  @Override
+  protected void parse(Collection<T> definitions) {
+    log.info("attempting to parse {} amazon accounts provided as input", definitions.size());
+    Set<String> definitionNames = definitions.stream().map(T::getName).collect(Collectors.toSet());
+
+    log.info(
+        "removing all the accounts from the credentials repository that are not present in the provided input");
+    credentialsRepository.getAll().stream()
+        .map(Credentials::getName)
+        .filter(name -> !definitionNames.contains(name))
+        .peek(loadedDefinitions::remove)
+        .forEach(credentialsRepository::delete);
+
+    // adding this after the delete from credentials repository step. This is to ensure that if the
+    // new input does not
+    // contain any accounts, then that should be reflected in the credentials repository
+    // appropriately
+    if (definitionNames.size() == 0) {
+      log.info("did not find any aws account definitions to parse");
+      return;
+    }
+
+    List<U> toApply = new ArrayList<>();
+    if (credentialsConfig.getLoadAccounts().isMultiThreadingEnabled()) {
+      log.info(
+          "Multi-threading is enabled for loading aws accounts. Using {} threads, with timeout: {}s",
+          credentialsConfig.getLoadAccounts().getNumberOfThreads(),
+          credentialsConfig.getLoadAccounts().getTimeoutInSeconds());
+      toApply = multiThreadedParseAccounts(definitions);
+    } else {
+      log.info("Multi-threading is disabled. AWS accounts will be loaded serially");
+      for (T definition : definitions) {
+        if (!loadedDefinitions.containsKey(definition.getName())) {
+          U cred = parser.parse(definition);
+          if (cred != null) {
+            toApply.add(cred);
+            // Add to loaded definition now in case we trigger another parse before this one
+            // finishes
+            loadedDefinitions.put(definition.getName(), definition);
+          }
+        } else if (!loadedDefinitions.get(definition.getName()).equals(definition)) {
+          U cred = parser.parse(definition);
+          if (cred != null) {
+            toApply.add(cred);
+            loadedDefinitions.put(definition.getName(), definition);
+          }
+        }
+      }
+    }
+
+    log.info("saving aws accounts in the credentials repository");
+    Stream<U> stream = parallel ? toApply.parallelStream() : toApply.stream();
+    stream.forEach(credentialsRepository::save);
+    log.info("parsed and saved {} aws accounts", credentialsRepository.getAll().size());
+  }
+
+  /**
+   * parses aws accounts using a configurable fixed thread pool.
+   *
+   * @param definitions - the list of aws accounts to parse
+   * @return - a list of parsed aws accounts
+   */
+  private List<U> multiThreadedParseAccounts(Collection<T> definitions) {
+    List<U> toApply = new ArrayList<>();
+    final ExecutorService executorService =
+        Executors.newFixedThreadPool(
+            credentialsConfig.getLoadAccounts().getNumberOfThreads(),
+            new ThreadFactoryBuilder()
+                .setNameFormat(AmazonCredentialsParser.class.getSimpleName() + "-%d")
+                .build());
+
+    final ArrayList<Future<U>> futures = new ArrayList<>(definitions.size());
+    for (T definition : definitions) {
+      if (!loadedDefinitions.containsKey(definition.getName())
+          || !loadedDefinitions.get(definition.getName()).equals(definition)) {
+        futures.add(executorService.submit(() -> parser.parse(definition)));
+      }
+    }
+    for (Future<U> future : futures) {
+      try {
+        U cred =
+            future.get(credentialsConfig.getLoadAccounts().getTimeoutInSeconds(), TimeUnit.SECONDS);
+        if (cred != null) {
+          toApply.add(cred);
+          // Add to loaded definition now in case we trigger another parse before this one finishes
+          definitions.stream()
+              .filter(t -> t.getName().equals(cred.getName()))
+              .findFirst()
+              .ifPresent(definition -> loadedDefinitions.put(cred.getName(), definition));
+        }
+      } catch (Exception e) {
+        // failure to load an account should not prevent clouddriver from starting up.
+        log.error("Failed to load aws account: ", e);
+      }
+    }
+    try {
+      // attempt to shutdown the executor service
+      executorService.shutdownNow();
+    } catch (Exception e) {
+      log.error("Failed to shutdown the aws account loading executor service.", e);
+    }
+
+    return toApply;
   }
 }

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/AmazonCredentialsParser.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/AmazonCredentialsParser.java
@@ -31,9 +31,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+@Slf4j
 public class AmazonCredentialsParser<
         U extends AccountsConfiguration.Account, V extends NetflixAmazonCredentials>
     implements CredentialsParser<U, V> {
@@ -116,7 +118,16 @@ public class AmazonCredentialsParser<
 
   private List<Region> initRegions(Lazy<List<Region>> defaults, List<Region> toInit) {
     if (toInit == null) {
-      return defaults.get();
+      // when accounts are parsed in a multi-threaded manner, the defaults.get() result could be the
+      // same for multiple
+      // accounts which do not have any regions set. Thus, when the account.setRegion() call is
+      // made, it could end
+      // up throwing a ConcurrentModificationException because at that point, the same object (i.e.
+      // default.get) will be
+      // attempted to be sorted for multiple accounts at a time. Hence, to get around it, we
+      // initialize it in a new
+      // list
+      return new ArrayList<>(defaults.get());
     }
 
     Map<String, Region> toInitByName =
@@ -195,7 +206,6 @@ public class AmazonCredentialsParser<
 
   public List<V> load(CredentialsConfig source) throws Throwable {
     final CredentialsConfig config = objectMapper.convertValue(source, CredentialsConfig.class);
-
     if (accountsConfig.getAccounts() == null || accountsConfig.getAccounts().isEmpty()) {
       return Collections.emptyList();
     }
@@ -212,13 +222,16 @@ public class AmazonCredentialsParser<
   @Override
   public V parse(@NotNull U account) {
     try {
+      log.info("Parsing aws account: {}", account.getName());
       V a = parseAccount(credentialsConfig, account);
       if (a.isEnabled()) {
+        log.info("AWS account: {} is enabled", account.getName());
         return a;
+      } else {
+        log.info("AWS account: {} is disabled", account.getName());
       }
     } catch (Throwable t) {
-      t.printStackTrace();
-      return null;
+      log.warn("Failed to parse aws account: {}. Error: ", account.getName(), t);
     }
     return null;
   }
@@ -240,6 +253,7 @@ public class AmazonCredentialsParser<
       account.setAccountType(account.getName());
     }
 
+    log.info("Initializing regions for aws account: {}", account.getName());
     account.setRegions(initRegions(defaultRegions, account.getRegions()));
     account.setDefaultSecurityGroups(
         account.getDefaultSecurityGroups() != null

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/AmazonCredentialsParser.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/AmazonCredentialsParser.java
@@ -201,6 +201,7 @@ public class AmazonCredentialsParser<
     return result;
   }
 
+  // TODO: verify if this is safe to be removed if it is not used anywhere else apart from tests
   public List<V> load(CredentialsConfig source) throws Throwable {
     final CredentialsConfig config = objectMapper.convertValue(source, CredentialsConfig.class);
     if (accountsConfig.getAccounts() == null || accountsConfig.getAccounts().isEmpty()) {

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/AmazonCredentialsParser.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/AmazonCredentialsParser.java
@@ -55,15 +55,12 @@ public class AmazonCredentialsParser<
       Class<V> credentialsType,
       CredentialsConfig credentialsConfig,
       AccountsConfiguration accountsConfig) {
-    this.credentialsProvider = Objects.requireNonNull(credentialsProvider, "credentialsProvider");
-    this.awsAccountInfoLookup =
-        new DefaultAWSAccountInfoLookup(credentialsProvider, amazonClientProvider);
-    this.templateValues = Collections.emptyMap();
-    this.objectMapper = new ObjectMapper();
-    this.credentialTranslator = findTranslator(credentialsType, this.objectMapper);
-    this.credentialsConfig = credentialsConfig;
-    this.defaultRegions = createDefaults(credentialsConfig.getDefaultRegions());
-    this.accountsConfig = accountsConfig;
+    this(
+        credentialsProvider,
+        new DefaultAWSAccountInfoLookup(credentialsProvider, amazonClientProvider),
+        credentialsType,
+        credentialsConfig,
+        accountsConfig);
   }
 
   public AmazonCredentialsParser(

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsConfig.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsConfig.java
@@ -19,7 +19,10 @@ package com.netflix.spinnaker.clouddriver.aws.security.config;
 import static lombok.EqualsAndHashCode.Include;
 
 import java.util.List;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * A mutable credentials configurations structure suitable for transformation into concrete
@@ -132,6 +135,30 @@ public class CredentialsConfig {
     public void setDefaultResult(String defaultResult) {
       this.defaultResult = defaultResult;
     }
+  }
+
+  /** LoadAccounts class contains configuration related to loading aws accounts at start up. */
+  @Data
+  public static class LoadAccounts {
+    /**
+     * flag to enable loading aws accounts using multiple threads. This is turned off by default.
+     */
+    private boolean multiThreadingEnabled = false;
+
+    /**
+     * Only applicable when multiThreadingEnabled: true. This specifies the number of threads that
+     * should be used to load the aws accounts.
+     *
+     * <p>Adjust this number appropriately based on: - number of aws many accounts, - number of
+     * clouddriver pods (so that aws api calls are not rate-limited)
+     */
+    private int numberOfThreads = 5;
+
+    /**
+     * Only applicable when multiThreadingEnabled: true. This specifies the max amount of time for
+     * loading an aws account, after which a timeout exception will occur.
+     */
+    private int timeoutInSeconds = 180;
   }
 
   private String accessKeyId;
@@ -262,4 +289,6 @@ public class CredentialsConfig {
   public void setSecretAccessKey(String secretAccessKey) {
     this.secretAccessKey = secretAccessKey;
   }
+
+  @Getter @Setter private LoadAccounts loadAccounts = new LoadAccounts();
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoaderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoaderSpec.groovy
@@ -87,6 +87,9 @@ class AmazonBasicCredentialsLoaderSpec extends Specification{
           new CredentialsConfig.Region(name: 'us-west-2')
         ])
       }
+      // all other accounts would end up using the default regions from credentials config in this case. This is
+      // to test that with multiThreading enabled, we don't run into ConcurrentModificationException errors when
+      // sorting these regions per account
       accounts.add(account)
     }
     AccountsConfiguration accountsConfig = new AccountsConfiguration(accounts: accounts)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoaderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoaderSpec.groovy
@@ -18,37 +18,42 @@
 package com.netflix.spinnaker.clouddriver.aws.security
 
 import com.amazonaws.SDKGlobalConfiguration
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
+import com.netflix.spinnaker.clouddriver.aws.security.config.AmazonCredentialsParser
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig
 import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration
 import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration.Account
-import com.netflix.spinnaker.credentials.CredentialsRepository
+import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository
 import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.util.stream.Collectors
 
 class AmazonBasicCredentialsLoaderSpec extends Specification{
   @Shared
-  def credentialsConfig = new CredentialsConfig(){{
-    setAccessKeyId("accessKey")
-    setSecretAccessKey("secret")
-  }}
-  @Shared
   def defaultAccountConfigurationProperties = new DefaultAccountConfigurationProperties()
-  @Shared
-  def credentialsRepository = Mock(CredentialsRepository) {
-    getAll() >> []
-  }
-  @Shared
-  def definitionSource = Mock(CredentialsDefinitionSource) {
-    getCredentialsDefinitions() >> []
-  }
-
-  @Shared
-  def accountsConfig = new AccountsConfiguration()
 
   def 'should set defaults'() {
+    setup:
+    def credentialsConfig = new CredentialsConfig(){{
+      setAccessKeyId("accessKey")
+      setSecretAccessKey("secret")
+    }}
+    def definitionSource = Mock(CredentialsDefinitionSource) {
+      getCredentialsDefinitions() >> []
+    }
+    def credentialsRepository = new MapBackedCredentialsRepository<NetflixAmazonCredentials>(AmazonCloudProvider.ID, null)
+    AccountsConfiguration accountsConfig = new AccountsConfiguration()
     def loader = new AmazonBasicCredentialsLoader<Account, NetflixAmazonCredentials>(
-      definitionSource, null, credentialsRepository, credentialsConfig, accountsConfig, defaultAccountConfigurationProperties
+      definitionSource,
+      null,
+      credentialsRepository,
+      credentialsConfig,
+      accountsConfig,
+      defaultAccountConfigurationProperties
     )
 
     when:
@@ -56,8 +61,111 @@ class AmazonBasicCredentialsLoaderSpec extends Specification{
 
     then:
     accountsConfig.getAccounts().size() == 1
+    with (accountsConfig.getAccounts().first()) { Account account ->
+      account.name == "default"
+      account.environment == "default"
+      account.accountType == "default"
+    }
+
     credentialsConfig.getDefaultRegions().size() == 4
     System.getProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY) == "accessKey"
     System.getProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY) == "secret"
+  }
+
+  @Unroll("should load and parse a large number of accounts with multi-threading: #multiThreadingEnabled")
+  def 'should load and parse a large number of accounts'() {
+    setup:
+    def credentialsRepository = new MapBackedCredentialsRepository<NetflixAmazonCredentials>(AmazonCloudProvider.ID, null)
+
+    // create 500 accounts
+    List<Account> accounts = new ArrayList<>()
+    for (number in 0..499) {
+      Account account = new Account(name: 'prod' + number, accountId: number)
+      if (number == 0) {
+        // test an account having a region that matches one of the default regions
+        account.setRegions([
+          new CredentialsConfig.Region(name: 'us-west-2')
+        ])
+      }
+      accounts.add(account)
+    }
+    AccountsConfiguration accountsConfig = new AccountsConfiguration(accounts: accounts)
+
+    AWSCredentialsProvider provider = Mock(AWSCredentialsProvider)
+    AWSAccountInfoLookup lookup = Mock(AWSAccountInfoLookup)
+
+    CredentialsConfig credentialsConfig = new CredentialsConfig(){{
+      setAccessKeyId("accessKey")
+      setSecretAccessKey("secret")
+    }}
+    credentialsConfig.loadAccounts.setMultiThreadingEnabled(multiThreadingEnabled)
+
+    credentialsConfig.setDefaultRegions(
+      ['us-east-1','us-west-2'] .stream()
+        .map(
+          { it ->
+            new CredentialsConfig.Region() {
+              {
+                setName(it)
+              }
+            }
+          })
+        .collect(Collectors.toList())
+    )
+
+    CredentialsDefinitionSource<Account> amazonCredentialsSource = { -> accountsConfig.getAccounts() } as CredentialsDefinitionSource
+    AmazonCredentialsParser<Account, NetflixAmazonCredentials> ci = new AmazonCredentialsParser<>(
+      provider, lookup, NetflixAmazonCredentials.class, credentialsConfig, accountsConfig)
+    def loader = new AmazonBasicCredentialsLoader<Account, NetflixAmazonCredentials>(
+      amazonCredentialsSource, ci, credentialsRepository, credentialsConfig, accountsConfig, defaultAccountConfigurationProperties
+    )
+
+    when:
+    loader.load()
+
+    then:
+    lookup.listRegions(['us-east-1', 'us-west-2']) >> [
+      new AmazonCredentials.AWSRegion('us-east-1', ['us-east-1a', 'us-east-1b']),
+      new AmazonCredentials.AWSRegion('us-west-2', ['us-west-2a']),
+    ]
+
+    // verify we have 500 accounts in the accounts config object
+    accountsConfig.getAccounts().size() == 500
+
+    // verify we have saved 500 accounts in the credentials repository
+    credentialsRepository.getAll().size() == 500
+
+    // test some random accounts
+    with (accountsConfig.getAccounts().first()) { Account account ->
+      account.name == "prod0"
+      account.environment == "prod0"
+      account.accountType == "prod0"
+    }
+
+    // test an account that has 1 region which is not a default region
+    with (accountsConfig.getAccounts().get(100)) { Account account ->
+      account.name == "prod100"
+      account.environment == "prod100"
+      account.accountType == "prod100"
+    }
+
+    // test an account that has multiple regions
+    with (accountsConfig.getAccounts().get(200)) { Account account ->
+      account.name == "prod200"
+      account.environment == "prod200"
+      account.accountType == "prod200"
+    }
+
+    // test an account that does not have any regions
+    with (accountsConfig.getAccounts().last()) { Account account ->
+      account.name == "prod499"
+      account.environment == "prod499"
+      account.accountType == "prod499"
+    }
+
+    where:
+    multiThreadingEnabled | _
+    true                  | _
+    false                 | _
   }
 }


### PR DESCRIPTION

## Purpose
- This PR implements the last fix from this issue: https://github.com/spinnaker/spinnaker/issues/6528. 
- We have 450+ aws accounts in our setup. We have noticed that it takes a long time for clouddriver to parse these aws accounts, which leads to slow clouddriver start up times. 

For 456 accounts, it takes  7m 42s to parse AWS accounts.
```
2021-09-17 16:20:38.504 INFO 1 --- [ main] c.n.s.c.a.s.AmazonBasicCredentialsLoader : attempting to parse 456 aws accounts provided as input
2021-09-17 16:20:38.504 INFO 1 --- [ main] c.n.s.c.a.s.c.AmazonCredentialsParser : Parsing aws account: aws-iam-account
...
2021-09-17 16:28:19.564  INFO 1 --- [           main] c.n.s.c.a.s.c.AmazonCredentialsParser    : Parsing aws account: clane-ec2-account-add-test-01
2021-09-17 16:28:20.567  INFO 1 --- [           main] com.amazonaws.http.AmazonHttpClient      : Configuring Proxy. Proxy Host: publicproxy.publicproxy.local.sfdc.net Proxy Port: 8080

```

After including the changes in this PR, these accounts are parsed in 1m3s.
```
2021-09-20 03:52:56.620  INFO 1 --- [           main] c.n.s.c.a.s.AmazonBasicCredentialsLoader : attempting to parse 456 amazon accounts provided as input
2021-09-20 03:52:56.620  INFO 1 --- [           main] c.n.s.c.a.s.AmazonBasicCredentialsLoader : removing all the accounts from the credentials repository that are not present in the provided input
2021-09-20 03:52:56.621  INFO 1 --- [           main] c.n.s.c.a.s.AmazonBasicCredentialsLoader : Multi-threading is enabled for loading aws accounts. Using 25 threads, with timeout: 180s
...
2021-09-20 03:53:59.433  INFO 1 --- [           main] .c.a.s.AmazonCredentialsLifecycleHandler : The following cleanup agents have been added: [] (awsCleanupProvider.getAgentScheduler: com.netflix.spinnaker.clouddriver.cache.CacheConfig$1@14167612)
2021-09-20 03:53:59.434  INFO 1 --- [           main] c.n.s.c.a.s.AmazonBasicCredentialsLoader : parsed and saved 456 aws accounts
```
which is a `6m 39s` improvement in loading aws accounts.


## Changes:
- enable multi-threaded support for parsing AWS accounts. This is turned off by default. If anyone wants to opt-in, they can set
```
aws:
  loadAccounts:
    multiThreadingEnabled: true
```
