### PR TITLE
chore(cats): make relationship log info instead of warn

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
@@ -699,7 +699,7 @@ class SqlCache(
       .toSet()
 
     if (sourceAgents.isEmpty()) {
-      log.warn("no relationships found for type $type")
+      log.info("no relationships found for type $type")
       return result
     }
 


### PR DESCRIPTION
As the number of ECS providers increases the chattiness of this
message can creates upwards of 400GB/day in data. We do not believe
there is an adverse effect in changing the log level here. Info messages
can be safely turned off for those concerned with log storage costs.