### PR TITLE
fix(image): Add tzdata to set timezone on clouddriver pod

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -19,7 +19,8 @@ RUN apk update \
     wget \
     openjdk11 \
     git \
-    openssh-client
+    openssh-client \
+    tzdata
 
 # AWS CLI
 RUN pip install --upgrade awscli==${AWS_CLI_VERSION} s3cmd==${AWS_CLI_S3_CMD} python-magic \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -15,7 +15,8 @@ RUN apt-get update && apt-get install -y curl gnupg && \
   kubectl \
   python-pip \
   git \
-  openssh-client && \
+  openssh-client \
+  tzdata && \
   pip install awscli==1.18.152 --upgrade && \
   rm -rf ~/.config/gcloud
 


### PR DESCRIPTION
Issue:
Inorder to set timezone on a container, setting it through "TZ" environment variable is one of the ways. However, as tzdata package is not installed on the pod, setting "TZ" environment variable doesn't make any difference.

Solution:
Having "tzdata" package installed on the pod gives the flexibility to the user to simply set "TZ" env var and configurable timezone of the pod for better troubleshooting of the logs.

