### PR TITLE
fix(cf): scale app before building droplet

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -656,8 +656,11 @@ public class Applications {
                     "Cloud Foundry signaled that package upload succeeded but failed to provide a response."));
   }
 
-  public String createBuild(String packageGuid) throws CloudFoundryApiException {
-    return safelyCall(() -> api.createBuild(new CreateBuild(packageGuid)))
+  public String createBuild(
+      String packageGuid, @Nullable Integer memoryAmount, @Nullable Integer diskSizeAmount)
+      throws CloudFoundryApiException {
+    return safelyCall(
+            () -> api.createBuild(new CreateBuild(packageGuid, memoryAmount, diskSizeAmount)))
         .map(Build::getGuid)
         .orElseThrow(
             () ->

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/CreateBuild.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/CreateBuild.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -25,13 +26,22 @@ public class CreateBuild {
   @JsonProperty("package")
   private PackageId packageId;
 
-  public CreateBuild(String packageId) {
+  @JsonProperty("staging_memory_in_mb")
+  private final Integer memoryAmount;
+
+  @JsonProperty("staging_disk_in_mb")
+  private final Integer diskSizeAmount;
+
+  public CreateBuild(
+      String packageId, @Nullable Integer memoryAmount, @Nullable Integer diskSizeAmount) {
     this.packageId = new PackageId(packageId);
+    this.memoryAmount = memoryAmount == null ? 1024 : memoryAmount;
+    this.diskSizeAmount = diskSizeAmount == null ? 1024 : diskSizeAmount;
   }
 
   @RequiredArgsConstructor
   @Getter
-  private class PackageId {
+  private static class PackageId {
     private final String guid;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -97,11 +97,13 @@ public class DeployCloudFoundryServerGroupAtomicOperation
       }
     }
 
+    // create service bindings and configure app/processes before building droplet
     createServiceBindings(serverGroup, description);
 
+    // build the app droplet
     buildDroplet(packageId, serverGroup.getId(), description);
 
-    // update process before scaling process
+    // update processes before scaling them
     updateProcess(serverGroup.getId(), description);
     scaleApplication(serverGroup.getId(), description);
 
@@ -464,7 +466,12 @@ public class DeployCloudFoundryServerGroupAtomicOperation
     CloudFoundryClient client = description.getClient();
     getTask().updateStatus(PHASE, "Building droplet for package '" + packageId + "'");
 
-    String buildId = client.getApplications().createBuild(packageId);
+    Integer memoryAmount =
+        convertToMb("memory", description.getApplicationAttributes().getMemory());
+    Integer diskSizeAmount =
+        convertToMb("disk quota", description.getApplicationAttributes().getDiskQuota());
+
+    String buildId = client.getApplications().createBuild(packageId, memoryAmount, diskSizeAmount);
 
     operationPoller.waitForOperation(
         () -> client.getApplications().buildCompleted(buildId),
@@ -559,10 +566,10 @@ public class DeployCloudFoundryServerGroupAtomicOperation
     } else {
       size = size.toLowerCase();
       if (size.endsWith("g") || size.endsWith("gb")) {
-        String value = size.substring(0, size.indexOf("g"));
+        String value = size.substring(0, size.indexOf('g'));
         if (StringUtils.isNumeric(value)) return Integer.parseInt(value) * 1024;
       } else if (size.endsWith("m") || size.endsWith("mb")) {
-        String value = size.substring(0, size.indexOf("m"));
+        String value = size.substring(0, size.indexOf('m'));
         if (StringUtils.isNumeric(value)) return Integer.parseInt(value);
       }
     }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/CreateBuildTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/CreateBuildTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.Test;
 class CreateBuildTest {
   @Test
   void serialize() throws JsonProcessingException {
-    assertThat(new ObjectMapper().writeValueAsString(new CreateBuild("123")))
-        .isEqualTo("{\"package\":{\"guid\":\"123\"}}");
+    assertThat(new ObjectMapper().writeValueAsString(new CreateBuild("123", 1024, 1024)))
+        .isEqualTo(
+            "{\"package\":{\"guid\":\"123\"},\"staging_memory_in_mb\":1024,\"staging_disk_in_mb\":1024}");
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
@@ -19,8 +19,8 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops.DeployCloudFoundryServerGroupAtomicOperation.convertToMb;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.artifacts.ArtifactCredentialsFromString;
@@ -128,11 +128,11 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
     // Given
     final DeployCloudFoundryServerGroupDescription description =
         getDeployCloudFoundryServerGroupDescription(true);
-    final CloudFoundryClusterProvider clusterProvider = mock(CloudFoundryClusterProvider.class);
     final DeployCloudFoundryServerGroupAtomicOperation operation =
         new DeployCloudFoundryServerGroupAtomicOperation(
             new PassThroughOperationPoller(), description);
-    final Applications apps = getApplications(clusterProvider, ProcessStats.State.CRASHED);
+    final CloudFoundryClusterProvider clusterProvider = mock(CloudFoundryClusterProvider.class);
+    getApplications(clusterProvider, ProcessStats.State.CRASHED);
 
     Exception exception = null;
     // When
@@ -190,7 +190,7 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
         .createPackage(eq(new CreatePackage("serverGroupId", CreatePackage.Type.BITS, null)));
     inOrder.verify(apps).uploadPackageBits(any(), any());
     inOrder.verify(serviceInstances).createServiceBinding(any());
-    inOrder.verify(apps).createBuild(any());
+    inOrder.verify(apps).createBuild(any(), any(), any());
     inOrder.verify(apps).buildCompleted(any());
     inOrder.verify(apps).findDropletGuidFromBuildId(any());
     inOrder.verify(apps).setCurrentDroplet(any(), any());
@@ -208,7 +208,7 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
     inOrder.verify(apps).createApplication(any(), any(), any(), any());
     inOrder.verify(apps).createPackage(any());
     inOrder.verify(cloudFoundryClient.getServiceInstances()).createServiceBinding(any());
-    inOrder.verify(apps).createBuild(any());
+    inOrder.verify(apps).createBuild(any(), any(), any());
     inOrder.verify(processes).updateProcess("serverGroupId", null, "http", "/health", 180, null);
     inOrder.verify(processes).scaleProcess("serverGroupId", 7, 1024, 2048);
     inOrder.verify(apps, calls.get()).startApplication("serverGroupId");
@@ -252,7 +252,7 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
                   Object[] args = invocation.getArguments();
                   return args[0].toString() + "_package";
                 });
-    when(apps.createBuild(any())).thenReturn("some-build");
+    when(apps.createBuild(any(), any(), any())).thenReturn("some-build");
     when(apps.buildCompleted(any())).thenReturn(true);
     when(apps.findDropletGuidFromBuildId(any())).thenReturn("droplet-guid");
     doNothing().when(apps).setCurrentDroplet(any(), any());


### PR DESCRIPTION
Currently we set process config and scale the app/processes after building the droplet. This causes issues if the droplet requires more memory to build (e.g. lots of Python dependencies to install).

`cf push` uses a v2 endpoint to create applications which allows specifying scale when creating the app, whereas we are using a v3 endpoint which does not have those fields. Scaling is therefore a separate call.