### PR TITLE
feat(provider/azure): Wait for server group healthy before continuing

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/ops/AzureOpsConfig.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/ops/AzureOpsConfig.groovy
@@ -30,7 +30,7 @@ import groovy.util.logging.Slf4j
 class AzureOpsConfig {
 
   AzureOpsConfig() {
-    log.info("Constructor....AzureOpsConfig")
+    log.trace("Constructor....AzureOpsConfig")
   }
 
   @Bean

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/application/model/AzureApplication.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/application/model/AzureApplication.groovy
@@ -32,7 +32,7 @@ class AzureApplication implements Application, Serializable {
   Map<String, String> attributes = Collections.synchronizedMap(new HashMap<String, String>())
 
   AzureApplication(String name, Map<String, String> attributes, Map<String, Set<String>> clusterNames) {
-    log.info("Constructor....AzureApplication")
+    log.trace("Constructor....AzureApplication")
 
     this.name = name
     this.attributes = attributes

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/DeleteAzureLoadBalancerAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/DeleteAzureLoadBalancerAtomicOperationConverter.groovy
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component
 @Component("deleteAzureLoadBalancerDescription")
 class DeleteAzureLoadBalancerAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   public DeleteAzureLoadBalancerAtomicOperationConverter() {
-    log.info("Constructor....DeleteAzureLoadBalancerAtomicOperationConverter")
+    log.trace("Constructor....DeleteAzureLoadBalancerAtomicOperationConverter")
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/UpsertAzureLoadBalancerAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/UpsertAzureLoadBalancerAtomicOperationConverter.groovy
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component
 @Component("upsertAzureLoadBalancerDescription")
 class UpsertAzureLoadBalancerAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   UpsertAzureLoadBalancerAtomicOperationConverter() {
-    log.info("Constructor....UpsertAzureLoadBalancerAtomicOperationConverter")
+    log.trace("Constructor....UpsertAzureLoadBalancerAtomicOperationConverter")
   }
 
   AtomicOperation convertOperation(Map input) {
@@ -59,4 +59,3 @@ class UpsertAzureLoadBalancerAtomicOperationConverter extends AbstractAtomicOper
     }
   }
 }
-

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/converters/DeleteAzureSecurityGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/converters/DeleteAzureSecurityGroupAtomicOperationConverter.groovy
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component
 @Component("deleteAzureSecurityGroupDescription")
 class DeleteAzureSecurityGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   DeleteAzureSecurityGroupAtomicOperationConverter() {
-    log.info("Constructor....DeleteAzureSecurityGroupAtomicOperationConverter")
+    log.trace("Constructor....DeleteAzureSecurityGroupAtomicOperationConverter")
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/converters/UpsertAzureSecurityGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/converters/UpsertAzureSecurityGroupAtomicOperationConverter.groovy
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component
 @Component("upsertAzureSecurityGroupDescription")
 class UpsertAzureSecurityGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   UpsertAzureSecurityGroupAtomicOperationConverter() {
-    log.info("Constructor....UpsertAzureSecurityGroupAtomicOperationConverter")
+    log.trace("Constructor....UpsertAzureSecurityGroupAtomicOperationConverter")
   }
 
   AtomicOperation convertOperation(Map input) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DestroyAzureServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DestroyAzureServerGroupAtomicOperationConverter.groovy
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component
 @Component("destroyAzureServerGroupDescription")
 class DestroyAzureServerGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   DestroyAzureServerGroupAtomicOperationConverter() {
-    log.info("Constructor....DestroyAzureServerGroupAtomicOperationConverter")
+    log.trace("Constructor....DestroyAzureServerGroupAtomicOperationConverter")
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DisableAzureServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DisableAzureServerGroupAtomicOperationConverter.groovy
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component
 @Component("disableAzureServerGroupDescription")
 class DisableAzureServerGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   DisableAzureServerGroupAtomicOperationConverter() {
-    log.info("Constructor....DestroyAzureServerGroupAtomicOperationConverter")
+    log.trace("Constructor....DestroyAzureServerGroupAtomicOperationConverter")
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/EnableAzureServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/EnableAzureServerGroupAtomicOperationConverter.groovy
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component
 @Component("enableAzureServerGroupDescription")
 class EnableAzureServerGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport{
   EnableAzureServerGroupAtomicOperationConverter() {
-    log.info("Constructor....EnableAzureServerGroupAtomicOperationConverter")
+    log.trace("Constructor....EnableAzureServerGroupAtomicOperationConverter")
   }
 
   @Override

--- a/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupWithoutLoadBalancersAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupWithoutLoadBalancersAtomicOperation.groovy
@@ -29,6 +29,8 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
 import org.springframework.beans.factory.annotation.Autowired
 
+import static com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.CreateAzureServerGroupAtomicOperation.*
+
 class CreateAzureServerGroupWithoutLoadBalancersAtomicOperation implements AtomicOperation<Map> {
   private static final String BASE_PHASE = "CREATE_SERVER_GROUP"
 
@@ -140,6 +142,16 @@ class CreateAzureServerGroupWithoutLoadBalancersAtomicOperation implements Atomi
           "serverGroup",
           templateParameters)
 
+        def healthy = description.credentials.computeClient.waitForScaleSetHealthy(resourceGroupName, description.name, SERVER_WAIT_TIMEOUT);
+
+        if (healthy) {
+          getTask().updateStatus(BASE_PHASE, String.format(
+            "Done enabling Azure server group %s in %s.",
+            description.getName(), description.getRegion()))
+        } else {
+          errList.add("Server group did not come up in time")
+        }
+
         errList.addAll(AzureDeploymentOperation.checkDeploymentOperationStatus(task, BASE_PHASE, description.credentials, resourceGroupName, deployment.name()))
         serverGroupName = errList.isEmpty() ? description.name : null
       }
@@ -157,14 +169,14 @@ class CreateAzureServerGroupWithoutLoadBalancersAtomicOperation implements Atomi
       // cleanup any resources that might have been created prior to server group failing to deploy
       task.updateStatus(BASE_PHASE, "Cleanup any resources created as part of server group upsert")
       try {
-        if (serverGroupName) {
+        if (description.name) {
           def sgDescription = description.credentials
             .computeClient
-            .getServerGroup(resourceGroupName, serverGroupName)
+            .getServerGroup(resourceGroupName, description.name)
           if (sgDescription) {
             description.credentials
               .computeClient
-              .destroyServerGroup(resourceGroupName, serverGroupName)
+              .destroyServerGroup(resourceGroupName, description.name)
 
             // If this an Azure Market Store image, delete the storage that was created for it as well
             if (!sgDescription.image.isCustom) {

--- a/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/ResizeAzureServerGroupAtomicOperationConverter.java
+++ b/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/ResizeAzureServerGroupAtomicOperationConverter.java
@@ -38,7 +38,7 @@ public class ResizeAzureServerGroupAtomicOperationConverter
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   public ResizeAzureServerGroupAtomicOperationConverter() {
-    log.info("Constructor....ResizeAzureServerGroupAtomicOperationConverter");
+    log.trace("Constructor....ResizeAzureServerGroupAtomicOperationConverter");
   }
 
   @Override


### PR DESCRIPTION
## Problem

In Azure, deployments complete immediately regardless of the health status of the instance. This causes deployments of bad code to bring down a working service.

## Solution

When deploying Azure VM scale sets, wait for the scale set to become healthy before marking it complete. If not healthy after a period of time, mark the deployment as failed.

This also fixes a bug where if the server group did not come up for some reason other than timeout, it would not actually get cleaned up.

## Testing done

1. Deploy healthy VM scale set
2. Deploy unhealthy VM scale set (I changed my customData cloud-init script to not work correctly)
3. Wait to see if Spinnaker marks the deployment complete
4. Spinnaker does not show the deployment completes