### PR TITLE
fix(core): improve robustness of account API

### DIFF
--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionService.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionService.java
@@ -111,13 +111,13 @@ public class AccountDefinitionService {
       CredentialsDefinition definition, AccountAction action) {
     var credentials =
         objectMapper.convertValue(definition, new TypeReference<Map<String, Object>>() {});
+    var permission =
+        permissionEvaluator.getPermission(AuthenticatedRequest.getSpinnakerUser().orElseThrow());
+    if (permission.isAdmin()) {
+      return;
+    }
     var userRoles =
-        AuthenticatedRequest.getSpinnakerUser()
-            .map(permissionEvaluator::getPermission)
-            .map(
-                view ->
-                    view.getRoles().stream().map(Role.View::getName).collect(Collectors.toSet()))
-            .orElseGet(Set::of);
+        permission.getRoles().stream().map(Role.View::getName).collect(Collectors.toSet());
     var permissions = (Map<String, List<String>>) credentials.getOrDefault("permissions", Map.of());
     var writeRoles = Set.copyOf(permissions.getOrDefault("WRITE", List.of()));
     if (Sets.intersection(userRoles, writeRoles).isEmpty()) {

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionService.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionService.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.security;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Role;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PostFilter;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+/**
+ * Service wrapper for an {@link AccountDefinitionRepository} which enforces permissions and other
+ * validations.
+ */
+@Alpha
+@NonnullByDefault
+@RequiredArgsConstructor
+public class AccountDefinitionService {
+  private final AccountDefinitionRepository repository;
+  private final AccountCredentialsProvider accountCredentialsProvider;
+  private final FiatPermissionEvaluator permissionEvaluator;
+  private final ObjectMapper objectMapper;
+
+  /**
+   * Lists accounts by type that the current user has {@link Authorization#WRITE} access. Users who
+   * only have {@link Authorization#READ} access can only view related items like load balancers,
+   * clusters, security groups, etc., that use the account, but they may not directly use or view
+   * account definitions and credentials.
+   *
+   * @see AccountDefinitionRepository#listByType(String, int, String)
+   */
+  @PostFilter("hasPermission(filterObject.name, 'ACCOUNT', 'WRITE')")
+  public List<? extends CredentialsDefinition> listAccountDefinitionsByType(
+      String accountType, int limit, @Nullable String startingAccountName) {
+    return repository.listByType(accountType, limit, startingAccountName);
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  public CredentialsDefinition createAccount(CredentialsDefinition definition) {
+    String name = definition.getName();
+    if (accountCredentialsProvider.getCredentials(name) != null) {
+      throw new InvalidRequestException(
+          String.format("Cannot create duplicate account (name: %s)", name));
+    }
+    validateAccountWritePermissions(definition, AccountAction.CREATE);
+    repository.create(definition);
+    return definition;
+  }
+
+  @PreAuthorize("hasPermission(#definition.name, 'ACCOUNT', 'WRITE')")
+  public CredentialsDefinition updateAccount(CredentialsDefinition definition) {
+    if (accountCredentialsProvider.getCredentials(definition.getName()) == null) {
+      throw new InvalidRequestException(
+          String.format(
+              "Cannot update an account which does not exist (name: %s)", definition.getName()));
+    }
+    validateAccountWritePermissions(definition, AccountAction.UPDATE);
+    repository.update(definition);
+    return definition;
+  }
+
+  @PreAuthorize("hasPermission(#accountName, 'ACCOUNT', 'WRITE')")
+  public void deleteAccount(String accountName) {
+    if (accountCredentialsProvider.getCredentials(accountName) == null) {
+      throw new InvalidRequestException(
+          String.format("Cannot delete an account which does not exist (name: %s)", accountName));
+    }
+    repository.delete(accountName);
+  }
+
+  /**
+   * Deletes an account by name if the current user has {@link Authorization#WRITE} access to the
+   * given account.
+   */
+  @PreAuthorize("hasPermission(#accountName, 'ACCOUNT', 'WRITE')")
+  public List<AccountDefinitionRepository.Revision> getAccountHistory(String accountName) {
+    return repository.revisionHistory(accountName);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void validateAccountWritePermissions(
+      CredentialsDefinition definition, AccountAction action) {
+    var credentials =
+        objectMapper.convertValue(definition, new TypeReference<Map<String, Object>>() {});
+    var userRoles =
+        AuthenticatedRequest.getSpinnakerUser()
+            .map(permissionEvaluator::getPermission)
+            .map(
+                view ->
+                    view.getRoles().stream().map(Role.View::getName).collect(Collectors.toSet()))
+            .orElseGet(Set::of);
+    var permissions = (Map<String, List<String>>) credentials.getOrDefault("permissions", Map.of());
+    var writeRoles = Set.copyOf(permissions.getOrDefault("WRITE", List.of()));
+    if (Sets.intersection(userRoles, writeRoles).isEmpty()) {
+      throw new InvalidRequestException(
+          String.format(
+              "Cannot %s account without specifying WRITE permissions for current user (name: %s)",
+              action.name().toLowerCase(Locale.ROOT), definition.getName()));
+    }
+  }
+
+  private enum AccountAction {
+    CREATE,
+    UPDATE
+  }
+}

--- a/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionServiceTest.java
+++ b/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionServiceTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.netflix.spinnaker.clouddriver.config.AccountDefinitionConfiguration;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.fiat.model.resources.Role;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
+import io.spinnaker.test.security.TestAccount;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(
+    classes = {AccountDefinitionServiceTest.Config.class, AccountDefinitionConfiguration.class})
+@TestPropertySource(
+    properties = {
+      "account.storage.additionalScanPackages = io.spinnaker.test.security",
+      "account.storage.enabled = true"
+    })
+@ImportAutoConfiguration(JacksonAutoConfiguration.class)
+@ComponentScan("com.netflix.spinnaker.kork.secrets")
+class AccountDefinitionServiceTest {
+
+  @MockBean FiatPermissionEvaluator permissionEvaluator;
+
+  @Autowired AccountDefinitionService service;
+
+  @Autowired AccountDefinitionRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    given(
+            permissionEvaluator.hasPermission(
+                any(Authentication.class), any(Serializable.class), eq("ACCOUNT"), eq("WRITE")))
+        .willReturn(true);
+    var userPermissions = new UserPermission();
+    userPermissions.addResource(new Role("dev"));
+    given(permissionEvaluator.getPermission(eq("diane"))).willReturn(userPermissions.getView());
+    var userDetails =
+        User.withUsername("diane").password("hunter2").authorities("authenticated").build();
+    var user =
+        new TestingAuthenticationToken(
+            userDetails, userDetails.getPassword(), new ArrayList<>(userDetails.getAuthorities()));
+    SecurityContextHolder.getContext().setAuthentication(user);
+  }
+
+  @Test
+  void smokeTest() {
+    var account = new TestAccount();
+    account.setData("name", "roger");
+    account.setData("password", "vector");
+    account.getPermissions().add(Authorization.WRITE, List.of("sre", "dev"));
+    account.getPermissions().add(Authorization.READ, List.of("sre", "dev"));
+    service.createAccount(account);
+    List<? extends CredentialsDefinition> results =
+        service.listAccountDefinitionsByType("test", 1, null);
+    assertThat(results).hasSize(1);
+    CredentialsDefinition result = results.get(0);
+    assertThat(result).isNotNull().isInstanceOf(TestAccount.class);
+    assertThat(((TestAccount) result).getData().get("password")).isEqualTo("vector");
+  }
+
+  @Configuration
+  static class Config {
+    @Bean
+    AccountDefinitionRepository accountDefinitionRepository() {
+      return new InMemoryAccountDefinitionRepository();
+    }
+
+    @Bean
+    AccountCredentialsProvider accountCredentialsProvider() {
+      return new DefaultAccountCredentialsProvider();
+    }
+  }
+}

--- a/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/security/InMemoryAccountDefinitionRepository.java
+++ b/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/security/InMemoryAccountDefinitionRepository.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.security;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.Nullable;
+
+@NonnullByDefault
+public class InMemoryAccountDefinitionRepository implements AccountDefinitionRepository {
+  private final Map<String, CredentialsDefinition> accounts = new ConcurrentHashMap<>();
+
+  @Nullable
+  @Override
+  public CredentialsDefinition getByName(String name) {
+    return accounts.get(name);
+  }
+
+  @Override
+  public List<? extends CredentialsDefinition> listByType(
+      String typeName, int limit, @Nullable String startingAccountName) {
+    return accounts.values().stream()
+        .filter(
+            definition ->
+                typeName.equals(AccountDefinitionMapper.getJsonTypeName(definition.getClass())))
+        .sorted(Comparator.comparing(CredentialsDefinition::getName))
+        .filter(
+            definition ->
+                startingAccountName == null
+                    || startingAccountName.compareTo(definition.getName()) >= 0)
+        .limit(limit)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<? extends CredentialsDefinition> listByType(String typeName) {
+    return accounts.values().stream()
+        .filter(
+            definition ->
+                typeName.equals(AccountDefinitionMapper.getJsonTypeName(definition.getClass())))
+        .sorted(Comparator.comparing(CredentialsDefinition::getName))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public void create(CredentialsDefinition definition) {
+    accounts.putIfAbsent(definition.getName(), definition);
+  }
+
+  @Override
+  public void update(CredentialsDefinition definition) {
+    accounts.put(definition.getName(), definition);
+  }
+
+  @Override
+  public void delete(String name) {
+    accounts.remove(name);
+  }
+
+  @Override
+  public List<Revision> revisionHistory(String name) {
+    return List.of();
+  }
+}


### PR DESCRIPTION
This smooths out some rough edges discovered in the alpha version of the
Account Management API. In particular, this addresses a few concerns:
- Ignore class loading errors during classpath scan for supported
  CredentialsDefinition types. While these exceptions are purely
  theoretical using the existing Spring-provided class, this isn't
  always guaranteed to work via reflection.
- Ensure created and updated credentials contain appropriate permissions
  to prevent locking out the user making the API call.
- Catch exceptions thrown by secrets decryption when loading accounts.
  This prevents Clouddriver from crashing due to user error or service
  outages in the underlying secrets manager.
- Fix version used for newly created accounts when that account name had
  a previous history (e.g., deleting an account and recreating it).
- Extracts credentials controller logic into a service class.

Related to https://github.com/spinnaker/spinnaker/issues/6525 and https://github.com/spinnaker/gate/pull/1514