### PR TITLE
fix(clouddriver-sql): add missing com.fasterxml.jackson.core:jackson-annotations and com.fasterxml.jackson.core:jackson-databind dependencies

### DIFF
--- a/clouddriver-sql/clouddriver-sql.gradle
+++ b/clouddriver-sql/clouddriver-sql.gradle
@@ -29,6 +29,8 @@ dependencies {
   implementation "de.huxhorn.sulky:de.huxhorn.sulky.ulid"
   implementation "org.jooq:jooq"
   implementation "org.hibernate.validator:hibernate-validator"
+  implementation "com.fasterxml.jackson.core:jackson-annotations"
+  implementation "com.fasterxml.jackson.core:jackson-databind"
 
   testImplementation project(":clouddriver-core-tck")
 


### PR DESCRIPTION
When we are using spring boot 2.2.x (existing kork) we did not face below error, and as we move for spring boot 2.3.x we face error as given below:
```
> Task :clouddriver-sql:compileKotlin FAILED
e: /clouddriver/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt: (18, 30): Unresolved reference: databind
e: /clouddriver/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt: (40, 23): Unresolved reference: ObjectMapper
e: /clouddriver/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskMapper.kt: (18, 30): Unresolved reference: core
e: /clouddriver/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskMapper.kt: (19, 30): Unresolved reference: databind
e: /clouddriver/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskMapper.kt: (32, 23): Unresolved reference: ObjectMapper
e: /clouddriver/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskMapper.kt: (38, 42): Unresolved reference: TypeReference
```
After introducing explicit implementation of **com.fasterxml.jackson.core:jackson-annotations** and **com.fasterxml.jackson.core:jackson-databind** in clouddriver-sql.gradle, build got success.
