### PR TITLE
feat(kubernetes): enable getManifest() to return Kubernetes system resources

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotater.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.netflix.frigga.Names;
+import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesResourceAwareNames;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.moniker.Moniker;
@@ -201,8 +201,13 @@ public class KubernetesManifestAnnotater {
   }
 
   public static Moniker getMoniker(KubernetesManifest manifest) {
-    Names parsed = Names.parseName(manifest.getName());
+    // first get the annotations
     Map<String, String> annotations = manifest.getAnnotations();
+    // attempt to get the names - this will be used in case there are no annotations
+    // use KubernetesResourceAwareNames so that it can handle special Kubernetes system resources.
+    // see KubernetesResourceAwareNames for more details
+    KubernetesResourceAwareNames parsed =
+        KubernetesResourceAwareNames.parseName(manifest.getName());
     Integer defaultSequence = parsed.getSequence();
 
     return Moniker.builder()

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/names/KubernetesResourceAwareNames.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/names/KubernetesResourceAwareNames.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2022 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.names;
+
+import com.netflix.frigga.NameConstants;
+import com.netflix.frigga.Names;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.Getter;
+
+/**
+ * the {@link Names} class is used for deconstructing information about AWS Auto Scaling Groups,
+ * Load Balancers, Launch Configurations, and Security Groups created by Asgard based on their name.
+ *
+ * <p>While the above class is mainly used for AWS, it works for most of the Kubernetes resources as
+ * well, since Kubernetes resources follow a similar naming convention. But there are certain
+ * Kubernetes resources which are reserved for Kubernetes system use that have the prefix "system:".
+ * See <a
+ * href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-subjects">Referring
+ * to subjects</a> for more details.
+ *
+ * <p>One such use of these resources is in {@link KubernetesKind#CLUSTER_ROLE} kind, which you can
+ * attempt to patch via Spinnaker. Because the {@link Names} class cannot parse this name, Spinnaker
+ * fails to return the manifest. This class is used to handle such resources in addition to all the
+ * other resources.
+ */
+@Getter
+public class KubernetesResourceAwareNames {
+
+  /**
+   * identifier for the special system resources. See <a
+   * href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-subjects">Referring
+   * to subjects</a> for more details
+   */
+  private static final String KUBERNETES_SYSTEM_RESOURCE_PREFIX = "system:";
+
+  /**
+   * A regex pattern to figure out if the manifest name has a version present in it. Used to obtain
+   * the sequence number for those resources that have the {@link
+   * KubernetesResourceAwareNames#KUBERNETES_SYSTEM_RESOURCE_PREFIX}.
+   */
+  private static final Pattern PUSH_PATTERN =
+      Pattern.compile(
+          "^([" + KUBERNETES_SYSTEM_RESOURCE_PREFIX + "].*)-(" + NameConstants.PUSH_FORMAT + ")$");
+
+  /**
+   * It gets the value from {@link Names#parseName(String)} for most of the Kubernetes resources.
+   * But for manifests with {@link
+   * KubernetesResourceAwareNames#KUBERNETES_SYSTEM_RESOURCE_PREFIX},it gets it from {@link
+   * KubernetesResourceAwareNames#parseName(String)}.
+   *
+   * <p>For example, if manifest name = system:coredns, then cluster = system:coredns.
+   *
+   * <p>if manifest name = system:coredns-v003, then cluster = system:coredns.
+   *
+   * <p>If manifest name = test-abc, cluster = test-abc
+   *
+   * <p>If manifest name = test-abc-v003, cluster = test-abc
+   *
+   * <p>See <a
+   * href="https://github.com/Netflix/frigga/blob/master/src/test/groovy/com/netflix/frigga/NamesSpec.groovy">
+   * ParseName Examples</a> for more details.
+   */
+  private final String cluster;
+
+  /**
+   * The Spinnaker Application to which this resource belongs to.
+   *
+   * <p>It gets the value from {@link Names#parseName(String)} for most of the Kubernetes resources.
+   * But for manifests with {@link KubernetesResourceAwareNames#KUBERNETES_SYSTEM_RESOURCE_PREFIX},
+   * it gets it from {@link KubernetesResourceAwareNames#parseName(String)}.
+   *
+   * <p>For example, if manifest name = system:coredns, then app = system.
+   *
+   * <p>If manifest name = test-abc, app = test
+   *
+   * <p>See <a
+   * href="https://github.com/Netflix/frigga/blob/master/src/test/groovy/com/netflix/frigga/NamesSpec.groovy">
+   * ParseName Examples</a> for more details.
+   */
+  private final String app;
+
+  /**
+   * The versioned sequence number of this manifest.
+   *
+   * <p>It gets the value from {@link Names#parseName(String)} for most of the Kubernetes
+   * resources.But for manifests with {@link
+   * KubernetesResourceAwareNames#KUBERNETES_SYSTEM_RESOURCE_PREFIX}, it gets it from {@link
+   * KubernetesResourceAwareNames#parseName(String)}.
+   *
+   * <p>For example, if manifest name = system:coredns, then sequence = null.
+   *
+   * <p>If manifest name = system:coredns-v003, then sequence = 3.
+   *
+   * <p>If manifest name = test-abc, sequence = null.
+   *
+   * <p>If manifest name = test-abc-v003, sequence = 3.
+   *
+   * <p>See <a
+   * href="https://github.com/Netflix/frigga/blob/master/src/test/groovy/com/netflix/frigga/NamesSpec.groovy">
+   * ParseName Examples</a> for more details.
+   */
+  private final Integer sequence;
+
+  public KubernetesResourceAwareNames(String cluster, String application, Integer sequence) {
+    this.cluster = cluster;
+    this.app = application;
+    this.sequence = sequence;
+  }
+
+  /**
+   * parses the given manifestName into a {@link KubernetesResourceAwareNames} object. It handles
+   * all types of Kubernetes manifests
+   *
+   * @param manifestName given manifest name
+   * @return {@link KubernetesResourceAwareNames} representation of the manifest name
+   */
+  public static KubernetesResourceAwareNames parseName(String manifestName) {
+    if (manifestName != null && !manifestName.trim().isEmpty()) {
+      if (manifestName.startsWith(KUBERNETES_SYSTEM_RESOURCE_PREFIX)) {
+        return parseSystemResourceName(manifestName);
+      }
+    }
+
+    Names parsed = Names.parseName(manifestName);
+    return new KubernetesResourceAwareNames(
+        parsed.getCluster(), parsed.getApp(), parsed.getSequence());
+  }
+
+  /**
+   * handles Kubernetes manifests that contain the prefix {@link
+   * KubernetesResourceAwareNames#KUBERNETES_SYSTEM_RESOURCE_PREFIX}.
+   *
+   * @param manifestName given manifest name
+   * @return {@link KubernetesResourceAwareNames} representation of the manifest name
+   */
+  private static KubernetesResourceAwareNames parseSystemResourceName(String manifestName) {
+    String[] split = manifestName.split(":");
+    Integer sequence = null;
+    Matcher pushMatcher = PUSH_PATTERN.matcher(manifestName);
+    boolean hasPush = pushMatcher.matches();
+
+    // if manifestName == "system:certificates.k8s.io:certificatesigningrequests:nodeclient-v003",
+    // then
+    // pushMatcher.group(0) =
+    // "system:certificates.k8s.io:certificatesigningrequests:nodeclient-v003",
+    // pushMatcher.group(1) = "system:certificates.k8s.io:certificatesigningrequests:nodeclient",
+    // pushMatcher.group(2) = "v003",
+    // pushMatcher.group(3) = "3"
+    String theCluster = hasPush ? pushMatcher.group(1) : manifestName;
+    String sequenceString = hasPush ? pushMatcher.group(3) : null;
+    if (sequenceString != null) {
+      sequence = Integer.parseInt(sequenceString);
+    }
+    // since this method is called only when the manifest name contains
+    // KUBERNETES_SYSTEM_RESOURCE_PREFIX, split[0] will always contain what we need, which
+    // is KUBERNETES_SYSTEM_RESOURCE_PREFIX without the ":"
+    return new KubernetesResourceAwareNames(theCluster, split[0], sequence);
+  }
+}

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotatorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotatorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.description.manifest;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.netflix.spinnaker.moniker.Moniker;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+
+public class KubernetesManifestAnnotatorTest {
+  @Test
+  public void testDeriveMonikerForAnUnversionedManifest() {
+    // when:
+    Moniker moniker =
+        KubernetesManifestAnnotater.getMoniker(manifest("testapp-abc", KubernetesKind.DEPLOYMENT));
+
+    // then:
+    assertThat(moniker.getApp()).isEqualTo("testapp");
+    assertThat(moniker.getCluster()).isEqualTo("testapp-abc");
+    assertThat(moniker.getStack()).isNull();
+    assertThat(moniker.getDetail()).isNull();
+    assertThat(moniker.getSequence()).isNull();
+  }
+
+  @Test
+  public void testDeriveMonikerForAVersionedManifestName() {
+    // when:
+    Moniker moniker =
+        KubernetesManifestAnnotater.getMoniker(
+            manifest("testapp-abc-v003", KubernetesKind.DEPLOYMENT));
+
+    // then:
+    assertThat(moniker.getApp()).isEqualTo("testapp");
+    assertThat(moniker.getCluster()).isEqualTo("testapp-abc");
+    assertThat(moniker.getStack()).isNull();
+    assertThat(moniker.getDetail()).isNull();
+    assertThat(moniker.getSequence()).isEqualTo(3);
+  }
+
+  @Test
+  public void testDeriveMonikerForAnUnversionedKubernetesSystemResource() {
+    // when:
+    Moniker moniker =
+        KubernetesManifestAnnotater.getMoniker(
+            manifest("system:coredns", KubernetesKind.DEPLOYMENT));
+
+    // then:
+    assertThat(moniker).isNotNull();
+    assertThat(moniker.getApp()).isEqualTo("system");
+    assertThat(moniker.getCluster()).isEqualTo("system:coredns");
+    assertThat(moniker.getStack()).isNull();
+    assertThat(moniker.getDetail()).isNull();
+    assertThat(moniker.getSequence()).isNull();
+  }
+
+  @Test
+  public void testDeriveMonikerForAnUnversionedKubernetesSystemResourceWithMultipleColons() {
+    // when:
+    Moniker moniker =
+        KubernetesManifestAnnotater.getMoniker(
+            manifest(
+                "system:certificates.k8s.io:certificatesigningrequests:nodeclient",
+                KubernetesKind.CLUSTER_ROLE));
+
+    // then:
+    assertThat(moniker).isNotNull();
+    assertThat(moniker.getApp()).isEqualTo("system");
+    assertThat(moniker.getCluster())
+        .isEqualTo("system:certificates.k8s.io:certificatesigningrequests:nodeclient");
+    assertThat(moniker.getStack()).isNull();
+    assertThat(moniker.getDetail()).isNull();
+    assertThat(moniker.getSequence()).isNull();
+  }
+
+  @Test
+  public void testDeriveMonikerForAVersionedKubernetesSystemResource() {
+    // when:
+    Moniker moniker =
+        KubernetesManifestAnnotater.getMoniker(
+            manifest(
+                "system:certificates.k8s.io:certificatesigningrequests:nodeclient-v003",
+                KubernetesKind.CLUSTER_ROLE));
+
+    // then:
+    assertThat(moniker).isNotNull();
+    assertThat(moniker.getApp()).isEqualTo("system");
+    assertThat(moniker.getCluster())
+        .isEqualTo("system:certificates.k8s.io:certificatesigningrequests:nodeclient");
+    assertThat(moniker.getStack()).isNull();
+    assertThat(moniker.getDetail()).isNull();
+    assertThat(moniker.getSequence()).isEqualTo(3);
+  }
+
+  /** A test manifest */
+  private static KubernetesManifest manifest(String deploymentName, KubernetesKind kind) {
+    KubernetesManifest deployment = new KubernetesManifest();
+    deployment.put("metadata", new HashMap<>());
+    deployment.setNamespace("namespace");
+    deployment.setKind(kind);
+    deployment.setApiVersion(KubernetesApiVersion.APPS_V1);
+    deployment.setName(deploymentName);
+    return deployment;
+  }
+}


### PR DESCRIPTION
the getManifest() endpoint fails to return Kubernetes system resources which have the prefix `"system:"` in their names. See [the Caution Note here](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-subjects) for more details about such resources.
> Caution: The prefix system: is reserved for Kubernetes system use, so you should ensure that you don't have users or groups with names that start with system: by accident. Other than this special prefix, the RBAC authorization system does not require any format for usernames.

This fix allows getManifest() endpoint to deal with such resources.

## Change

* API Call in question:
```
curl localhost:7002/manifests/test-account/kube-system/clusterrole%20system%3Acoredns?includeEvents=false -H "X-SPINNAKER-USER: someuser"
```

* Results

Before:
```
{"error":"Forbidden","message":"Access is denied","status":403,"timestamp":1647039540619}
```

After:
```
{
  "account":"test-account",
  "artifacts":[],
  "events":[],
   "location":"",
   "manifest": {
    ...
    }
   ...
}
```