### PR TITLE
feat(cf): filter out non-Spinnaker environment variables from caching

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -421,6 +421,13 @@ public class Applications {
             ? emptyMap()
             : applicationEnv.getEnvironmentJson();
 
+    // filter out environment variables that aren't Spinnaker metadata
+    // as these could contain secrets
+    environmentVars =
+        environmentVars.entrySet().stream()
+            .filter(e -> ServerGroupMetaDataEnvVar.contains(e.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
     final CloudFoundryBuildInfo buildInfo = getBuildInfoFromEnvVars(environmentVars);
     final ArtifactInfo artifactInfo = getArtifactInfoFromEnvVars(environmentVars);
     final String pipelineId =

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServerGroup.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServerGroup.java
@@ -39,7 +39,7 @@ import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import lombok.experimental.Wither;
+import lombok.With;
 
 @Value
 @EqualsAndHashCode(of = "id", callSuper = false)
@@ -77,11 +77,11 @@ public class CloudFoundryServerGroup extends CloudFoundryModel implements Server
 
   @JsonView(Views.Cache.class)
   @Nullable
-  private String healthCheckType;
+  String healthCheckType;
 
   @JsonView(Views.Cache.class)
   @Nullable
-  private String healthCheckHttpEndpoint;
+  String healthCheckHttpEndpoint;
 
   @JsonView(Views.Cache.class)
   State state;
@@ -98,7 +98,7 @@ public class CloudFoundryServerGroup extends CloudFoundryModel implements Server
   @JsonView(Views.Cache.class)
   Map<String, Object> env;
 
-  @Wither
+  @With
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   @JsonView(Views.Cache.class)
   List<CloudFoundryServiceInstance> serviceInstances;
@@ -112,11 +112,11 @@ public class CloudFoundryServerGroup extends CloudFoundryModel implements Server
   @JsonView(Views.Cache.class)
   String pipelineId;
 
-  @Wither
+  @With
   @JsonView(Views.Relationship.class)
   Set<CloudFoundryInstance> instances;
 
-  @Wither
+  @With
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   @JsonView(Views.Relationship.class)
   Set<String> loadBalancerNames;
@@ -155,7 +155,7 @@ public class CloudFoundryServerGroup extends CloudFoundryModel implements Server
 
               @Override
               public Map<String, Object> getImage() {
-                return IMAGE_MAPPER.convertValue(this, new TypeReference<Map<String, Object>>() {});
+                return IMAGE_MAPPER.convertValue(this, new TypeReference<>() {});
               }
 
               @Override
@@ -242,7 +242,6 @@ public class CloudFoundryServerGroup extends CloudFoundryModel implements Server
     return Names.parseName(name).getDetail();
   }
 
-  @SuppressWarnings("unchecked")
   public Moniker getMoniker() {
     Moniker moniker = NamerRegistry.getDefaultNamer().deriveMoniker(this);
     return new Moniker(

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/ServerGroupMetaDataEnvVar.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/ServerGroupMetaDataEnvVar.java
@@ -31,4 +31,13 @@ public enum ServerGroupMetaDataEnvVar {
   ServerGroupMetaDataEnvVar(String envVarName) {
     this.envVarName = envVarName;
   }
+
+  public static boolean contains(String envVar) {
+    for (ServerGroupMetaDataEnvVar v : values()) {
+      if (v.envVarName.equals(envVar)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
Spinnaker currently caches all user provided environment variables on an application and displays them in Deck. This is a problem because people often provide secrets as environment variables, which are then displayed in Deck.

This PR filters the environment variables Spinnaker caches to only the metadata ones that Spinnaker sets itself (pipeline execution ID, artifact info etc).

The changes in `CloudFoundryServerGroup` are just cleanup when I opened the file, replacing deprecated annotations etc.