### PR TITLE
fix(gce) : duplication of firewall rules when using shared vpc network

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
@@ -206,12 +206,15 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
       List<Firewall> firewalls = timeExecute(compute.firewalls().list(project),
                                              "compute.firewalls.list", TAG_SCOPE, SCOPE_GLOBAL).items as List
 
-      if (xpnHostProject) {
+  /*    if (xpnHostProject) {
         List<Firewall> hostFirewalls = timeExecute(compute.firewalls().list(xpnHostProject),
                                                    "compute.firewalls.list", TAG_SCOPE, SCOPE_GLOBAL).items as List
 
         firewalls = (firewalls ?: []) + (hostFirewalls ?: [])
-      }
+      }   */
+      // to remove duplication of securityGroups firewalls of host project are not added
+
+      firewalls = (firewalls ?: [])
 
       return firewalls
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
@@ -206,16 +206,6 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
       List<Firewall> firewalls = timeExecute(compute.firewalls().list(project),
                                              "compute.firewalls.list", TAG_SCOPE, SCOPE_GLOBAL).items as List
 
-  /*    if (xpnHostProject) {
-        List<Firewall> hostFirewalls = timeExecute(compute.firewalls().list(xpnHostProject),
-                                                   "compute.firewalls.list", TAG_SCOPE, SCOPE_GLOBAL).items as List
-
-        firewalls = (firewalls ?: []) + (hostFirewalls ?: [])
-      }   */
-      // to remove duplication of securityGroups firewalls of host project are not added
-
-      firewalls = (firewalls ?: [])
-
       return firewalls
     }
   }


### PR DESCRIPTION
The code change is to address the issue of duplication of securityGroups  when using a SharedVPC network [#4373](https://github.com/spinnaker/spinnaker/issues/4373)

In case of using a Shared VPC Network the firewall rules of service project are adding the firewalls of host project because of which there is duplication of securityGroups

With this modification only the firewalls of existing project will be populated and resolves the issue 

