### PR TITLE
fix(cloudfoundry): add timeout to converter

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
@@ -213,6 +213,7 @@ public class DeployCloudFoundryServerGroupAtomicOperationConverter
               attrs.setCommand(app.getCommand());
               attrs.setProcesses(app.getProcesses());
               attrs.setRandomRoute(app.getRandomRoute());
+              attrs.setTimeout(app.getTimeout());
               return attrs;
             })
         .get();
@@ -247,6 +248,8 @@ public class DeployCloudFoundryServerGroupAtomicOperationConverter
     @Nullable private String command;
 
     @Nullable private Boolean randomRoute;
+
+    @Nullable private Integer timeout;
 
     private List<ProcessRequest> processes = Collections.emptyList();
   }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -296,4 +296,12 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
 
     assertThat(applicationAttributes.getRandomRoute()).isTrue();
   }
+
+  @Test
+  void convertTimeout() {
+    DeployCloudFoundryServerGroupDescription.ApplicationAttributes applicationAttributes =
+        converter.convertManifest(ImmutableMap.of("applications", List.of(Map.of("timeout", 60))));
+
+    assertThat(applicationAttributes.getTimeout() == 60);
+  }
 }


### PR DESCRIPTION
Manifest attributes are unfortunately set/transferred between two different manifest attributes classes. Timeout was missing from the converter class. This code should ultimately be changed to leverage a single class for representation. 