### PR TITLE
feat(artifacts/bitbuket): add token auth credentials support

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactAccount.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.artifacts.bitbucket;
 import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
 import com.netflix.spinnaker.clouddriver.artifacts.config.BasicAuth;
+import com.netflix.spinnaker.clouddriver.artifacts.config.TokenAuth;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import java.util.Optional;
 import javax.annotation.ParametersAreNullableByDefault;
@@ -29,20 +30,35 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 @NonnullByDefault
 @Value
-public class BitbucketArtifactAccount implements ArtifactAccount, BasicAuth {
-  private final String name;
-  private final Optional<String> username;
-  private final Optional<String> password;
-  private final Optional<String> usernamePasswordFile;
+public class BitbucketArtifactAccount implements ArtifactAccount, BasicAuth, TokenAuth {
+  String name;
+  Optional<String> username;
+  Optional<String> password;
+  Optional<String> usernamePasswordFile;
+  Optional<String> token;
+  Optional<String> tokenFile;
 
   @Builder
   @ConstructorBinding
   @ParametersAreNullableByDefault
   BitbucketArtifactAccount(
-      String name, String username, String password, String usernamePasswordFile) {
+      String name,
+      String username,
+      String password,
+      String usernamePasswordFile,
+      String token,
+      String tokenFile) {
     this.name = Strings.nullToEmpty(name);
     this.username = Optional.ofNullable(Strings.emptyToNull(username));
     this.password = Optional.ofNullable(Strings.emptyToNull(password));
     this.usernamePasswordFile = Optional.ofNullable(Strings.emptyToNull(usernamePasswordFile));
+    this.token = Optional.ofNullable(Strings.emptyToNull(token));
+    this.tokenFile = Optional.ofNullable(Strings.emptyToNull(tokenFile));
+  }
+
+  @ParametersAreNullableByDefault
+  BitbucketArtifactAccount(
+      String name, String username, String password, String usernamePasswordFile) {
+    this(name, username, password, usernamePasswordFile, null, null);
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentials.java
@@ -17,11 +17,15 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.bitbucket;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
 import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
 import com.netflix.spinnaker.clouddriver.artifacts.config.SimpleHttpArtifactCredentials;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.OkHttpClient;
+import java.util.Optional;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,6 +40,18 @@ public class BitbucketArtifactCredentials
   BitbucketArtifactCredentials(BitbucketArtifactAccount account, OkHttpClient okHttpClient) {
     super(okHttpClient, account);
     this.name = account.getName();
+  }
+
+  @Override
+  protected Headers getHeaders(BitbucketArtifactAccount account) {
+    Headers.Builder headers = new Headers.Builder();
+    Optional<String> token = account.getTokenAsString();
+    if (token.isPresent()) {
+      headers.set(AUTHORIZATION, "Bearer " + token.get());
+      log.info("Loaded credentials for Bitbucket Artifact Account {}", account.getName());
+      return headers.build();
+    }
+    return super.getHeaders(account);
   }
 
   @Override


### PR DESCRIPTION
Add token auth credentials support

* Implements TokenAuth interface in BitBucketArtifactAccount
* Update on BitbucketArtifactCredentials (similar to GitHubArtifactCredentials)

When using a valid token, after invalid token was used
![Screen Shot 2022-01-10 at 11 09 14](https://user-images.githubusercontent.com/9583719/148802665-5852ebdd-7aa7-4133-bb02-a68e69503623.png)

Swap token inside tokenFile
![swap-token](https://user-images.githubusercontent.com/9583719/148806325-03357137-c648-4883-bf03-cce6c38b60cd.gif)


