### PR TITLE
feat(kube/cache): Only cache spinnaker infra kube objects

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -115,6 +115,12 @@ dependencies {
   integrationImplementation "org.yaml:snakeyaml"
 }
 
+testlogger {
+  // don't show passed unit tests, it's difficult to know which ones failed among hundreds of tests
+  showPassed false
+  showPassedStandardStreams false
+}
+
 task integrationTest(type: Test) {
   description = 'Runs kubernetes provider integration tests.'
   group = 'verification'

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/CustomKubernetesCachingAgentFactory.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/CustomKubernetesCachingAgentFactory.java
@@ -28,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurati
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
-import java.util.Objects;
 
 public class CustomKubernetesCachingAgentFactory {
   public static KubernetesCachingAgent create(
@@ -53,6 +52,13 @@ public class CustomKubernetesCachingAgentFactory {
         kubernetesSpinnakerKindMap);
   }
 
+  /**
+   * Instances of this class cache kinds specified in the list
+   * "kubernetes.accounts[*].customResourceDefinitions" in config.
+   *
+   * <p>There's one instance of this class for every kind in the list, and only the kinds that are
+   * allowed by the configuration in "kubernetes.cache.*" are cached.
+   */
   private static class Agent extends KubernetesCachingAgent {
     private final KubernetesKind kind;
 
@@ -81,11 +87,6 @@ public class CustomKubernetesCachingAgentFactory {
     @Override
     protected ImmutableList<KubernetesKind> primaryKinds() {
       return ImmutableList.of(this.kind);
-    }
-
-    @Override
-    protected boolean cachesKind(KubernetesKind kind) {
-      return Objects.equals(this.kind, kind);
     }
 
     @Override

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/CustomKubernetesCachingAgentFactory.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/CustomKubernetesCachingAgentFactory.java
@@ -24,8 +24,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import java.util.Objects;
 
 public class CustomKubernetesCachingAgentFactory {
   public static KubernetesCachingAgent create(
@@ -35,7 +38,9 @@ public class CustomKubernetesCachingAgentFactory {
       Registry registry,
       int agentIndex,
       int agentCount,
-      Long agentInterval) {
+      Long agentInterval,
+      KubernetesConfigurationProperties configurationProperties,
+      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
     return new Agent(
         kind,
         namedAccountCredentials,
@@ -43,7 +48,9 @@ public class CustomKubernetesCachingAgentFactory {
         registry,
         agentIndex,
         agentCount,
-        agentInterval);
+        agentInterval,
+        configurationProperties,
+        kubernetesSpinnakerKindMap);
   }
 
   private static class Agent extends KubernetesCachingAgent {
@@ -56,14 +63,29 @@ public class CustomKubernetesCachingAgentFactory {
         Registry registry,
         int agentIndex,
         int agentCount,
-        Long agentInterval) {
-      super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount, agentInterval);
+        Long agentInterval,
+        KubernetesConfigurationProperties configurationProperties,
+        KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
+      super(
+          namedAccountCredentials,
+          objectMapper,
+          registry,
+          agentIndex,
+          agentCount,
+          agentInterval,
+          configurationProperties,
+          kubernetesSpinnakerKindMap);
       this.kind = kind;
     }
 
     @Override
     protected ImmutableList<KubernetesKind> primaryKinds() {
       return ImmutableList.of(this.kind);
+    }
+
+    @Override
+    protected boolean cachesKind(KubernetesKind kind) {
+      return Objects.equals(this.kind, kind);
     }
 
     @Override

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgent.java
@@ -31,7 +31,10 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesCachingPolicy;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesCachingProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKindProperties;
@@ -41,11 +44,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -58,6 +57,14 @@ import org.slf4j.LoggerFactory;
 public abstract class KubernetesCachingAgent
     implements AgentIntervalAware, CachingAgent, AccountAware {
   private static final Logger log = LoggerFactory.getLogger(KubernetesCachingAgent.class);
+
+  public static final List<SpinnakerKind> SPINNAKER_UI_KINDS =
+      Arrays.asList(
+          SpinnakerKind.SERVER_GROUP_MANAGERS,
+          SpinnakerKind.SERVER_GROUPS,
+          SpinnakerKind.INSTANCES,
+          SpinnakerKind.LOAD_BALANCERS,
+          SpinnakerKind.SECURITY_GROUPS);
 
   @Getter @Nonnull protected final String accountName;
   protected final Registry registry;
@@ -72,13 +79,19 @@ public abstract class KubernetesCachingAgent
 
   @Getter protected final Long agentInterval;
 
+  protected final KubernetesConfigurationProperties configurationProperties;
+
+  protected final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
+
   protected KubernetesCachingAgent(
       KubernetesNamedAccountCredentials namedAccountCredentials,
       ObjectMapper objectMapper,
       Registry registry,
       int agentIndex,
       int agentCount,
-      Long agentInterval) {
+      Long agentInterval,
+      KubernetesConfigurationProperties configurationProperties,
+      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
     this.accountName = namedAccountCredentials.getName();
     this.credentials = namedAccountCredentials.getCredentials();
     this.objectMapper = objectMapper;
@@ -86,16 +99,66 @@ public abstract class KubernetesCachingAgent
     this.agentIndex = agentIndex;
     this.agentCount = agentCount;
     this.agentInterval = agentInterval;
+    this.configurationProperties = configurationProperties;
+    this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
   }
 
   protected Map<String, Object> defaultIntrospectionDetails() {
     Map<String, Object> result = new HashMap<>();
     result.put("namespaces", getNamespaces());
-    result.put("kinds", primaryKinds());
+    result.put("kinds", kindsToCache());
     return result;
   }
 
   protected abstract List<KubernetesKind> primaryKinds();
+
+  protected abstract boolean cachesKind(KubernetesKind kind);
+
+  protected List<KubernetesKind> kindsToCache() {
+    List<KubernetesKind> cacheKinds;
+
+    if (configurationProperties.getCache().isCacheAll()) {
+      cacheKinds = primaryKinds();
+
+    } else if (configurationProperties.getCache().getCacheKinds() != null
+        && configurationProperties.getCache().getCacheKinds().size() > 0) {
+      // If provider config specifies what kinds to cache, use it
+      cacheKinds =
+          configurationProperties.getCache().getCacheKinds().stream()
+              .map(KubernetesKind::fromString)
+              .filter(this::cachesKind)
+              .filter(credentials::isValidKind)
+              .collect(Collectors.toList());
+
+    } else {
+      // Only cache kinds used in Spinnaker's classic infrastructure screens, which are the kinds
+      // mapped to Spinnaker kinds like ServerGroups, Instances, etc.
+      cacheKinds =
+          kubernetesSpinnakerKindMap.allKubernetesKinds().stream()
+              .filter(this::cachesKind)
+              .filter(credentials::isValidKind)
+              .filter(
+                  k -> {
+                    SpinnakerKind spinnakerKind =
+                        kubernetesSpinnakerKindMap.translateKubernetesKind(k);
+                    return SPINNAKER_UI_KINDS.contains(spinnakerKind);
+                  })
+              .collect(Collectors.toList());
+    }
+
+    // Filter out explicitly omitted kinds in provider config
+    if (configurationProperties.getCache().getCacheOmitKinds() != null
+        && configurationProperties.getCache().getCacheOmitKinds().size() > 0) {
+      List<KubernetesKind> omitKinds =
+          configurationProperties.getCache().getCacheOmitKinds().stream()
+              .map(KubernetesKind::fromString)
+              .collect(Collectors.toList());
+      cacheKinds =
+          cacheKinds.stream().filter(k -> !omitKinds.contains(k)).collect(Collectors.toList());
+    }
+
+    return cacheKinds;
+  }
 
   private ImmutableList<KubernetesManifest> loadResources(
       @Nonnull Iterable<KubernetesKind> kubernetesKinds, Optional<String> optionalNamespace) {
@@ -129,7 +192,7 @@ public abstract class KubernetesCachingAgent
   }
 
   private ImmutableSetMultimap<ResourceScope, KubernetesKind> primaryKindsByScope() {
-    return primaryKinds().stream()
+    return kindsToCache().stream()
         .collect(
             ImmutableSetMultimap.toImmutableSetMultimap(
                 k -> credentials.getKindProperties(k).getResourceScope(), Function.identity()));

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcher.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcher.java
@@ -19,7 +19,9 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesResourceProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.ResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
@@ -38,11 +40,19 @@ import org.springframework.stereotype.Component;
 public class KubernetesCachingAgentDispatcher {
   private final ObjectMapper objectMapper;
   private final Registry registry;
+  private final KubernetesConfigurationProperties configurationProperties;
+  private final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
 
   @Autowired
-  public KubernetesCachingAgentDispatcher(ObjectMapper objectMapper, Registry registry) {
+  public KubernetesCachingAgentDispatcher(
+      ObjectMapper objectMapper,
+      Registry registry,
+      KubernetesConfigurationProperties configurationProperties,
+      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
     this.objectMapper = objectMapper;
     this.registry = registry;
+    this.configurationProperties = configurationProperties;
+    this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
   }
 
   public Collection<KubernetesCachingAgent> buildAllCachingAgents(
@@ -69,7 +79,9 @@ public class KubernetesCachingAgentDispatcher {
                                 registry,
                                 i,
                                 credentials.getCacheThreads(),
-                                agentInterval))
+                                agentInterval,
+                                configurationProperties,
+                                kubernetesSpinnakerKindMap))
                     .filter(Objects::nonNull)
                     .forEach(result::add));
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcher.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcher.java
@@ -25,18 +25,16 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinna
 import com.netflix.spinnaker.clouddriver.kubernetes.description.ResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class KubernetesCachingAgentDispatcher {
   private final ObjectMapper objectMapper;
   private final Registry registry;
@@ -57,6 +55,12 @@ public class KubernetesCachingAgentDispatcher {
 
   public Collection<KubernetesCachingAgent> buildAllCachingAgents(
       KubernetesNamedAccountCredentials credentials) {
+
+    if (!configurationProperties.getCache().isEnabled()) {
+      log.info("Caching is disabled by configuration ('kubernetes.cache.enabled')");
+      return Collections.emptyList();
+    }
+
     KubernetesCredentials kubernetesCredentials = credentials.getCredentials();
     List<KubernetesCachingAgent> result = new ArrayList<>();
     Long agentInterval =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentFactory.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentFactory.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 
 @FunctionalInterface
@@ -29,5 +31,7 @@ public interface KubernetesCachingAgentFactory {
       Registry registry,
       int agentIndex,
       int agentCount,
-      Long agentInterval);
+      Long agentInterval,
+      KubernetesConfigurationProperties configurationProperties,
+      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap);
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -68,6 +68,9 @@ public class KubernetesConfigurationProperties {
   @Data
   public static class Cache {
 
+    /** Whether caching is enabled in the kubernetes provider. */
+    private boolean enabled = true;
+
     /**
      * Whether to cache all kubernetes kinds or not. If this value is "true", the setting
      * "cacheKinds" is ignored.

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -33,6 +33,8 @@ public class KubernetesConfigurationProperties {
   /** flag to toggle account health check. Defaults to true. */
   private boolean verifyAccountHealth = true;
 
+  private Cache cache = new Cache();
+
   @Data
   public static class KubernetesJobExecutorProperties {
     private Retries retries = new Retries();
@@ -61,5 +63,43 @@ public class KubernetesConfigurationProperties {
       // only applicable when exponentialBackoff = true
       long exponentialBackOffIntervalMs = 10000;
     }
+  }
+
+  @Data
+  public static class Cache {
+
+    /**
+     * Whether to cache all kubernetes kinds or not. If this value is "true", the setting
+     * "cacheKinds" is ignored.
+     */
+    private boolean cacheAll = false;
+
+    /**
+     * Only cache the kubernetes kinds in this list. If not configured, only the kinds that show in
+     * Spinnaker's classic infrastructure screens are cached, which are the ones mapped to the
+     * following Spinnaker's kinds: <br>
+     * - SERVER_GROUP_MANAGERS <br>
+     * - SERVER_GROUPS <br>
+     * - INSTANCES <br>
+     * - LOAD_BALANCERS <br>
+     * - SECURITY_GROUPS
+     *
+     * <p>Names are in {kind.group} format, where the group is optional for core kinds. Example:
+     * <br>
+     * cacheKinds: <br>
+     * - deployment.apps <br>
+     * - replicaSet <br>
+     * - pod <br>
+     * - myCustomKind.my.group
+     *
+     * <p>If the setting {@link Cache#cacheAll} is true, this setting is ignored.
+     */
+    private List<String> cacheKinds = null;
+
+    /**
+     * Do not cache the kinds in this list. The format of the list is the same as {@link
+     * Cache#cacheKinds}
+     */
+    private List<String> cacheOmitKinds = null;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKind.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NonnullByDefault
@@ -111,7 +112,7 @@ public class KubernetesKind {
 
   private final String name;
   @EqualsAndHashCode.Include private final String lcName;
-  private final KubernetesApiGroup apiGroup;
+  @Getter private final KubernetesApiGroup apiGroup;
   @EqualsAndHashCode.Include @Nullable private final KubernetesApiGroup customApiGroup;
 
   private KubernetesKind(String name, @Nullable KubernetesApiGroup apiGroup) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CustomKubernetesHandlerFactory.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CustomKubernetesHandlerFactory.java
@@ -22,6 +22,8 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.CustomKubernetesCachingAgentFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgentFactory;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
@@ -94,7 +96,9 @@ public class CustomKubernetesHandlerFactory {
         Registry registry,
         int agentIndex,
         int agentCount,
-        Long agentInterval) {
+        Long agentInterval,
+        KubernetesConfigurationProperties configurationProperties,
+        KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
       return CustomKubernetesCachingAgentFactory.create(
           kubernetesKind,
           namedAccountCredentials,
@@ -102,7 +106,9 @@ public class CustomKubernetesHandlerFactory {
           registry,
           agentIndex,
           agentCount,
-          agentInterval);
+          agentInterval,
+          configurationProperties,
+          kubernetesSpinnakerKindMap);
     }
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java
@@ -29,6 +29,8 @@ import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.InfrastructureC
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgentFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.KubernetesManifestProvider;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
@@ -106,10 +108,19 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
       Registry registry,
       int agentIndex,
       int agentCount,
-      Long agentInterval) {
+      Long agentInterval,
+      KubernetesConfigurationProperties configurationProperties,
+      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
     return cachingAgentFactory()
         .buildCachingAgent(
-            namedAccountCredentials, objectMapper, registry, agentIndex, agentCount, agentInterval);
+            namedAccountCredentials,
+            objectMapper,
+            registry,
+            agentIndex,
+            agentCount,
+            agentInterval,
+            configurationProperties,
+            kubernetesSpinnakerKindMap);
   }
 
   // used for stripping sensitive values

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -260,7 +260,7 @@ public class KubernetesCredentials {
     }
   }
 
-  private boolean isValidKind(@Nonnull KubernetesKind kind) {
+  public boolean isValidKind(@Nonnull KubernetesKind kind) {
     return getKindStatus(kind) == KubernetesKindStatus.VALID;
   }
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcherTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcherTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.caching.agent;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesResourceProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.ResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesDeploymentHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+public class KubernetesCachingAgentDispatcherTest {
+
+  @Test
+  public void buildAllCachingAgentsOneThread() {
+    KubernetesCachingAgentDispatcher dispatcher =
+        new KubernetesCachingAgentDispatcher(
+            new ObjectMapper(),
+            null,
+            new KubernetesConfigurationProperties(),
+            new KubernetesSpinnakerKindMap(new ArrayList<>()));
+    KubernetesNamedAccountCredentials creds = mockCredentials(1);
+    Collection<KubernetesCachingAgent> agents = dispatcher.buildAllCachingAgents(creds);
+
+    assertNotNull(agents);
+    assertEquals(1, agents.size());
+  }
+
+  @Test
+  public void buildAllCachingAgentsTwoThreads() {
+    KubernetesCachingAgentDispatcher dispatcher =
+        new KubernetesCachingAgentDispatcher(
+            new ObjectMapper(),
+            null,
+            new KubernetesConfigurationProperties(),
+            new KubernetesSpinnakerKindMap(new ArrayList<>()));
+    KubernetesNamedAccountCredentials creds = mockCredentials(2);
+    Collection<KubernetesCachingAgent> agents = dispatcher.buildAllCachingAgents(creds);
+
+    assertNotNull(agents);
+    assertEquals(2, agents.size());
+  }
+
+  @Test
+  public void buildAllCachingAgentsCacheDisabled() {
+    KubernetesConfigurationProperties configProperties = new KubernetesConfigurationProperties();
+    configProperties.getCache().setEnabled(false);
+    KubernetesCachingAgentDispatcher dispatcher =
+        new KubernetesCachingAgentDispatcher(
+            new ObjectMapper(),
+            null,
+            configProperties,
+            new KubernetesSpinnakerKindMap(new ArrayList<>()));
+    KubernetesNamedAccountCredentials creds = mockCredentials(2);
+    Collection<KubernetesCachingAgent> agents = dispatcher.buildAllCachingAgents(creds);
+
+    assertNotNull(agents);
+    assertEquals(0, agents.size());
+  }
+
+  @NotNull
+  private KubernetesNamedAccountCredentials mockCredentials(int threads) {
+    ResourcePropertyRegistry propertyRegistry = mock(ResourcePropertyRegistry.class);
+    when(propertyRegistry.values())
+        .thenReturn(
+            ImmutableList.of(
+                new KubernetesResourceProperties(new KubernetesDeploymentHandler(), false)));
+    KubernetesCredentials credentials = mock(KubernetesCredentials.class);
+    when(credentials.getResourcePropertyRegistry()).thenReturn(propertyRegistry);
+    KubernetesNamedAccountCredentials namedCredentials =
+        mock(KubernetesNamedAccountCredentials.class);
+    when(namedCredentials.getCredentials()).thenReturn(credentials);
+    when(namedCredentials.getCacheThreads()).thenReturn(threads);
+    return namedCredentials;
+  }
+}

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
@@ -41,12 +41,14 @@ import com.netflix.spinnaker.cats.provider.DefaultProviderCache;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesAccountProperties.ManagedAccount;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.GlobalResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.ResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.*;
 import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesManifestNamer;
-import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesUnregisteredCustomResourceHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.*;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.moniker.Namer;
@@ -54,6 +56,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.stream.IntStream;
 import lombok.Value;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.runner.JUnitPlatform;
@@ -92,6 +95,15 @@ final class KubernetesCoreCachingAgentTest {
   private static final ResourcePropertyRegistry resourcePropertyRegistry =
       new GlobalResourcePropertyRegistry(
           ImmutableList.of(), new KubernetesUnregisteredCustomResourceHandler());
+  private static final ImmutableList<KubernetesHandler> handlers =
+      ImmutableList.of(
+          new KubernetesDeploymentHandler(),
+          new KubernetesReplicaSetHandler(),
+          new KubernetesServiceHandler(),
+          new KubernetesPodHandler(),
+          new KubernetesConfigMapHandler());
+  private static final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap =
+      new KubernetesSpinnakerKindMap(handlers);
   private static final Namer<KubernetesManifest> NAMER = new KubernetesManifestNamer();
 
   /** A test Deployment manifest */
@@ -154,6 +166,7 @@ final class KubernetesCoreCachingAgentTest {
                   return result.build();
                 });
     when(credentials.getNamer()).thenReturn(NAMER);
+    when(credentials.isValidKind(any(KubernetesKind.class))).thenReturn(true);
     return credentials;
   }
 
@@ -176,12 +189,21 @@ final class KubernetesCoreCachingAgentTest {
    * collection of those agents.
    */
   private static ImmutableCollection<KubernetesCoreCachingAgent> createCachingAgents(
-      KubernetesNamedAccountCredentials credentials, int agentCount) {
+      KubernetesNamedAccountCredentials credentials,
+      int agentCount,
+      KubernetesConfigurationProperties configurationProperties) {
     return IntStream.range(0, agentCount)
         .mapToObj(
             i ->
                 new KubernetesCoreCachingAgent(
-                    credentials, objectMapper, new NoopRegistry(), i, agentCount, 10L))
+                    credentials,
+                    objectMapper,
+                    new NoopRegistry(),
+                    i,
+                    agentCount,
+                    10L,
+                    configurationProperties,
+                    kubernetesSpinnakerKindMap))
         .collect(toImmutableList());
   }
 
@@ -236,8 +258,12 @@ final class KubernetesCoreCachingAgentTest {
         Keys.InfrastructureCacheKey.createKey(
             KubernetesKind.STORAGE_CLASS, ACCOUNT, "", STORAGE_CLASS_NAME);
 
+    KubernetesConfigurationProperties configurationProperties =
+        new KubernetesConfigurationProperties();
+    configurationProperties.getCache().setCacheAll(true);
+
     ImmutableCollection<KubernetesCoreCachingAgent> cachingAgents =
-        createCachingAgents(getNamedAccountCredentials(), numAgents);
+        createCachingAgents(getNamedAccountCredentials(), numAgents, configurationProperties);
     LoadDataResult loadDataResult = processLoadData(cachingAgents, ImmutableMap.of());
 
     assertThat(loadDataResult.getResults()).containsKey(DEPLOYMENT_KIND);
@@ -303,8 +329,12 @@ final class KubernetesCoreCachingAgentTest {
   @ParameterizedTest
   @ValueSource(ints = {1, 2, 10})
   public void authoritativeForLogicalTypes(int numAgents) {
+    KubernetesConfigurationProperties configurationProperties =
+        new KubernetesConfigurationProperties();
+    configurationProperties.getCache().setCacheAll(true);
+
     ImmutableCollection<KubernetesCoreCachingAgent> cachingAgents =
-        createCachingAgents(getNamedAccountCredentials(), numAgents);
+        createCachingAgents(getNamedAccountCredentials(), numAgents, configurationProperties);
     cachingAgents.forEach(
         cachingAgent ->
             assertThat(getAuthoritativeTypes(cachingAgent.getProvidedDataTypes()))
@@ -318,8 +348,12 @@ final class KubernetesCoreCachingAgentTest {
   @ParameterizedTest
   @ValueSource(ints = {1, 2, 10})
   public void authoritativeForKubernetesKinds(int numAgents) {
+    KubernetesConfigurationProperties configurationProperties =
+        new KubernetesConfigurationProperties();
+    configurationProperties.getCache().setCacheAll(true);
+
     ImmutableCollection<KubernetesCoreCachingAgent> cachingAgents =
-        createCachingAgents(getNamedAccountCredentials(), numAgents);
+        createCachingAgents(getNamedAccountCredentials(), numAgents, configurationProperties);
     cachingAgents.forEach(
         cachingAgent ->
             assertThat(getAuthoritativeTypes(cachingAgent.getProvidedDataTypes()))
@@ -328,6 +362,120 @@ final class KubernetesCoreCachingAgentTest {
                         KubernetesKind.NAMESPACE.toString(),
                         KubernetesKind.POD.toString(),
                         KubernetesKind.REPLICA_SET.toString())));
+  }
+
+  /**
+   * kindsToCache returns all registered core kinds, coming from {@link
+   * KubernetesCoreCachingAgentTest#kindProperties}
+   */
+  @Test
+  public void kindsToCacheAll() {
+    KubernetesConfigurationProperties configurationProperties =
+        new KubernetesConfigurationProperties();
+    configurationProperties.getCache().setCacheAll(true);
+    KubernetesNamedAccountCredentials namedAccountCredentials = getNamedAccountCredentials();
+    KubernetesCoreCachingAgent cachingAgent =
+        createCachingAgents(namedAccountCredentials, 1, configurationProperties).asList().get(0);
+
+    List<KubernetesKind> kindsToCache = cachingAgent.kindsToCache();
+
+    KubernetesKind[] expected = kindProperties.keySet().toArray(new KubernetesKind[0]);
+    assertThat(kindsToCache).containsExactlyInAnyOrder(expected); // has everything in global kinds
+  }
+
+  /**
+   * kindsToCache returns only core kinds specified in {@link
+   * KubernetesConfigurationProperties.Cache#getCacheKinds()}
+   */
+  @Test
+  public void kindsToCacheFromConfig() {
+    KubernetesConfigurationProperties configurationProperties =
+        new KubernetesConfigurationProperties();
+    configurationProperties.getCache().setCacheAll(false);
+    configurationProperties
+        .getCache()
+        .setCacheKinds(Arrays.asList("deployment", "myCustomKind.my.group"));
+    KubernetesCoreCachingAgent cachingAgent =
+        createCachingAgents(getNamedAccountCredentials(), 1, configurationProperties)
+            .asList()
+            .get(0);
+
+    List<KubernetesKind> kindsToCache = cachingAgent.kindsToCache();
+
+    assertThat(kindsToCache)
+        .containsExactlyInAnyOrder(KubernetesKind.fromString("deployment")); // only has core kinds
+  }
+
+  /**
+   * kindsToCache returns only core kinds mapped to SpinnakerKinds that show in classic
+   * infrastructure screens {@link KubernetesCachingAgent#SPINNAKER_UI_KINDS}
+   */
+  @Test
+  public void kindsToCacheSpinnakerUI() {
+    KubernetesConfigurationProperties configurationProperties =
+        new KubernetesConfigurationProperties();
+    KubernetesCoreCachingAgent cachingAgent =
+        createCachingAgents(getNamedAccountCredentials(), 1, configurationProperties)
+            .asList()
+            .get(0);
+
+    List<KubernetesKind> kindsToCache = cachingAgent.kindsToCache();
+
+    KubernetesKind[] expected =
+        KubernetesCachingAgent.SPINNAKER_UI_KINDS.stream()
+            .map(kubernetesSpinnakerKindMap::translateSpinnakerKind)
+            .flatMap(Collection::stream)
+            .toArray(KubernetesKind[]::new);
+    assertThat(kindsToCache).containsExactlyInAnyOrder(expected); // only has UI kinds
+  }
+
+  /**
+   * kindsToCache doesn't include kinds specified in {@link
+   * KubernetesConfigurationProperties.Cache#getCacheOmitKinds()}
+   */
+  @Test
+  public void kindsToCacheOmitKind() {
+    KubernetesConfigurationProperties configurationProperties =
+        new KubernetesConfigurationProperties();
+    configurationProperties.getCache().setCacheOmitKinds(Collections.singletonList("deployment"));
+    KubernetesCoreCachingAgent cachingAgent =
+        createCachingAgents(getNamedAccountCredentials(), 1, configurationProperties)
+            .asList()
+            .get(0);
+
+    List<KubernetesKind> kindsToCache = cachingAgent.kindsToCache();
+
+    KubernetesKind[] expected =
+        KubernetesCachingAgent.SPINNAKER_UI_KINDS.stream()
+            .map(kubernetesSpinnakerKindMap::translateSpinnakerKind)
+            .flatMap(Collection::stream)
+            .filter(k -> !k.equals(KubernetesKind.DEPLOYMENT))
+            .toArray(KubernetesKind[]::new);
+    assertThat(kindsToCache).containsExactlyInAnyOrder(expected); // excludes Deployment
+  }
+
+  /**
+   * kindsToCache doesn't include invalid kinds. An invalid kind is one that failed access checks
+   * during startup.
+   */
+  @Test
+  public void kindsToCacheInvalidKind() {
+    KubernetesConfigurationProperties configurationProperties =
+        new KubernetesConfigurationProperties();
+    KubernetesNamedAccountCredentials namedCreds = getNamedAccountCredentials();
+    when(namedCreds.getCredentials().isValidKind(KubernetesKind.DEPLOYMENT)).thenReturn(false);
+    KubernetesCoreCachingAgent cachingAgent =
+        createCachingAgents(namedCreds, 1, configurationProperties).asList().get(0);
+
+    List<KubernetesKind> kindsToCache = cachingAgent.kindsToCache();
+
+    KubernetesKind[] expected =
+        KubernetesCachingAgent.SPINNAKER_UI_KINDS.stream()
+            .map(kubernetesSpinnakerKindMap::translateSpinnakerKind)
+            .flatMap(Collection::stream)
+            .filter(k -> !k.equals(KubernetesKind.DEPLOYMENT))
+            .toArray(KubernetesKind[]::new);
+    assertThat(kindsToCache).containsExactlyInAnyOrder(expected); // excludes Deployment
   }
 
   private static ImmutableList<String> getAuthoritativeTypes(

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgentTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgentTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.caching.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesAccountProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.*;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+public class KubernetesUnregisteredCustomResourceCachingAgentTest {
+
+  private static final String ACCOUNT = "my-account";
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ImmutableList<KubernetesHandler> handlers =
+      ImmutableList.of(
+          new KubernetesDeploymentHandler(),
+          new KubernetesReplicaSetHandler(),
+          new KubernetesServiceHandler(),
+          new KubernetesPodHandler(),
+          new KubernetesConfigMapHandler());
+  private static final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap =
+      new KubernetesSpinnakerKindMap(handlers);
+
+  /**
+   * kindsToCache returns only non-core kinds specified in {@link
+   * KubernetesConfigurationProperties.Cache#getCacheKinds()}
+   */
+  @Test
+  public void kindsToCacheFromConfig() {
+    KubernetesConfigurationProperties configurationProperties =
+        new KubernetesConfigurationProperties();
+    configurationProperties.getCache().setCacheAll(false);
+    configurationProperties
+        .getCache()
+        .setCacheKinds(Arrays.asList("deployment", "myCustomKind.my.group"));
+    KubernetesUnregisteredCustomResourceCachingAgent cachingAgent =
+        createCachingAgent(getNamedAccountCredentials(), configurationProperties);
+
+    List<KubernetesKind> kindsToCache = cachingAgent.kindsToCache();
+
+    assertThat(kindsToCache)
+        .containsExactlyInAnyOrder(
+            KubernetesKind.fromString("myCustomKind.my.group")); // only has CRD kinds
+  }
+
+  /**
+   * Returns a KubernetesNamedAccountCredentials that contains a mock KubernetesCredentials object
+   */
+  private static KubernetesNamedAccountCredentials getNamedAccountCredentials() {
+    KubernetesAccountProperties.ManagedAccount managedAccount =
+        new KubernetesAccountProperties.ManagedAccount();
+    managedAccount.setName(ACCOUNT);
+
+    KubernetesCredentials credentials = mock(KubernetesCredentials.class);
+    when(credentials.isValidKind(any(KubernetesKind.class))).thenReturn(true);
+    KubernetesCredentials.Factory credentialFactory = mock(KubernetesCredentials.Factory.class);
+    when(credentialFactory.build(managedAccount)).thenReturn(credentials);
+    return new KubernetesNamedAccountCredentials(managedAccount, credentialFactory);
+  }
+
+  private static KubernetesUnregisteredCustomResourceCachingAgent createCachingAgent(
+      KubernetesNamedAccountCredentials credentials,
+      KubernetesConfigurationProperties configurationProperties) {
+    return new KubernetesUnregisteredCustomResourceCachingAgent(
+        credentials,
+        objectMapper,
+        new NoopRegistry(),
+        0,
+        1,
+        10L,
+        configurationProperties,
+        kubernetesSpinnakerKindMap);
+  }
+}

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -47,6 +47,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.Kubernete
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesServerGroupSummary;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.KubernetesManifestProvider.Sort;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesAccountProperties.ManagedAccount;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.AccountResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.GlobalResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
@@ -99,8 +100,6 @@ final class KubernetesDataProviderIntegrationTest {
   private static final Registry registry = new NoopRegistry();
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private static final KubernetesProvider kubernetesProvider = new KubernetesProvider();
-  private static final KubernetesCachingAgentDispatcher dispatcher =
-      new KubernetesCachingAgentDispatcher(objectMapper, registry);
   private static final ImmutableList<KubernetesHandler> handlers =
       ImmutableList.of(
           new KubernetesDeploymentHandler(),
@@ -109,6 +108,9 @@ final class KubernetesDataProviderIntegrationTest {
           new KubernetesPodHandler());
   private static final KubernetesSpinnakerKindMap kindMap =
       new KubernetesSpinnakerKindMap(handlers);
+  private static final KubernetesCachingAgentDispatcher dispatcher =
+      new KubernetesCachingAgentDispatcher(
+          objectMapper, registry, new KubernetesConfigurationProperties(), kindMap);
   private static final GlobalResourcePropertyRegistry resourcePropertyRegistry =
       new GlobalResourcePropertyRegistry(
           handlers, new KubernetesUnregisteredCustomResourceHandler());


### PR DESCRIPTION
BREAKING: The changes in this PR modify the default behavior of the kubernetes provider from caching all infrastructure, to caching only objects shown in the classic spinnaker infrastructure screens (clusters, load balancers and firewalls). Running pipelines no longer rely on the cache anymore since Spinnaker 1.23, so it's safe to assume that the cache is only used for populating the UI.

The config options introduced allow to continue caching all the kinds like before, useful when using the "raw resources" UI screen, which displays every kubernetes kind.

Configuration
```
kubernetes:
  cache:
    enabled: (true|false)   # (Default: true). Whether caching is enabled at the provider level.
    cacheAll: (true|false)  # (Default: false). Whether to cache all kubernetes kinds or not. If this value is "true", the setting "cacheKinds" is ignored.
    cacheKinds: []          # (Default: list with kinds populating spinnaker infrastructure scren). Only cache the kubernetes kinds in this list. Names are in {kind.group} format, where the group is optional for core kinds. If the setting cacheAll is true, this setting is ignored.
    cacheOmitKinds: []      # (Default: empty). Do not cache the kinds in this list. The format of the list is the same as cacheKinds.
```

The default list of kinds to cache is:
* Deployment
* ReplicaSet
* CronJob
* DaemonSet
* Job
* StatefulSet
* Pod
* Ingress
* Service
* NetworkPolicy
* _Any CRD configured in `kubernetes.accounts[].customResourceDefinitions` having one of the supported spinnaker kinds (server group managers, server groups, instances, load balancers or security groups)_

With the default settings, no action is needed when upgrading to a new version of Spinnaker. Pipelines will continue to work, as well as the UI screens for clusters, load balancers and firewalls. Only for users working with the raw resources screen, they would need to set `kubernetes.cache.cacheAll: true` to continue using it.