### PR TITLE
fix(artifacts): close leaking input stream when downloading artifacts

### DIFF
--- a/clouddriver-web/src/main/java/com/netflix/spinnaker/clouddriver/controllers/ArtifactController.java
+++ b/clouddriver-web/src/main/java/com/netflix/spinnaker/clouddriver/controllers/ArtifactController.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.artifacts.ArtifactDownloader;
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.exceptions.MissingCredentialsException;
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -64,7 +65,11 @@ public class ArtifactController {
           "Artifacts have not been enabled. Enable them using 'artifacts.enabled' in clouddriver");
     }
 
-    return outputStream -> IOUtils.copy(artifactDownloader.download(artifact), outputStream);
+    return outputStream -> {
+      try (InputStream artifactStream = artifactDownloader.download(artifact)) {
+        IOUtils.copy(artifactStream, outputStream);
+      }
+    };
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/account/{accountName}/names")


### PR DESCRIPTION
At least for s3, this can lead to connection pool exhaustion.  See https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/S3Object.html#getObjectContent-- which says:

> If you retrieve an S3Object, you should close this input stream as soon as possible, because the object contents aren't buffered in memory and stream directly from Amazon S3. Further, failure to close this stream can cause the request pool to become blocked.