### PR TITLE
fix(core): set error message for AtomicOperationConverterNotFoundException

### DIFF
--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationConverterNotFoundException.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationConverterNotFoundException.java
@@ -22,7 +22,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 public class AtomicOperationConverterNotFoundException extends RuntimeException {
   public AtomicOperationConverterNotFoundException() {}
 
-  public AtomicOperationConverterNotFoundException(String message) {}
+  public AtomicOperationConverterNotFoundException(String message) {
+    super(message);
+  }
 
   public AtomicOperationConverterNotFoundException(String message, Throwable cause) {}
 

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/orchestration/AnnotationsBasedAtomicOperationsRegistrySpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/orchestration/AnnotationsBasedAtomicOperationsRegistrySpec.groovy
@@ -70,7 +70,8 @@ class AnnotationsBasedAtomicOperationsRegistrySpec extends Specification {
     def converter = atomicOperationsRegistry.getAtomicOperationConverter('foo', 'test-provider')
 
     then:
-    thrown(AtomicOperationConverterNotFoundException)
+    def e = thrown(AtomicOperationConverterNotFoundException)
+    e.message != null
     converter == null
   }
 


### PR DESCRIPTION
### Problem
Currently when an AtomicOperationConverterNotFoundException gets thrown, the error message is not being properly set and is resulting in a null message in the logs.
```
com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationConverterNotFoundException: null
	at jdk.internal.reflect.GeneratedConstructorAccessor389.newInstance(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:80)
	at org.codehaus.groovy.reflection.CachedConstructor.doConstructorInvoke(CachedConstructor.java:74)
....
```

### New Behaviour 
Set this error message for AtomicOperationConverterNotFoundException so it is visible in the logs.
```
com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationConverterNotFoundException: No atomic operation converter found for description 'destroyJob' and cloud provider 'kubernetes'. It is possible that either 1) the account name used for the operation is incorrect, or 2) the account name used for the operation is unhealthy/unable to communicate with kubernetes.
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:80)
	at org.codehaus.groovy.reflection.CachedConstructor.doConstructorInvoke(CachedConstructor.java:74)
	at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrap.callConstructor(ConstructorSite.java:84)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:249)
....
```
