### PR TITLE
fix(cloudfoundry): Remove lombok generated getter

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
@@ -80,6 +81,8 @@ public class CloudFoundryCredentials extends AbstractAccountCredentials<CloudFou
   private final Permissions permissions;
   private final ForkJoinPool forkJoinPool;
   private final List<CloudFoundrySpace> filteredSpaces;
+
+  @Getter(AccessLevel.NONE)
   private final CloudFoundryClient cloudFoundryClient;
 
   public CloudFoundryCredentials(


### PR DESCRIPTION
The `/credentials` endpoint was failing when clouddriver had an invalid cloudfoundry account, returning a `400 - Bad Request`.  The root cause was that Lombok was generating an additional unignored getter for the cloudfoundry client field (the class already has 2 Json Ignored getters for that field), so whenever a call for expanded credentials `/credentials?expand=true` was made, jackson tried to serialize it and made expensive (and unnecessary) calls to the cloudfoundry api and caused the 400 errors if the account is invalid.

This small fix improves latency for valid accounts and removes the 400 errors for invalid accounts.

This should be backported to the latest `1.27.x` release.