### PR TITLE
fix(provider/azure): Remove unused serverGroups tags

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureAppGatewayResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureAppGatewayResourceTemplate.groovy
@@ -140,7 +140,6 @@ class AzureAppGatewayResourceTemplate {
       if (description.stack) tags.stack = description.stack
       if (description.detail) tags.detail = description.detail
       if (description.cluster) tags.cluster = description.cluster
-      if (description.serverGroups) tags.serverGroups = description.serverGroups.join(" ")
       if (description.securityGroup) tags.securityGroup = description.securityGroup
       if (description.vnet) tags.vnet = description.vnet
       if (description.subnet) tags.subnet = description.subnet

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/template/AzureAppGatewayResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/template/AzureAppGatewayResourceTemplateSpec.groovy
@@ -186,7 +186,6 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
       "stack" : "lb1",
       "detail" : "d1",
       "cluster" : "testappgw-sg1-d1",
-      "serverGroups" : "testappgw-sg1-d1-v000 testappgw-sg1-d1-v001",
       "vnet" : "vnet-testappgw-westus",
       "subnet" : "subnet-testappgw-lb1-d1",
       "vnetResourceGroup" : null


### PR DESCRIPTION
## Background

When a server group is deployed to a load balancer or application gateway, the server groups that are associated with that load balancer or app gateway are appended to a tag named `serverGroups` on that load balancer or app gateway. This tag isn't used for anything within clouddriver.

## Problem

If a scale set is destroyed outside of Spinnaker, the tag does not get cleaned up. Tags in Azure have a maximum length of 256 characters. For a server group such as `foo-bar-v001`, this means that having 20 server groups destroyed outside of Spinnaker would prevent a new scale set from being deployed.

## Solution

Since these tags were not used for anything besides debugging, I just removed them entirely. They will not be cleaned up from existing load balancers, nor will they ever be modified by Spinnaker.

## Testing done

* Verified that no new tags were added on scale set deployment
* Verified that no tags were removed on scale set destruction/disable
* Verified that associated scale sets still show up on the "load balancers" section in deck