### PR TITLE
fix(k8s/credentials): do not cache kind accessibility for external providers

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -193,7 +193,9 @@ public class KubernetesCredentials {
     this.context = managedAccount.getContext();
 
     this.onlySpinnakerManaged = managedAccount.isOnlySpinnakerManaged();
-    this.checkPermissionsOnStartup = managedAccount.isCheckPermissionsOnStartup();
+    // we allow the k8s-agent to manage how it'll check access to kinds
+    this.checkPermissionsOnStartup =
+        kubectlExecutable != null ? false : managedAccount.isCheckPermissionsOnStartup();
     this.cachingPolicies = managedAccount.getCachingPolicies();
 
     this.oAuthServiceAccount = managedAccount.getOAuthServiceAccount();


### PR DESCRIPTION
There is a flag for kubernetes accounts `checkPermissionsOnStartup` that when turned on will cache k8s kind accessibility in `kubernetesCredentials.readableKinds`, this is configurable for V2 provider accounts, but for external kubernetesProviders this configuration is not available and the flag is defaulted to true, this kind of behavior should be overridable by the provider so defaulting to false in these cases will leave the responsibility to such.