### PR TITLE
chore(agent&cloudriver)

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKind.java
@@ -54,6 +54,10 @@ public class KubernetesKind {
       createWithAlias("daemonSet", "ds", KubernetesApiGroup.APPS);
   public static final KubernetesKind DEPLOYMENT =
       createWithAlias("deployment", "deploy", KubernetesApiGroup.APPS);
+  public static final KubernetesKind CSI_DRIVERS =
+      createWithAlias("csidriver", null, KubernetesApiGroup.STORAGE_K8S_IO);
+  public static final KubernetesKind CSI_NODES =
+      createWithAlias("csinode", null, KubernetesApiGroup.STORAGE_K8S_IO);
   public static final KubernetesKind EVENT =
       createWithAlias("event", null, KubernetesApiGroup.CORE);
   public static final KubernetesKind HORIZONTAL_POD_AUTOSCALER =


### PR DESCRIPTION
Add two core kubernetes kind (csidriver, csinode).
To be use for the agent and clouddriver when they are getting
those kinds.

JIRA Ticket : https://armory.atlassian.net/browse/BOB-30402

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
