### PR TITLE
feat(provider/azure): Wait for server group healthy before continuing

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/ops/AzureOpsConfig.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/ops/AzureOpsConfig.groovy
@@ -30,7 +30,7 @@ import groovy.util.logging.Slf4j
 class AzureOpsConfig {
 
   AzureOpsConfig() {
-    log.info("Constructor....AzureOpsConfig")
+    log.trace("Constructor....AzureOpsConfig")
   }
 
   @Bean

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/application/model/AzureApplication.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/application/model/AzureApplication.groovy
@@ -32,7 +32,7 @@ class AzureApplication implements Application, Serializable {
   Map<String, String> attributes = Collections.synchronizedMap(new HashMap<String, String>())
 
   AzureApplication(String name, Map<String, String> attributes, Map<String, Set<String>> clusterNames) {
-    log.info("Constructor....AzureApplication")
+    log.trace("Constructor....AzureApplication")
 
     this.name = name
     this.attributes = attributes

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/DeleteAzureLoadBalancerAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/DeleteAzureLoadBalancerAtomicOperationConverter.groovy
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component
 @Component("deleteAzureLoadBalancerDescription")
 class DeleteAzureLoadBalancerAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   public DeleteAzureLoadBalancerAtomicOperationConverter() {
-    log.info("Constructor....DeleteAzureLoadBalancerAtomicOperationConverter")
+    log.trace("Constructor....DeleteAzureLoadBalancerAtomicOperationConverter")
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/UpsertAzureLoadBalancerAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/UpsertAzureLoadBalancerAtomicOperationConverter.groovy
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component
 @Component("upsertAzureLoadBalancerDescription")
 class UpsertAzureLoadBalancerAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   UpsertAzureLoadBalancerAtomicOperationConverter() {
-    log.info("Constructor....UpsertAzureLoadBalancerAtomicOperationConverter")
+    log.trace("Constructor....UpsertAzureLoadBalancerAtomicOperationConverter")
   }
 
   AtomicOperation convertOperation(Map input) {
@@ -59,4 +59,3 @@ class UpsertAzureLoadBalancerAtomicOperationConverter extends AbstractAtomicOper
     }
   }
 }
-

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/converters/DeleteAzureSecurityGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/converters/DeleteAzureSecurityGroupAtomicOperationConverter.groovy
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component
 @Component("deleteAzureSecurityGroupDescription")
 class DeleteAzureSecurityGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   DeleteAzureSecurityGroupAtomicOperationConverter() {
-    log.info("Constructor....DeleteAzureSecurityGroupAtomicOperationConverter")
+    log.trace("Constructor....DeleteAzureSecurityGroupAtomicOperationConverter")
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/converters/UpsertAzureSecurityGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/converters/UpsertAzureSecurityGroupAtomicOperationConverter.groovy
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component
 @Component("upsertAzureSecurityGroupDescription")
 class UpsertAzureSecurityGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   UpsertAzureSecurityGroupAtomicOperationConverter() {
-    log.info("Constructor....UpsertAzureSecurityGroupAtomicOperationConverter")
+    log.trace("Constructor....UpsertAzureSecurityGroupAtomicOperationConverter")
   }
 
   AtomicOperation convertOperation(Map input) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/EnableAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/EnableAzureServerGroupAtomicOperation.groovy
@@ -72,6 +72,10 @@ class EnableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
                 .credentials
                 .networkClient
                 .enableServerGroupWithLoadBalancer(resourceGroupName, serverGroupDescription.loadBalancerName, serverGroupDescription.name)
+
+              // wait for health state to be up
+              description.credentials.networkClient.
+
               task.updateStatus BASE_PHASE, "Done enabling Azure server group ${serverGroupDescription.name} in ${region}."
             } else {
               task.updateStatus BASE_PHASE, "Azure server group ${serverGroupDescription.name} in ${region} is already enabled."
@@ -89,6 +93,7 @@ class EnableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
           } else {
             throw new RuntimeException("Azure server group with load balancer type $serverGroupDescription.loadBalancerType cannot be enabled.")
           }
+
 
         } catch (Exception e) {
           task.updateStatus(BASE_PHASE, "Enabling of server group ${description.name} failed: ${e.message}")

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DestroyAzureServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DestroyAzureServerGroupAtomicOperationConverter.groovy
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component
 @Component("destroyAzureServerGroupDescription")
 class DestroyAzureServerGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   DestroyAzureServerGroupAtomicOperationConverter() {
-    log.info("Constructor....DestroyAzureServerGroupAtomicOperationConverter")
+    log.trace("Constructor....DestroyAzureServerGroupAtomicOperationConverter")
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DisableAzureServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DisableAzureServerGroupAtomicOperationConverter.groovy
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component
 @Component("disableAzureServerGroupDescription")
 class DisableAzureServerGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   DisableAzureServerGroupAtomicOperationConverter() {
-    log.info("Constructor....DestroyAzureServerGroupAtomicOperationConverter")
+    log.trace("Constructor....DestroyAzureServerGroupAtomicOperationConverter")
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/EnableAzureServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/EnableAzureServerGroupAtomicOperationConverter.groovy
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component
 @Component("enableAzureServerGroupDescription")
 class EnableAzureServerGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport{
   EnableAzureServerGroupAtomicOperationConverter() {
-    log.info("Constructor....EnableAzureServerGroupAtomicOperationConverter")
+    log.trace("Constructor....EnableAzureServerGroupAtomicOperationConverter")
   }
 
   @Override

--- a/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupWithoutLoadBalancersAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupWithoutLoadBalancersAtomicOperation.groovy
@@ -29,6 +29,8 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
 import org.springframework.beans.factory.annotation.Autowired
 
+import static com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.CreateAzureServerGroupAtomicOperation.*
+
 class CreateAzureServerGroupWithoutLoadBalancersAtomicOperation implements AtomicOperation<Map> {
   private static final String BASE_PHASE = "CREATE_SERVER_GROUP"
 
@@ -140,6 +142,16 @@ class CreateAzureServerGroupWithoutLoadBalancersAtomicOperation implements Atomi
           "serverGroup",
           templateParameters)
 
+        def healthy = description.credentials.computeClient.waitForScaleSetHealthy(resourceGroupName, description.name, SERVER_WAIT_TIMEOUT);
+
+        if (healthy) {
+          getTask().updateStatus(BASE_PHASE, String.format(
+            "Done enabling Azure server group %s in %s.",
+            description.getName(), description.getRegion()))
+        } else {
+          errList.add("Server group did not come up in time")
+        }
+
         errList.addAll(AzureDeploymentOperation.checkDeploymentOperationStatus(task, BASE_PHASE, description.credentials, resourceGroupName, deployment.name()))
         serverGroupName = errList.isEmpty() ? description.name : null
       }
@@ -157,14 +169,14 @@ class CreateAzureServerGroupWithoutLoadBalancersAtomicOperation implements Atomi
       // cleanup any resources that might have been created prior to server group failing to deploy
       task.updateStatus(BASE_PHASE, "Cleanup any resources created as part of server group upsert")
       try {
-        if (serverGroupName) {
+        if (description.name) {
           def sgDescription = description.credentials
             .computeClient
-            .getServerGroup(resourceGroupName, serverGroupName)
+            .getServerGroup(resourceGroupName, description.name)
           if (sgDescription) {
             description.credentials
               .computeClient
-              .destroyServerGroup(resourceGroupName, serverGroupName)
+              .destroyServerGroup(resourceGroupName, description.name)
 
             // If this an Azure Market Store image, delete the storage that was created for it as well
             if (!sgDescription.image.isCustom) {

--- a/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/ResizeAzureServerGroupAtomicOperationConverter.java
+++ b/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/ResizeAzureServerGroupAtomicOperationConverter.java
@@ -38,7 +38,7 @@ public class ResizeAzureServerGroupAtomicOperationConverter
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   public ResizeAzureServerGroupAtomicOperationConverter() {
-    log.info("Constructor....ResizeAzureServerGroupAtomicOperationConverter");
+    log.trace("Constructor....ResizeAzureServerGroupAtomicOperationConverter");
   }
 
   @Override


### PR DESCRIPTION
* After spinning up a server group, wait until it is healthy before marking complete the deployment
* Move some logging of constructors to TRACE (they are just clutter)

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
