### PR TITLE
feat(core): Update account management API

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.groovy
@@ -88,6 +88,7 @@ import com.netflix.spinnaker.clouddriver.search.executor.SearchExecutorConfig
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.clouddriver.security.AccountDefinitionSecretManager
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.config.SecurityConfig
@@ -381,11 +382,13 @@ class CloudDriverConfig {
   @Bean
   DescriptionAuthorizerService descriptionAuthorizerService(Registry registry,
                                                             Optional<FiatPermissionEvaluator> fiatPermissionEvaluator,
-                                                            SecurityConfig.OperationsSecurityConfigurationProperties opsSecurityConfigProps) {
+                                                            SecurityConfig.OperationsSecurityConfigurationProperties opsSecurityConfigProps,
+                                                            AccountDefinitionSecretManager secretManager) {
     return new DescriptionAuthorizerService(
-      registry,
-      fiatPermissionEvaluator,
-      opsSecurityConfigProps
+            registry,
+            fiatPermissionEvaluator,
+            opsSecurityConfigProps,
+            secretManager
     )
   }
 

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/config/AccountDefinitionConfiguration.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/config/AccountDefinitionConfiguration.java
@@ -36,9 +36,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -66,8 +68,10 @@ public class AccountDefinitionConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public AccountDefinitionAuthorizer accountDefinitionAuthorizer(
-      @Nullable FiatPermissionEvaluator permissionEvaluator) {
-    return new AccountDefinitionAuthorizer(permissionEvaluator);
+      Optional<FiatPermissionEvaluator> maybePermissionEvaluator,
+      @Value("${services.fiat.enabled:false}") boolean isFiatEnabled) {
+    return new AccountDefinitionAuthorizer(
+        maybePermissionEvaluator.filter(ignored -> isFiatEnabled).orElse(null));
   }
 
   @Bean

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/AccountDefinitionModule.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/AccountDefinitionModule.java
@@ -18,10 +18,7 @@ package com.netflix.spinnaker.clouddriver.jackson;
 
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.netflix.spinnaker.clouddriver.jackson.mixins.CredentialsDefinitionMixin;
-import com.netflix.spinnaker.clouddriver.security.AccountDefinitionMapper;
 import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Jackson module to register {@link CredentialsDefinition} type discriminators for the provided
@@ -41,14 +38,5 @@ public class AccountDefinitionModule extends SimpleModule {
     super.setupModule(context);
     context.setMixInAnnotations(CredentialsDefinition.class, CredentialsDefinitionMixin.class);
     context.registerSubtypes(accountDefinitionTypes);
-  }
-
-  public Map<String, Class<? extends CredentialsDefinition>> getTypeMap() {
-    var typeMap =
-        new HashMap<String, Class<? extends CredentialsDefinition>>(accountDefinitionTypes.length);
-    for (Class<? extends CredentialsDefinition> type : accountDefinitionTypes) {
-      typeMap.put(AccountDefinitionMapper.getJsonTypeName(type), type);
-    }
-    return typeMap;
   }
 }

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/CredentialsDefinitionMixin.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/CredentialsDefinitionMixin.java
@@ -17,14 +17,17 @@
 package com.netflix.spinnaker.clouddriver.jackson.mixins;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 
 /**
  * Jackson mixin to add a polymorphic type name value. When a {@link
  * com.netflix.spinnaker.credentials.definition.CredentialsDefinition} implementation class is
  * annotated with {@link com.fasterxml.jackson.annotation.JsonTypeName}, then the value of that
- * annotation is used as the {@code @type} property value when marshalling and unmarshalling
+ * annotation is used as the {@code type} property value when marshalling and unmarshalling
  * CredentialsDefinition classes. It is recommended that the corresponding cloud provider name for
  * the credentials be used here.
+ *
+ * @see AccountCredentials#getCloudProvider()
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public interface CredentialsDefinitionMixin {}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionAuthorizer.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionAuthorizer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.security;
+
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.ResourceType;
+import com.netflix.spinnaker.fiat.model.resources.Role;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AccountDefinitionAuthorizer {
+  @Nullable private final FiatPermissionEvaluator permissionEvaluator;
+
+  public boolean isAccountManager(@Nonnull String username) {
+    if (permissionEvaluator == null) {
+      return true;
+    }
+    // TODO(jvz): update with https://github.com/spinnaker/fiat/pull/928
+    //  to check isAccountManager
+    var permission = permissionEvaluator.getPermission(username);
+    return permission != null && permission.isAdmin();
+  }
+
+  public boolean isAdmin(@Nonnull String username) {
+    if (permissionEvaluator == null) {
+      return true;
+    }
+    var permission = permissionEvaluator.getPermission(username);
+    return permission != null && permission.isAdmin();
+  }
+
+  public Set<String> getRoles(@Nonnull String username) {
+    if (permissionEvaluator == null) {
+      return Set.of();
+    }
+    var permission = permissionEvaluator.getPermission(username);
+    return permission != null
+        ? permission.getRoles().stream().map(Role.View::getName).collect(Collectors.toSet())
+        : Set.of();
+  }
+
+  public boolean canAccessAccount(@Nonnull String username, @Nonnull String accountName) {
+    if (permissionEvaluator == null) {
+      return true;
+    }
+    return permissionEvaluator.hasPermission(
+        username, accountName, ResourceType.ACCOUNT.getName(), Authorization.WRITE);
+  }
+}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionMapper.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionMapper.java
@@ -21,14 +21,17 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
-import java.util.Map;
 import java.util.Objects;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Maps account definitions to and from strings. Only {@link CredentialsDefinition} classes
- * annotated with a {@link JsonTypeName} will be considered.
+ * annotated with a {@link JsonTypeName} will be considered. {@code secret://} URIs may be used for
+ * credentials values which will be replaced with an appropriate string for the secret along with
+ * recording an associated account name for time of use permission checks on the user secret.
  */
 @NonnullByDefault
+@RequiredArgsConstructor
 public class AccountDefinitionMapper {
 
   /**
@@ -41,20 +44,12 @@ public class AccountDefinitionMapper {
   }
 
   private final ObjectMapper objectMapper;
-  private final Map<String, Class<? extends CredentialsDefinition>> typeMap;
 
-  public AccountDefinitionMapper(
-      ObjectMapper objectMapper, Map<String, Class<? extends CredentialsDefinition>> typeMap) {
-    this.objectMapper = objectMapper;
-    this.typeMap = typeMap;
-  }
-
-  public String convertToString(CredentialsDefinition definition) throws JsonProcessingException {
+  public String serialize(CredentialsDefinition definition) throws JsonProcessingException {
     return objectMapper.writeValueAsString(definition);
   }
 
-  public CredentialsDefinition convertFromString(String string, String type)
-      throws JsonProcessingException {
-    return objectMapper.readValue(string, typeMap.get(type));
+  public CredentialsDefinition deserialize(String string) throws JsonProcessingException {
+    return objectMapper.readValue(string, CredentialsDefinition.class);
   }
 }

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionSecretManager.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionSecretManager.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.security;
+
+import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
+import com.netflix.spinnaker.kork.secrets.SecretManager;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@RequiredArgsConstructor
+public class AccountDefinitionSecretManager {
+  private final SecretManager secretManager;
+  private final AccountDefinitionAuthorizer authorizer;
+
+  public String getEncryptedSecret(String encryptedUri) {
+    return EncryptedSecret.isEncryptedFile(encryptedUri)
+        ? secretManager.decryptAsFile(encryptedUri).toString()
+        : secretManager.decrypt(encryptedUri);
+  }
+
+  public boolean canAccessAccountWithSecrets(@Nonnull String accountName) {
+    var username = SecurityContextHolder.getContext().getAuthentication().getName();
+    if (authorizer.isAdmin(username)) {
+      return true;
+    }
+    var userRoles = authorizer.getRoles(username);
+    if (userRoles.isEmpty()) {
+      return false;
+    }
+    // TODO(jvz): update with https://github.com/spinnaker/kork/pull/942
+    //  to add user secrets usage tracking for time of use authz checks
+    return authorizer.canAccessAccount(username, accountName);
+  }
+}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionService.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionService.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022 Apple Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.security;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Role;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PostFilter;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+/**
+ * Service wrapper for an {@link AccountDefinitionRepository} which enforces permissions and other
+ * validations.
+ */
+@Alpha
+@NonnullByDefault
+@RequiredArgsConstructor
+public class AccountDefinitionService {
+  private final AccountDefinitionRepository repository;
+  private final AccountCredentialsProvider accountCredentialsProvider;
+  private final FiatPermissionEvaluator permissionEvaluator;
+  private final ObjectMapper objectMapper;
+
+  /**
+   * Lists accounts by type that the current user has {@link Authorization#WRITE} access. Users who
+   * only have {@link Authorization#READ} access can only view related items like load balancers,
+   * clusters, security groups, etc., that use the account, but they may not directly use or view
+   * account definitions and credentials.
+   *
+   * @see AccountDefinitionRepository#listByType(String, int, String)
+   */
+  @PostFilter("hasPermission(filterObject.name, 'ACCOUNT', 'WRITE')")
+  public List<? extends CredentialsDefinition> listAccountDefinitionsByType(
+      String accountType, int limit, @Nullable String startingAccountName) {
+    return repository.listByType(accountType, limit, startingAccountName);
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  public CredentialsDefinition createAccount(CredentialsDefinition definition) {
+    String name = definition.getName();
+    if (accountCredentialsProvider.getCredentials(name) != null) {
+      throw new InvalidRequestException(
+          String.format("Cannot create duplicate account (name: %s)", name));
+    }
+    validateAccountWritePermissions(definition, AccountAction.CREATE);
+    repository.create(definition);
+    return definition;
+  }
+
+  @PreAuthorize("hasPermission(#definition.name, 'ACCOUNT', 'WRITE')")
+  public CredentialsDefinition updateAccount(CredentialsDefinition definition) {
+    if (accountCredentialsProvider.getCredentials(definition.getName()) == null) {
+      throw new InvalidRequestException(
+          String.format(
+              "Cannot update an account which does not exist (name: %s)", definition.getName()));
+    }
+    validateAccountWritePermissions(definition, AccountAction.UPDATE);
+    repository.update(definition);
+    return definition;
+  }
+
+  @PreAuthorize("hasPermission(#accountName, 'ACCOUNT', 'WRITE')")
+  public void deleteAccount(String accountName) {
+    if (accountCredentialsProvider.getCredentials(accountName) == null) {
+      throw new InvalidRequestException(
+          String.format("Cannot delete an account which does not exist (name: %s)", accountName));
+    }
+    repository.delete(accountName);
+  }
+
+  /**
+   * Deletes an account by name if the current user has {@link Authorization#WRITE} access to the
+   * given account.
+   */
+  @PreAuthorize("hasPermission(#accountName, 'ACCOUNT', 'WRITE')")
+  public List<AccountDefinitionRepository.Revision> getAccountHistory(String accountName) {
+    return repository.revisionHistory(accountName);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void validateAccountWritePermissions(
+      CredentialsDefinition definition, AccountAction action) {
+    var credentials =
+        objectMapper.convertValue(definition, new TypeReference<Map<String, Object>>() {});
+    var userRoles =
+        AuthenticatedRequest.getSpinnakerUser()
+            .map(permissionEvaluator::getPermission)
+            .map(
+                view ->
+                    view.getRoles().stream().map(Role.View::getName).collect(Collectors.toSet()))
+            .orElseGet(Set::of);
+    var permissions = (Map<String, List<String>>) credentials.getOrDefault("permissions", Map.of());
+    var writeRoles = Set.copyOf(permissions.getOrDefault("WRITE", List.of()));
+    if (Sets.intersection(userRoles, writeRoles).isEmpty()) {
+      throw new InvalidRequestException(
+          String.format(
+              "Cannot %s account without specifying WRITE permissions for current user (name: %s)",
+              action.name().toLowerCase(Locale.ROOT), definition.getName()));
+    }
+  }
+
+  private enum AccountAction {
+    CREATE,
+    UPDATE
+  }
+}

--- a/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionMapperTest.java
+++ b/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionMapperTest.java
@@ -50,14 +50,13 @@ class AccountDefinitionMapperTest {
     account.getPermissions().add(Authorization.READ, Set.of("dev", "sre"));
     account.getPermissions().add(Authorization.WRITE, "sre");
     account.setData("password", "hunter2");
-    assertEquals(account, mapper.convertFromString(mapper.convertToString(account), "test"));
+    assertEquals(account, mapper.deserialize(mapper.serialize(account)));
   }
 
   @Test
   void canDecryptSecretUris() {
-    var data = "{\"@type\":\"test\",\"name\":\"bar\",\"password\":\"encrypted:noop!v:hunter2\"}";
-    CredentialsDefinition account =
-        assertDoesNotThrow(() -> mapper.convertFromString(data, "test"));
+    var data = "{\"type\":\"test\",\"name\":\"bar\",\"password\":\"encrypted:noop!v:hunter2\"}";
+    CredentialsDefinition account = assertDoesNotThrow(() -> mapper.deserialize(data));
     assertThat(account).isInstanceOf(TestAccount.class);
     assertThat(account.getName()).isEqualTo("bar");
     TestAccount testAccount = (TestAccount) account;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsParser.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsParser.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.security;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesAccountProperties.ManagedAccount;
+import com.netflix.spinnaker.credentials.definition.CredentialsParser;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Custom CredentialsParser for Kubernetes credentials to handle configuration errors when parsing
+ * account credentials. As account credentials can be created by users through the credentials API,
+ * this parser is provided for more robust protection from user error.
+ */
+@RequiredArgsConstructor
+@Log4j2
+public class KubernetesCredentialsParser
+    implements CredentialsParser<ManagedAccount, KubernetesNamedAccountCredentials> {
+  private final KubernetesCredentials.Factory credentialFactory;
+
+  @Nullable
+  @Override
+  public KubernetesNamedAccountCredentials parse(@Nonnull ManagedAccount managedAccount) {
+    try {
+      return new KubernetesNamedAccountCredentials(managedAccount, credentialFactory);
+    } catch (RuntimeException e) {
+      log.warn("Skipping invalid account definition account={}", managedAccount.getName(), e);
+      return null;
+    }
+  }
+}

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsControllerSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.security.AbstractAccountCredentials
 
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import groovy.json.JsonSlurper
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc


### PR DESCRIPTION
This refactors some things in preparation for user secrets support along with updating the type discriminator handling for account definitions.

These changes are independent of https://github.com/spinnaker/fiat/pull/928 and https://github.com/spinnaker/kork/pull/942, and I've noted TODO comments on where relevant updates related to those PRs will be added (with additional tests).