### PR TITLE
fix(titus): Removing reference to bintray repo

### DIFF
--- a/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver-titus/clouddriver-titus.gradle
@@ -5,10 +5,6 @@ ext {
   grpcVersion = '1.37.1'
 }
 
-repositories {
-  maven { url 'https://dl.bintray.com/netflixoss' }
-}
-
 dependencies {
   protobuf 'com.netflix.titus:titus-api-definitions:0.0.1-rc71'
 


### PR DESCRIPTION
```
Execution failed for task ':clouddriver-titus:extractIncludeProto'.
> Could not resolve all files for configuration ':clouddriver-titus:compileProtoPath'.
   > Could not resolve com.google.protobuf:protobuf-java:[3.2.0,).
     Required by:
         project :clouddriver-titus
      > Failed to list versions for com.google.protobuf:protobuf-java.
         > Unable to load Maven meta-data from https://dl.bintray.com/netflixoss/com/google/protobuf/protobuf-java/maven-metadata.xml.
            > Could not get resource 'https://dl.bintray.com/netflixoss/com/google/protobuf/protobuf-java/maven-metadata.xml'.
               > Could not GET 'https://dl.bintray.com/netflixoss/com/google/protobuf/protobuf-java/maven-metadata.xml'. Received status code 502 from server: Bad Gateway
```