### PR TITLE
fix(cloudfoundry): skip API calls for apps that won't be cached

### DIFF
--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ApplicationsTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ApplicationsTest.java
@@ -197,11 +197,12 @@ class ApplicationsTest {
 
   @Test
   void allDoesNotSkipVersionedAppWhenOnlySpinnakerManagedTrue() {
+    String guid = "guid";
     Application application =
         new Application()
             .setCreatedAt(ZonedDateTime.now())
             .setUpdatedAt(ZonedDateTime.now())
-            .setGuid("guid")
+            .setGuid(guid)
             .setName("my-app-v000")
             .setState("STARTED")
             .setLinks(
@@ -226,11 +227,12 @@ class ApplicationsTest {
 
   @Test
   void allSkipsUnversionedAppWhenOnlySpinnakerManagedTrue() {
+    String guid = "guid";
     Application application =
         new Application()
             .setCreatedAt(ZonedDateTime.now())
             .setUpdatedAt(ZonedDateTime.now())
-            .setGuid("guid")
+            .setGuid(guid)
             .setName("my-app")
             .setState("STARTED")
             .setLinks(
@@ -245,12 +247,19 @@ class ApplicationsTest {
     when(applicationService.all(any(), any(), any(), any()))
         .thenReturn(Calls.response(Response.success(applicationPagination)));
     when(applicationService.findById(anyString())).thenReturn(Calls.response(application));
-    mockMap(cloudFoundrySpace, "droplet-guid");
 
     List<CloudFoundryApplication> result = apps.all(List.of(spaceId));
     assertThat(result.size()).isEqualTo(0);
 
     verify(applicationService).all(null, resultsPerPage, null, spaceId);
+
+    // these methods should never be called if the app is skipped
+    verify(applicationService, never()).findApplicationEnvById(guid);
+    verify(spaces, never()).findById(guid);
+    verify(processesService, never()).findProcessById(guid);
+    verify(applicationService, never()).instances(guid);
+    verify(applicationService, never()).findPackagesByAppId(guid);
+    verify(applicationService, never()).findDropletByApplicationGuid(guid);
   }
 
   @Test


### PR DESCRIPTION
Moving the "should cache" checks prior to the call to map so that unnecessary API calls aren't made for apps that won't be cached anyway.
