### PR TITLE
docs(lambda): tags in CreateLambdaFunctionDescription is a map, not a…

### DIFF
--- a/clouddriver-lambda/README.md
+++ b/clouddriver-lambda/README.md
@@ -171,11 +171,9 @@ curl -X POST \
     "role": "arn:aws:iam::<acctno.>:role/service-role/test",
     "runtime": "python3.6",
     "timeout": "60",
-    "tags": [{
+    "tags": {
         "key":"value"
     }
-
-    ]
 }'
 ```
 
@@ -216,11 +214,9 @@ curl -X POST \
     "role": "arn:aws:iam::<acctno>:role/service-role/test",
     "runtime": "python3.6",
     "timeout": "68",
-    "tags": [{
+    "tags": {
         "key":"value"
     }
-
-    ]
 }'
 ```
 Note: I've changed the timeout from 60 to 68. Naviagate to the aws console to see


### PR DESCRIPTION
…n array

so fix the example in the docs to avoid
```
{
  "error": "Bad Request",
  "message": "Cannot deserialize instance of `java.util.LinkedHashMap<java.lang.String,java.lang.String>` out of START_ARRAY token\n at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: com.netflix.spinnaker.clouddriver.lambda.deploy.description.CreateLambdaFunctionDescription[\"tags\"])",
  "status": 400,
  "timestamp": 1641318255539
}
```