### PR TITLE
chore(ci): Only run CodeQL on Spinnaker repos

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   analyze:
+    if: startsWith(github.repository, 'spinnaker/')
     name: Analyze
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
We don't want/need this to run in fork's. 