### PR TITLE
fix(kubernetes): Pin Debian Package version of kubectl as well

### DIFF
--- a/clouddriver-web/pkg_scripts/postInstall.sh
+++ b/clouddriver-web/pkg_scripts/postInstall.sh
@@ -1,20 +1,23 @@
 #!/bin/sh
 
+# Remember to also update Dockerfile.*
+# KUBECTL_RELEASE kept one minor version behind latest to maximise compatibility overlap
+KUBECTL_RELEASE=1.20.6
+
 # ubuntu
 # check that owner group exists
-if [ -z `getent group spinnaker` ]; then
+if [ -z "$(getent group spinnaker)" ]; then
   groupadd spinnaker
 fi
 
 # check that user exists
-if [ -z `getent passwd spinnaker` ]; then
+if [ -z "$(getent passwd spinnaker)" ]; then
   useradd --gid spinnaker spinnaker -m --home-dir /home/spinnaker
 fi
 
 install_kubectl() {
-  if [ -z `which kubectl` ]; then
-    wget https://storage.googleapis.com/kubernetes-release/release/stable.txt && wget https://storage.googleapis.com/kubernetes-release/release/$(cat stable.txt)/bin/linux/amd64/kubectl
-    rm stable.txt
+  if [ -z "$(which kubectl)" ]; then
+    wget "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_RELEASE}/bin/linux/amd64/kubectl"
     chmod +x kubectl
     mv ./kubectl /usr/local/bin/kubectl
   fi
@@ -22,4 +25,4 @@ install_kubectl() {
 
 install_kubectl
 
-install --mode=755 --owner=spinnaker --group=spinnaker --directory  /var/log/spinnaker/clouddriver 
+install --mode=755 --owner=spinnaker --group=spinnaker --directory /var/log/spinnaker/clouddriver


### PR DESCRIPTION
Currently installing `spinnaker-clouddriver` results in `kubectl`
version 1.23.5 being installed.

This commit changes behaviour to install the same version as currently
specified in the `Dockerfile.slim|ubuntu` files rather than the latest stable
version.

FWIW the script doesn't upgrade `kubectl` if it is already installed which is
great as some users may manage this component separately via Ansible/etc.

However this does present a problem if/when an update to a later clouddriver
version would normally install with a newer `kubectl`.
No changes in this regard.