### PR TITLE
fix(namespaceValidation): revert #5359 which caused a new namespace deploy to fail

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtil.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtil.java
@@ -124,7 +124,7 @@ public class KubernetesValidationUtil {
   }
 
   protected boolean validateNamespace(String namespace, KubernetesCredentials credentials) {
-    final List<String> configuredNamespaces = credentials.getDeclaredNamespaces();
+    final List<String> configuredNamespaces = credentials.getNamespaces();
     if (configuredNamespaces != null
         && !configuredNamespaces.isEmpty()
         && !configuredNamespaces.contains(namespace)) {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtilSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtilSpec.groovy
@@ -51,7 +51,7 @@ class KubernetesValidationUtilSpec extends Specification {
     accountCredentialsProvider.getCredentials(kubernetesAccount) >> accountCredentials
     accountCredentials.getCredentials() >> credentials
     credentials.getOmitNamespaces() >> omitNamespaces
-    credentials.getDeclaredNamespaces() >> namespaces
+    credentials.namespaces >> namespaces
     manifest.getNamespace() >> testNamespace
     manifest.getKind() >> kind
     credentials.isValidKind(kind) >> true
@@ -79,7 +79,7 @@ class KubernetesValidationUtilSpec extends Specification {
 
     then:
     credentials.getOmitNamespaces() >> toImmutableList(omitNamespaces)
-    credentials.getDeclaredNamespaces() >> toImmutableList(namespaces)
+    credentials.namespaces >> toImmutableList(namespaces)
     judgement == allowedNamespace
 
     where:


### PR DESCRIPTION
Reverting this because it causes a new namespace deployment to fail. Ideally, we address both use-cases in a future PR but reverting for now.