### PR TITLE
feat(kubernetes): support propagation policy in delete manifest stage

### DIFF
--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/DeleteManifestIT.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/DeleteManifestIT.java
@@ -56,7 +56,7 @@ public class DeleteManifestIT extends BaseTest {
     kubeCluster.execKubectl("-n " + account1Ns + " apply -f -", manifest);
     // ------------------------- when ---------------------------
     List<Map<String, Object>> request =
-        buildStaticRequestBody(String.format("%s %s", kind, name), true);
+        buildStaticRequestBody(String.format("%s %s", kind, name), "true");
     List<String> deletions = KubeTestUtils.sendOperation(baseUrl(), request, account1Ns);
     // ------------------------- then ---------------------------
     String exist =
@@ -99,7 +99,7 @@ public class DeleteManifestIT extends BaseTest {
     List<Map<String, Object>> deleteRequest =
         buildDynamicRequestBody(
             String.format("%s %s", kind, nameToDelete),
-            true,
+            "true",
             String.format("%s %s", kind, name),
             criteria,
             kind);
@@ -145,7 +145,7 @@ public class DeleteManifestIT extends BaseTest {
     List<Map<String, Object>> deleteRequest =
         buildDynamicRequestBody(
             String.format("%s %s", kind, nameToDelete),
-            true,
+            "true",
             String.format("%s %s", kind, name),
             criteria,
             kind);
@@ -191,7 +191,7 @@ public class DeleteManifestIT extends BaseTest {
     List<Map<String, Object>> deleteRequest =
         buildDynamicRequestBody(
             String.format("%s %s", kind, nameToDelete),
-            true,
+            "true",
             String.format("%s %s", kind, name),
             criteria,
             kind);
@@ -238,7 +238,7 @@ public class DeleteManifestIT extends BaseTest {
     List<Map<String, Object>> deleteRequest =
         buildDynamicRequestBody(
             String.format("%s %s", kind, nameToDelete),
-            true,
+            "true",
             String.format("%s %s", kind, name),
             criteria,
             kind);
@@ -285,7 +285,7 @@ public class DeleteManifestIT extends BaseTest {
     List<Map<String, Object>> deleteRequest =
         buildDynamicRequestBody(
             String.format("%s %s", kind, nameToDelete),
-            true,
+            "true",
             String.format("%s %s", kind, name),
             criteria,
             kind);
@@ -322,7 +322,7 @@ public class DeleteManifestIT extends BaseTest {
             kind, account1Ns, name));
     // ------------------------- when ---------------------------
     List<Map<String, Object>> deleteRequest =
-        buildStaticRequestBody(String.format("%s %s", kind, name), false);
+        buildStaticRequestBody(String.format("%s %s", kind, name), "false");
     List<String> deletions = KubeTestUtils.sendOperation(baseUrl(), deleteRequest, account1Ns);
     // ------------------------- then ---------------------------
     String exists =
@@ -342,7 +342,7 @@ public class DeleteManifestIT extends BaseTest {
   public void shouldNotDeleteStaticTarget() throws InterruptedException {
     // ------------------------- given --------------------------
     // ------------------------- when ---------------------------
-    List<Map<String, Object>> request = buildStaticRequestBody("deployment notExists", true);
+    List<Map<String, Object>> request = buildStaticRequestBody("deployment notExists", "true");
     // ------------------------- then ---------------------------
     List<String> deletions = KubeTestUtils.sendOperation(baseUrl(), request, account1Ns);
     assertEquals(0, deletions.size());
@@ -387,7 +387,7 @@ public class DeleteManifestIT extends BaseTest {
     kubeCluster.execKubectl(" apply -f -", crdManifest);
     // ------------------------- when ---------------------------
     List<Map<String, Object>> request =
-        buildStaticRequestBody(String.format("%s %s", kind, crdName), true);
+        buildStaticRequestBody(String.format("%s %s", kind, crdName), "true");
     List<String> deletions = KubeTestUtils.sendOperation(baseUrl(), request, account1Ns);
     // ------------------------- then ---------------------------
     String exists =
@@ -422,7 +422,7 @@ public class DeleteManifestIT extends BaseTest {
     kubeCluster.execKubectl("-n " + account1Ns + " apply -f -", crManifest);
     // ------------------------- when ---------------------------
     List<Map<String, Object>> request =
-        buildStaticRequestBody(String.format("%s %s", kind, crName), true);
+        buildStaticRequestBody(String.format("%s %s", kind, crName), "true");
     List<String> deletions = KubeTestUtils.sendOperation(baseUrl(), request, account1Ns);
     // ------------------------- then ---------------------------
     String exists =
@@ -434,7 +434,7 @@ public class DeleteManifestIT extends BaseTest {
             && deletions.get(0).equals(String.format("%s %s", kind, crName)));
   }
 
-  private List<Map<String, Object>> buildStaticRequestBody(String manifestName, Boolean cascading) {
+  private List<Map<String, Object>> buildStaticRequestBody(String manifestName, String cascading) {
     return KubeTestUtils.loadJson("classpath:requests/delete_manifest.json")
         .withValue("deleteManifest.app", APP1_NAME)
         .withValue("deleteManifest.mode", "static")
@@ -446,7 +446,7 @@ public class DeleteManifestIT extends BaseTest {
   }
 
   private List<Map<String, Object>> buildDynamicRequestBody(
-      String manifestName, Boolean cascading, String cluster, String criteria, String kind) {
+      String manifestName, String cascading, String cluster, String criteria, String kind) {
     return KubeTestUtils.loadJson("classpath:requests/delete_manifest.json")
         .withValue("deleteManifest.app", APP1_NAME)
         .withValue("deleteManifest.mode", "dynamic")

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/DeleteManifestIT.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/DeleteManifestIT.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.it;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.it.utils.KubeTestUtils;
@@ -373,6 +374,47 @@ public class DeleteManifestIT extends BaseTest {
     assertTrue(exists.isBlank());
     assertEquals(1, deletions.size());
     assertEquals(String.format("%s %s", kind, name), deletions.get(0));
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given a deployment\n"
+          + "When sending a delete manifest operation with invalid cascading value\n"
+          + "Then the delete manifest operation fails and the deployment remains\n===")
+  @Test
+  public void deleteWithInvalidCascadingValue() throws IOException, InterruptedException {
+    // ------------------------- given --------------------------
+    String kind = "deployment";
+    String name = "myapp";
+    Map<String, Object> deployManifest =
+        KubeTestUtils.loadYaml("classpath:manifests/deployment.yml")
+            .withValue("metadata.name", name)
+            .asMap();
+    kubeCluster.execKubectl("-n " + account1Ns + " apply -f -", deployManifest);
+    kubeCluster.execKubectl(
+        String.format(
+            "wait %s -n %s %s --for condition=Available=True --timeout=600s",
+            kind, account1Ns, name));
+
+    // ------------------------- when ---------------------------
+    String invalidCascadingValue = "bogus";
+    List<Map<String, Object>> deleteRequest =
+        buildStaticRequestBody(String.format("%s %s", kind, name), invalidCascadingValue);
+
+    // KubeTestUtils.repeatUntilTrue waits in 5 second increments, and we need
+    // to wait at least 10 seconds to get it to try more than once.  Even if it
+    // the operation completes more quickly than that, it doesn't happen on the
+    // first attempt.
+    String status =
+        KubeTestUtils.sendOperationExpectFailure(
+            baseUrl(), deleteRequest, account1Ns, 10, TimeUnit.SECONDS);
+    // ------------------------- then ---------------------------
+    String exists =
+        kubeCluster.execKubectl(
+            String.format(
+                "-n %s get deployment %s -o jsonpath='{.metadata.name}'", account1Ns, name));
+    assertThat(status).contains("invalid cascade value (" + invalidCascadingValue + ")");
+    assertEquals(name, exists);
   }
 
   @DisplayName(

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/utils/KubeTestUtils.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/utils/KubeTestUtils.java
@@ -286,7 +286,7 @@ public abstract class KubeTestUtils {
   }
 
   /** Wait until a task has completed, calling a consumer with the response once it has. */
-  private static void processOperation(
+  public static void processOperation(
       String baseUrl, String taskId, long duration, TimeUnit unit, Consumer<Response> consumer)
       throws InterruptedException {
     System.out.println("> Waiting for task to complete");
@@ -317,7 +317,7 @@ public abstract class KubeTestUtils {
    *
    * @return the task id
    */
-  private static String submitOperation(String baseUrl, List<Map<String, Object>> reqBody) {
+  public static String submitOperation(String baseUrl, List<Map<String, Object>> reqBody) {
     String url = baseUrl + "/kubernetes/ops";
     System.out.println("POST " + url);
     Response resp =
@@ -334,7 +334,7 @@ public abstract class KubeTestUtils {
    * @return the response from the get task method, if the task has completed, or null if the task
    *     was not found, or the task hasn't completed yet.
    */
-  private static Response getTask(String baseUrl, String taskId) {
+  public static Response getTask(String baseUrl, String taskId) {
     String taskUrl = baseUrl + "/task/" + taskId;
     System.out.println("GET " + taskUrl);
     Response respTask = given().get(taskUrl);

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/utils/KubeTestUtils.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/utils/KubeTestUtils.java
@@ -234,14 +234,7 @@ public abstract class KubeTestUtils {
       TimeUnit unit)
       throws InterruptedException {
 
-    String url = baseUrl + "/kubernetes/ops";
-    System.out.println("POST " + url);
-    Response resp =
-        given().log().body(false).contentType("application/json").body(reqBody).post(url);
-    System.out.println(resp.asString());
-    resp.then().statusCode(200);
-    System.out.println("< Completed in " + resp.getTimeIn(TimeUnit.SECONDS) + " seconds");
-    String taskId = resp.jsonPath().get("id");
+    String taskId = submitOperation(baseUrl, reqBody);
 
     System.out.println("> Waiting for task to complete");
     long start = System.currentTimeMillis();
@@ -288,14 +281,7 @@ public abstract class KubeTestUtils {
       TimeUnit unit)
       throws InterruptedException {
 
-    String url = baseUrl + "/kubernetes/ops";
-    System.out.println("POST " + url);
-    Response resp =
-        given().log().body(false).contentType("application/json").body(reqBody).post(url);
-    System.out.println(resp.asString());
-    resp.then().statusCode(200);
-    System.out.println("< Completed in " + resp.getTimeIn(TimeUnit.SECONDS) + " seconds");
-    String taskId = resp.jsonPath().get("id");
+    String taskId = submitOperation(baseUrl, reqBody);
 
     System.out.println("> Waiting for task to fail");
     long start = System.currentTimeMillis();
@@ -334,6 +320,22 @@ public abstract class KubeTestUtils {
 
     // Return the status to the caller so it's possible to assert on it.
     return Iterables.getOnlyElement(status);
+  }
+
+  /**
+   * Submit an operation to clouddriver
+   *
+   * @return the task id
+   */
+  private static String submitOperation(String baseUrl, List<Map<String, Object>> reqBody) {
+    String url = baseUrl + "/kubernetes/ops";
+    System.out.println("POST " + url);
+    Response resp =
+        given().log().body(false).contentType("application/json").body(reqBody).post(url);
+    System.out.println(resp.asString());
+    resp.then().statusCode(200);
+    System.out.println("< Completed in " + resp.getTimeIn(TimeUnit.SECONDS) + " seconds");
+    return resp.jsonPath().get("id");
   }
 
   @SuppressWarnings("unchecked")

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/utils/KubeTestUtils.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/utils/KubeTestUtils.java
@@ -222,6 +222,16 @@ public abstract class KubeTestUtils {
   public static List<String> sendOperation(
       String baseUrl, List<Map<String, Object>> reqBody, String targetNs)
       throws InterruptedException {
+    return sendOperation(baseUrl, reqBody, targetNs, 30, TimeUnit.SECONDS);
+  }
+
+  public static List<String> sendOperation(
+      String baseUrl,
+      List<Map<String, Object>> reqBody,
+      String targetNs,
+      long duration,
+      TimeUnit unit)
+      throws InterruptedException {
 
     String url = baseUrl + "/kubernetes/ops";
     System.out.println("POST " + url);
@@ -257,9 +267,13 @@ public abstract class KubeTestUtils {
                       String.class));
           return respTask.jsonPath().getBoolean("status.completed");
         },
-        30,
-        TimeUnit.SECONDS,
-        "Waited 30 seconds on GET /task/{id} to return \"status.completed: true\"");
+        duration,
+        unit,
+        "Waited "
+            + duration
+            + " "
+            + unit
+            + " on GET /task/{id} to return \"status.completed: true\"");
     System.out.println(
         "< Task completed in " + ((System.currentTimeMillis() - start) / 1000) + " seconds");
     return deployedObjectNames;

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/utils/KubeTestUtils.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/utils/KubeTestUtils.java
@@ -241,14 +241,10 @@ public abstract class KubeTestUtils {
     List<String> deployedObjectNames = new ArrayList<>();
     KubeTestUtils.repeatUntilTrue(
         () -> {
-          String taskUrl = baseUrl + "/task/" + taskId;
-          System.out.println("GET " + taskUrl);
-          Response respTask = given().get(taskUrl);
-          if (respTask.statusCode() == 404) {
+          Response respTask = getTask(baseUrl, taskId);
+          if (respTask == null) {
             return false;
           }
-          respTask.then().statusCode(200);
-          System.out.println(respTask.jsonPath().getObject("status", Map.class));
           respTask.then().body("status.failed", is(false));
           deployedObjectNames.clear();
           deployedObjectNames.addAll(
@@ -292,14 +288,11 @@ public abstract class KubeTestUtils {
     List<String> status = new ArrayList<>();
     KubeTestUtils.repeatUntilTrue(
         () -> {
-          String taskUrl = baseUrl + "/task/" + taskId;
-          System.out.println("GET " + taskUrl);
-          Response respTask = given().get(taskUrl);
-          if (respTask.statusCode() == 404) {
+          Response respTask = getTask(baseUrl, taskId);
+          if (respTask == null) {
             return false;
           }
-          respTask.then().statusCode(200);
-          System.out.println(respTask.jsonPath().getObject("status", Map.class));
+
           if (!respTask.jsonPath().getBoolean("status.completed")) {
             return false;
           }
@@ -336,6 +329,23 @@ public abstract class KubeTestUtils {
     resp.then().statusCode(200);
     System.out.println("< Completed in " + resp.getTimeIn(TimeUnit.SECONDS) + " seconds");
     return resp.jsonPath().get("id");
+  }
+
+  /**
+   * Get a task from clouddriver
+   *
+   * @return the response from the get task method, or null if the task was not found
+   */
+  private static Response getTask(String baseUrl, String taskId) {
+    String taskUrl = baseUrl + "/task/" + taskId;
+    System.out.println("GET " + taskUrl);
+    Response respTask = given().get(taskUrl);
+    if (respTask.statusCode() == 404) {
+      return null;
+    }
+    respTask.then().statusCode(200);
+    System.out.println(respTask.jsonPath().getObject("status", Map.class));
+    return respTask;
   }
 
   @SuppressWarnings("unchecked")

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/utils/KubeTestUtils.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/utils/KubeTestUtils.java
@@ -292,13 +292,17 @@ public abstract class KubeTestUtils {
     System.out.println("> Waiting for task to complete");
     long start = System.currentTimeMillis();
 
+    // So it's possible to capture the Response from the lambda passed to
+    // repeatUntilTrue, uese a wrapper.  List is an arbitrary choice.
+    List<Response> respList = new ArrayList();
+
     KubeTestUtils.repeatUntilTrue(
         () -> {
           Response respTask = getTask(baseUrl, taskId);
           if (respTask == null) {
             return false;
           }
-          consumer.accept(respTask);
+          respList.add(respTask);
           return true;
         },
         duration,
@@ -310,6 +314,8 @@ public abstract class KubeTestUtils {
             + " on GET /task/{id} to return \"status.completed: true\"");
     System.out.println(
         "< Task completed in " + ((System.currentTimeMillis() - start) / 1000) + " seconds");
+
+    consumer.accept(Iterables.getOnlyElement(respList));
   }
 
   /**

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -150,17 +150,12 @@ public class KubectlJobExecutor {
     // spinnaker generally accepts deletes of resources that don't exist
     command.add("--ignore-not-found=true");
 
-    if (deleteOptions.getOrphanDependents() != null) {
-      command.add("--cascade=" + !deleteOptions.getOrphanDependents());
+    if (deleteOptions.getPropagationPolicy() != null) {
+      command.add("--cascade=" + deleteOptions.getPropagationPolicy());
     }
 
     if (deleteOptions.getGracePeriodSeconds() != null) {
       command.add("--grace-period=" + deleteOptions.getGracePeriodSeconds());
-    }
-
-    if (!Strings.isNullOrEmpty(deleteOptions.getPropagationPolicy())) {
-      throw new IllegalArgumentException(
-          "Propagation policy is not yet supported as a delete option");
     }
 
     String id;


### PR DESCRIPTION
https://github.com/spinnaker/clouddriver/pull/5426 is a previous PR related to this one.

Consider this basic layout of the json for a delete manifest stage:
```
{
  "deleteManifest": {
    "account": "account"
    "app": "app",
    "cloudProvider": "kubernetes",
    "manifestName": "kind name",
    "options": { ... }
    },
}
```
There are two relevant properties in the options object: `cascading` and `orphanDependents`.  Both before and after this PR, orphanDependents takes precedence.  If it's specified, cascading is ignored.  Here is how the various values for cascading and orphanDependents map to `--cascade` options to `kubectl delete`

|option| before this PR|after this PR|
|------|---------------|------------|
|orphanDependents: "true"|--cascade=false|--cascade=orphan|
|orphanDependents: "false"|--cascade=true|--cascade=background|
|cascading: "true"|--cascade=true|--cascade=background|
|cascading: "false"|--cascade=false|--cascade=orphan|
|cascading: "background"|unsupported|--cascade=background|
|cascading: "orphan"|unsupported|--cascade=orphan|
|cascading: "foreground"|unsupported|--cascade=foreground|
