### PR TITLE
fix(titus/test): remove duplicate assignment

### DIFF
--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/actions/PrepareTitusDeployActionSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/actions/PrepareTitusDeployActionSpec.groovy
@@ -267,7 +267,7 @@ class PrepareTitusDeployActionSpec extends Specification {
   }
 
   private static class Fixture {
-    Moniker moniker = mimicker.moniker().get()
+    Moniker moniker
     // TODO(rz): barf
     String monikerName
     String region


### PR DESCRIPTION
The constructor handles it a few lines down, and after the upgrade to kork v7.121.0
(https://github.com/spinnaker/clouddriver/pull/5543/checks?check_run_id=3726482904), the
compiler complains:
```
/home/runner/work/clouddriver/clouddriver/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/actions/PrepareTitusDeployActionSpec.groovy: 270: Apparent variable 'mimicker' was found in a static scope but doesn't refer to a local variable, static field or class. Possible causes:
You attempted to reference a variable in the binding or an instance variable from a static context.
You misspelled a classname or statically imported field. Please check the spelling.
You attempted to use a method 'mimicker' but left out brackets in a place not allowed by the grammar.
 @ line 270, column 23.
       Moniker moniker = mimicker.moniker().get()
```