### PR TITLE
feat(docker): Docker Registry account management

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.docker.registry.config
 
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.netflix.spinnaker.clouddriver.docker.registry.DockerRegistryCloudProvider
 import com.netflix.spinnaker.credentials.definition.CredentialsDefinition
 import groovy.transform.ToString
 
@@ -23,6 +25,7 @@ import groovy.transform.ToString
 class DockerRegistryConfigurationProperties {
 
   @ToString(includeNames = true)
+  @JsonTypeName(DockerRegistryCloudProvider.DOCKER_REGISTRY)
   static class ManagedAccount implements CredentialsDefinition {
     String name
     String environment

--- a/clouddriver-docker/src/main/java/com/netflix/spinnaker/config/DockerRegistryAccountDefinitionSourceConfiguration.java
+++ b/clouddriver-docker/src/main/java/com/netflix/spinnaker/config/DockerRegistryAccountDefinitionSourceConfiguration.java
@@ -1,0 +1,29 @@
+package com.netflix.spinnaker.config;
+
+import com.netflix.spinnaker.clouddriver.docker.registry.config.DockerRegistryConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.docker.registry.config.DockerRegistryConfigurationProperties.ManagedAccount;
+import com.netflix.spinnaker.clouddriver.security.AccountDefinitionRepository;
+import com.netflix.spinnaker.clouddriver.security.AccountDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@ConditionalOnProperty({"account.storage.enabled", "account.storage.docker-registry.enabled"})
+public class DockerRegistryAccountDefinitionSourceConfiguration {
+  @Bean
+  @Primary
+  public CredentialsDefinitionSource<ManagedAccount> dockerRegistryAccountSource(
+      AccountDefinitionRepository repository,
+      Optional<List<CredentialsDefinitionSource<ManagedAccount>>> additionalSources,
+      DockerRegistryConfigurationProperties properties) {
+    return new AccountDefinitionSource<>(
+        repository,
+        ManagedAccount.class,
+        additionalSources.orElseGet(() -> List.of(properties::getAccounts)));
+  }
+}

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/config/KubernetesAccountDefinitionSourceConfiguration.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/config/KubernetesAccountDefinitionSourceConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
 @Configuration
-@ConditionalOnProperty("account.storage.enabled")
+@ConditionalOnProperty({"account.storage.enabled", "account.storage.kubernetes.enabled"})
 public class KubernetesAccountDefinitionSourceConfiguration {
   @Bean
   @Primary


### PR DESCRIPTION
This integrates Docker Registry Clouddriver accounts to take advantage
of the new self-service on-boarding account management API. Given
that Docker Registry accounts already use kork-credentials, this
is simpler than usual.