### PR TITLE
feat(kube/ext): Make KubernetesCredentials and KubectlJobExecutor extensible

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -72,7 +72,7 @@ public class KubectlJobExecutor {
   private final Optional<RetryRegistry> retryRegistry;
 
   @Autowired
-  KubectlJobExecutor(
+  public KubectlJobExecutor(
       JobExecutor jobExecutor,
       @Value("${kubernetes.kubectl.executable:kubectl}") String executable,
       @Value("${kubernetes.o-auth.executable:oauth2l}") String oAuthExecutable,

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -141,7 +141,7 @@ public class KubernetesCredentials {
           this::namespaceSupplier, NAMESPACE_EXPIRY_SECONDS, TimeUnit.SECONDS);
   @Getter private final Namer<KubernetesManifest> namer;
 
-  private KubernetesCredentials(
+  public KubernetesCredentials(
       Registry registry,
       KubectlJobExecutor jobExecutor,
       ManagedAccount managedAccount,


### PR DESCRIPTION
These classes (specially `KubernetesCredentials`) cannot be extended in plugins and contain a lot of logic. Allowing them to be extended will make it possible for users to change the behavior of the kubernetes provider using plugins.
