### PR TITLE
fix(sql): active tasks listing for graceful shutdown

### DIFF
--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt
@@ -284,7 +284,7 @@ class SqlTaskRepository(
    */
   private fun runningTaskIds(ctx: DSLContext, thisInstance: Boolean): Array<String> {
     return withPool(poolName) {
-      val baseQuery = ctx.select()
+      val baseQuery = ctx.select(field("a.task_id"))
         .from(taskStatesTable.`as`("a"))
         .innerJoin(
           ctx.select(field("task_id"), DSL.max(field("created_at")).`as`("created"))
@@ -295,7 +295,7 @@ class SqlTaskRepository(
 
       val select = if (thisInstance) {
         baseQuery
-          .innerJoin(tasksTable.`as`("t")).on(field("a.task_id").eq("t.id"))
+          .innerJoin(tasksTable.`as`("t")).on(sql("a.task_id = t.id"))
           .where(
             field("t.owner_id").eq(ClouddriverHostname.ID)
               .and(field("a.state").eq(TaskState.STARTED.toString()))
@@ -305,7 +305,7 @@ class SqlTaskRepository(
       }
 
       select
-        .fetch("t.task_id", String::class.java)
+        .fetch("a.task_id", String::class.java)
         .toTypedArray()
     }
   }


### PR DESCRIPTION
Fix active tasks listing which is used for graceful shutdown.

First problem is that we're comparing a.task_id with constant literal 't.id' instead of read field value. So results are always empty.

Second is that we're fetching results by field name with table alias (t.task_id) which is not working, at least on standard mysql 5.7 (Field (null) is not contained in Row). Fixed this by explicitly selecting required field (a.task_id) instead of all fields.