### PR TITLE
chore(clouddriver-sql): add missing com.fasterxml.jackson.datatype:ja…

### DIFF
--- a/clouddriver-sql/clouddriver-sql.gradle
+++ b/clouddriver-sql/clouddriver-sql.gradle
@@ -47,6 +47,7 @@ dependencies {
   testImplementation "dev.minutest:minutest"
   testImplementation "io.mockk:mockk"
   testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin"
+  testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 
   testRuntimeOnly "org.junit.platform:junit-platform-launcher"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"


### PR DESCRIPTION
…ckson-datatype-jsr310 dependency

to get past errors that appear when upgrading kork to 7.121.0 (https://github.com/spinnaker/clouddriver/pull/5543/checks?check_run_id=3724510876):

> Task :clouddriver-sql:compileTestKotlin FAILED
e: /Users/dbyron/src/spinnaker/clouddriver/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventRepositoryTest.kt: (20, 30): Unresolved reference: datatype
e: /Users/dbyron/src/spinnaker/clouddriver/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventRepositoryTest.kt: (207, 41): Unresolved reference: JavaTimeModule
