### PR TITLE
chore(titus): limit protobuf to 3.17.3

### DIFF
--- a/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver-titus/clouddriver-titus.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.google.protobuf"
 
 ext {
-  protobufVersion = '[3.2.0,)'
+  protobufVersion = '[3.2.0,3.17.3]'
   grpcVersion = '1.37.1'
 }
 


### PR DESCRIPTION
On May 11, builds (e.g. https://github.com/spinnaker/clouddriver/runs/6395450456?check_suite_focus=true, https://github.com/spinnaker/clouddriver/runs/6396984248?check_suite_focus=true and https://github.com/spinnaker/clouddriver/runs/6396922814?check_suite_focus=true) started failing with e.g.:
```
> Task :clouddriver-titus:compileJava
      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(accountId_)) {
                                                 ^
  symbol:   method isStringEmpty(Object)
  location: class GeneratedMessageV3
/home/runner/work/clouddriver/clouddriver/clouddriver-titus/build/generated/source/proto/main/java/com/netflix/titus/TitusVpcApi.java:413: error: cannot find symbol
```
According to https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/, com.google.protobuf:3.21.0-rc-1 arrived on May 11, so pin to the latest version before that.
