### PR TITLE
fix(google): Added scope to the credentials

### DIFF
--- a/clouddriver-google-common/src/main/groovy/com/netflix/spinnaker/clouddriver/googlecommon/security/GoogleCommonCredentials.groovy
+++ b/clouddriver-google-common/src/main/groovy/com/netflix/spinnaker/clouddriver/googlecommon/security/GoogleCommonCredentials.groovy
@@ -28,7 +28,7 @@ import groovy.transform.CompileStatic
 class GoogleCommonCredentials {
   GoogleCredentials getCredentials() {
     // No JSON key was specified in matching config on key server, so use application default credentials.
-    GoogleCredentials.getApplicationDefault()
+    GoogleCredentials.getApplicationDefault().createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"))
   }
 
   HttpTransport buildHttpTransport() {


### PR DESCRIPTION
This is to address the issue [#6661](https://github.com/spinnaker/spinnaker/issues/6661)

Without scope, application default credentials results in authenticate failure. This PR fixes the issue by adding the scope.