### PR TITLE
fix(elasticsearch): Unpinning elasticsearch package and removing deprecated Elasticsearch transport and Jest library

### DIFF
--- a/clouddriver-elasticsearch/clouddriver-elasticsearch.gradle
+++ b/clouddriver-elasticsearch/clouddriver-elasticsearch.gradle
@@ -4,10 +4,12 @@ dependencies {
   implementation project(":clouddriver-security")
 
   implementation "com.netflix.frigga:frigga"
+  implementation "io.searchbox:jest:6.3.1"
   implementation "io.spinnaker.kork:kork-exceptions"
   implementation "io.spinnaker.kork:kork-security"
   implementation "com.squareup.retrofit:retrofit"
   implementation "org.codehaus.groovy:groovy-all"
+  implementation "org.elasticsearch:elasticsearch"
   implementation "org.springframework.boot:spring-boot-starter-web"
 
   testImplementation "org.testcontainers:elasticsearch"
@@ -17,13 +19,4 @@ dependencies {
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
 
-  //TODO(jonsie): Determine why this is necessary to extend and build clouddriver so we can
-  // use the version constraints that were introduced in this PR:
-  // https://github.com/spinnaker/clouddriver/pull/4826
-  implementation("org.elasticsearch:elasticsearch:6.8.6") {
-    force = true
-  }
-  implementation("io.searchbox:jest:6.3.1") {
-    force = true
-  }
 }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
@@ -20,11 +20,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.security.config.SecurityConfig
 import com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder
 import com.netflix.spinnaker.kork.configserver.ConfigServerBootstrap
-import org.springframework.boot.actuate.autoconfigure.elasticsearch.ElasticSearchJestHealthContributorAutoConfiguration
+import org.springframework.boot.actuate.autoconfigure.elasticsearch.ElasticSearchRestHealthContributorAutoConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
-import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchAutoConfiguration
-import org.springframework.boot.autoconfigure.elasticsearch.jest.JestAutoConfiguration
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
 import org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
@@ -55,9 +54,8 @@ import java.security.Security
   GroovyTemplateAutoConfiguration,
   GsonAutoConfiguration,
   DataSourceAutoConfiguration,
-  ElasticsearchAutoConfiguration,
-  ElasticSearchJestHealthContributorAutoConfiguration,
-  JestAutoConfiguration
+  ElasticsearchDataAutoConfiguration,
+  ElasticSearchRestHealthContributorAutoConfiguration
 ])
 @EnableScheduling
 class Main extends SpringBootServletInitializer {


### PR DESCRIPTION
In Spring Boot 2.3, native elasticsearch transport has been removed as both elasticsearch and spring data won’t support in upcoming releases. Support for the Jest library has also been removed. Please refer https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.3-Release-Notes

This fix is required for upgrade activity of spring boot from 2.2.x to 2.3.x
