### PR TITLE
feat(cf): allow disk/memory values specified in GB/MB

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -575,7 +575,7 @@ public class DeployCloudFoundryServerGroupAtomicOperation
   private String getProcessGuidByType(List<Process> processes, String type) {
     return processes.stream()
         .filter(p -> p.getType().equalsIgnoreCase(type))
-        .map(Process:getGuid)
+        .map(Process::getGuid)
         .findFirst()
         .orElseThrow(
             () -> new CloudFoundryApiException("Unable to find a process with type: " + type));

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -53,6 +53,7 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 
 @RequiredArgsConstructor
 public class DeployCloudFoundryServerGroupAtomicOperation
@@ -390,7 +391,7 @@ public class DeployCloudFoundryServerGroupAtomicOperation
     @Builder.Default private Optional<String> url = Optional.empty();
   }
 
-  @Nullable
+  @NotNull
   private File downloadPackageArtifact(DeployCloudFoundryServerGroupDescription description) {
     File file = null;
     try {
@@ -555,23 +556,26 @@ public class DeployCloudFoundryServerGroupAtomicOperation
       return null;
     } else if (StringUtils.isNumeric(size)) {
       return Integer.parseInt(size);
-    } else if (size.toLowerCase().endsWith("g")) {
-      String value = size.substring(0, size.length() - 1);
-      if (StringUtils.isNumeric(value)) return Integer.parseInt(value) * 1024;
-    } else if (size.toLowerCase().endsWith("m")) {
-      String value = size.substring(0, size.length() - 1);
-      if (StringUtils.isNumeric(value)) return Integer.parseInt(value);
+    } else {
+      size = size.toLowerCase();
+      if (size.endsWith("g") || size.endsWith("gb")) {
+        String value = size.substring(0, size.indexOf("g"));
+        if (StringUtils.isNumeric(value)) return Integer.parseInt(value) * 1024;
+      } else if (size.endsWith("m") || size.endsWith("mb")) {
+        String value = size.substring(0, size.indexOf("m"));
+        if (StringUtils.isNumeric(value)) return Integer.parseInt(value);
+      }
     }
 
     throw new IllegalArgumentException(
-        "Invalid size for application " + field + " = '" + size + "'");
+        String.format("Invalid size for application %s = '%s'", field, size));
   }
 
   // Helper method for filtering and returning a process guid by type
   private String getProcessGuidByType(List<Process> processes, String type) {
     return processes.stream()
         .filter(p -> p.getType().equalsIgnoreCase(type))
-        .map(p -> p.getGuid())
+        .map(Process:getGuid)
         .findFirst()
         .orElseThrow(
             () -> new CloudFoundryApiException("Unable to find a process with type: " + type));

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
@@ -55,7 +55,7 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
 
   private final CloudFoundryClient cloudFoundryClient = new MockCloudFoundryClient();
 
-  private DefaultTask testTask = new DefaultTask("testTask");
+  private final DefaultTask testTask = new DefaultTask("testTask");
 
   {
     TaskRepository.threadLocalTask.set(testTask);
@@ -65,7 +65,9 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
   void convertToMbHandling() {
     assertThat(convertToMb("memory", "123")).isEqualTo(123);
     assertThat(convertToMb("memory", "1G")).isEqualTo(1024);
+    assertThat(convertToMb("memory", "1GB")).isEqualTo(1024);
     assertThat(convertToMb("memory", "1M")).isEqualTo(1);
+    assertThat(convertToMb("memory", "1MB")).isEqualTo(1);
 
     assertThatThrownBy(() -> convertToMb("memory", "abc"))
         .isInstanceOf(IllegalArgumentException.class);
@@ -90,7 +92,7 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
     final DeploymentResult result = operation.operate(Lists.emptyList());
 
     // Then
-    verifyInOrder(apps, serviceInstances, processes, () -> atLeastOnce());
+    verifyInOrder(apps, serviceInstances, processes, Mockito::atLeastOnce);
 
     assertThat(testTask.getStatus().isFailed()).isFalse();
     assertThat(result.getServerGroupNames())
@@ -114,7 +116,7 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
     final DeploymentResult result = operation.operate(Lists.emptyList());
 
     // Then
-    verifyInOrderDockerDeploy(apps, serviceInstances, processes, () -> atLeastOnce());
+    verifyInOrderDockerDeploy(apps, serviceInstances, processes, Mockito::atLeastOnce);
 
     assertThat(testTask.getStatus().isFailed()).isFalse();
     assertThat(result.getServerGroupNames())
@@ -169,7 +171,7 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
     final DeploymentResult result = operation.operate(Lists.emptyList());
 
     // Then
-    verifyInOrder(apps, serviceInstances, processes, () -> never());
+    verifyInOrder(apps, serviceInstances, processes, Mockito::never);
 
     assertThat(testTask.getStatus().isFailed()).isFalse();
     assertThat(result.getServerGroupNames())
@@ -220,8 +222,7 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
   }
 
   private Processes getProcesses() {
-    final Processes processes = cloudFoundryClient.getProcesses();
-    return processes;
+    return cloudFoundryClient.getProcesses();
   }
 
   private List<Resource<? extends AbstractServiceInstance>> createServiceInstanceResource() {


### PR DESCRIPTION
Cloud Foundry [allows memory/disk size to be specified](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#memory) as `G`, `GB`, `M` or `MB`, but Spinnaker currently only handles `G` or `M`. This PR adds support for `GB` and `MB`.