### PR TITLE
fix(cloudfoundry): Avoid NPE when no instances are present.

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServerGroup.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServerGroup.java
@@ -45,7 +45,7 @@ import lombok.experimental.Wither;
 @EqualsAndHashCode(of = "id", callSuper = false)
 @Builder(toBuilder = true)
 @JsonDeserialize(builder = CloudFoundryServerGroup.CloudFoundryServerGroupBuilder.class)
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties("loadBalancerNames")
 public class CloudFoundryServerGroup extends CloudFoundryModel implements ServerGroup {
   private static final ObjectMapper IMAGE_MAPPER = new ObjectMapper();
@@ -99,6 +99,7 @@ public class CloudFoundryServerGroup extends CloudFoundryModel implements Server
   Map<String, Object> env;
 
   @Wither
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
   @JsonView(Views.Cache.class)
   List<CloudFoundryServiceInstance> serviceInstances;
 
@@ -116,12 +117,18 @@ public class CloudFoundryServerGroup extends CloudFoundryModel implements Server
   Set<CloudFoundryInstance> instances;
 
   @Wither
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
   @JsonView(Views.Relationship.class)
   Set<String> loadBalancerNames;
 
   @Override
   public Set<String> getLoadBalancers() {
     return loadBalancerNames == null ? emptySet() : loadBalancerNames;
+  }
+
+  @Override
+  public Set<CloudFoundryInstance> getInstances() {
+    return instances == null ? emptySet() : instances;
   }
 
   @Override

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepositoryTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepositoryTest.java
@@ -78,14 +78,42 @@ class CacheRepositoryTest {
                     .build())
             .build();
 
+    CloudFoundryServerGroup serverGroupWithoutInstances =
+      CloudFoundryServerGroup.builder()
+        .name("demo-staging-v001")
+        .account("devaccount")
+        .createdTime(1L)
+        .space(CloudFoundrySpace.fromRegion("myorg > staging"))
+        .droplet(
+          CloudFoundryDroplet.builder()
+            .id("dropletid")
+            .name("dropletname")
+            .buildpacks(
+              singletonList(
+                CloudFoundryBuildpack.builder().buildpackName("java").build()))
+            .sourcePackage(CloudFoundryPackage.builder().checksum("check").build())
+            .build())
+        .build();
+
     CloudFoundryCluster cluster =
         CloudFoundryCluster.builder()
             .accountName("devaccount")
             .name("demo-dev")
             .serverGroups(singleton(serverGroup))
             .build();
+
+    CloudFoundryCluster clusterWithoutInstances =
+      CloudFoundryCluster.builder()
+        .accountName("devaccount")
+        .name("demo-staging")
+        .serverGroups(singleton(serverGroupWithoutInstances))
+        .build();
+
     CloudFoundryApplication app =
         CloudFoundryApplication.builder().name("demo").clusters(singleton(cluster)).build();
+
+    CloudFoundryApplication appWithoutInstances =
+      CloudFoundryApplication.builder().name("demo-without-instances").clusters(singleton(clusterWithoutInstances)).build();
 
     CloudFoundryClient client = mock(CloudFoundryClient.class);
     Applications apps = mock(Applications.class);
@@ -95,7 +123,7 @@ class CacheRepositoryTest {
 
     when(client.getApplications()).thenReturn(apps);
     when(client.getRoutes()).thenReturn(routes);
-    when(apps.all(emptyList())).thenReturn(singletonList(app));
+    when(apps.all(emptyList())).thenReturn(List.of(app, appWithoutInstances));
     when(routes.all(emptyList())).thenReturn(emptyList());
     when(providerCache.filterIdentifiers(any(), any())).thenReturn(emptyList());
     when(providerCache.getAll(any(), anyCollectionOf(String.class))).thenReturn(emptyList());
@@ -193,5 +221,18 @@ class CacheRepositoryTest {
                         assertThat(inst.getLaunchTime()).isEqualTo(1L);
                       });
             });
+  }
+
+  @Test
+  void findServerGroupWithoutInstances() {
+    assertThat(
+      repo.findServerGroupByKey(
+        Keys.getServerGroupKey("devaccount", "demo-staging-v001", "myorg > staging"), FULL))
+      .hasValueSatisfying(
+        serverGroup -> {
+          assertThat(serverGroup.getName()).isEqualTo("demo-staging-v001");
+          assertThat(serverGroup.getInstances()).isNotNull();
+          assertThat(serverGroup.getInstances()).isEmpty();
+        });
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepositoryTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepositoryTest.java
@@ -79,21 +79,21 @@ class CacheRepositoryTest {
             .build();
 
     CloudFoundryServerGroup serverGroupWithoutInstances =
-      CloudFoundryServerGroup.builder()
-        .name("demo-staging-v001")
-        .account("devaccount")
-        .createdTime(1L)
-        .space(CloudFoundrySpace.fromRegion("myorg > staging"))
-        .droplet(
-          CloudFoundryDroplet.builder()
-            .id("dropletid")
-            .name("dropletname")
-            .buildpacks(
-              singletonList(
-                CloudFoundryBuildpack.builder().buildpackName("java").build()))
-            .sourcePackage(CloudFoundryPackage.builder().checksum("check").build())
-            .build())
-        .build();
+        CloudFoundryServerGroup.builder()
+            .name("demo-staging-v001")
+            .account("devaccount")
+            .createdTime(1L)
+            .space(CloudFoundrySpace.fromRegion("myorg > staging"))
+            .droplet(
+                CloudFoundryDroplet.builder()
+                    .id("dropletid")
+                    .name("dropletname")
+                    .buildpacks(
+                        singletonList(
+                            CloudFoundryBuildpack.builder().buildpackName("java").build()))
+                    .sourcePackage(CloudFoundryPackage.builder().checksum("check").build())
+                    .build())
+            .build();
 
     CloudFoundryCluster cluster =
         CloudFoundryCluster.builder()
@@ -103,17 +103,20 @@ class CacheRepositoryTest {
             .build();
 
     CloudFoundryCluster clusterWithoutInstances =
-      CloudFoundryCluster.builder()
-        .accountName("devaccount")
-        .name("demo-staging")
-        .serverGroups(singleton(serverGroupWithoutInstances))
-        .build();
+        CloudFoundryCluster.builder()
+            .accountName("devaccount")
+            .name("demo-staging")
+            .serverGroups(singleton(serverGroupWithoutInstances))
+            .build();
 
     CloudFoundryApplication app =
         CloudFoundryApplication.builder().name("demo").clusters(singleton(cluster)).build();
 
     CloudFoundryApplication appWithoutInstances =
-      CloudFoundryApplication.builder().name("demo-without-instances").clusters(singleton(clusterWithoutInstances)).build();
+        CloudFoundryApplication.builder()
+            .name("demo-without-instances")
+            .clusters(singleton(clusterWithoutInstances))
+            .build();
 
     CloudFoundryClient client = mock(CloudFoundryClient.class);
     Applications apps = mock(Applications.class);
@@ -226,13 +229,13 @@ class CacheRepositoryTest {
   @Test
   void findServerGroupWithoutInstances() {
     assertThat(
-      repo.findServerGroupByKey(
-        Keys.getServerGroupKey("devaccount", "demo-staging-v001", "myorg > staging"), FULL))
-      .hasValueSatisfying(
-        serverGroup -> {
-          assertThat(serverGroup.getName()).isEqualTo("demo-staging-v001");
-          assertThat(serverGroup.getInstances()).isNotNull();
-          assertThat(serverGroup.getInstances()).isEmpty();
-        });
+            repo.findServerGroupByKey(
+                Keys.getServerGroupKey("devaccount", "demo-staging-v001", "myorg > staging"), FULL))
+        .hasValueSatisfying(
+            serverGroup -> {
+              assertThat(serverGroup.getName()).isEqualTo("demo-staging-v001");
+              assertThat(serverGroup.getInstances()).isNotNull();
+              assertThat(serverGroup.getInstances()).isEmpty();
+            });
   }
 }


### PR DESCRIPTION
Avoid an NPE in orca when no instances are present

![Image 2021-10-28 at 7 28 55 PM](https://user-images.githubusercontent.com/16300174/139353964-6e791993-8cf7-451e-b058-3ba0f49e1a1a.jpg)

