### PR TITLE
fix(build): Remove temporary workaround from 2016

### DIFF
--- a/clouddriver-azure/clouddriver-azure.gradle
+++ b/clouddriver-azure/clouddriver-azure.gradle
@@ -1,7 +1,3 @@
-repositories {
-  maven { url "https://adxsnapshots.azurewebsites.net" }
-}
-
 dependencies {
   implementation project(":clouddriver-api")
   implementation project(":clouddriver-core")

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -14,10 +14,6 @@ configurations.all {
   exclude group: "org.slf4j", module: "slf4j-log4j12"
 }
 
-repositories {
-  maven { url "https://adxsnapshots.azurewebsites.net" }
-}
-
 dependencies {
   implementation project(":cats:cats-core")
   implementation project(":clouddriver-api")


### PR DESCRIPTION
In 2016 there was an addition of the Microsoft SNAPSHOT repo to temporarily
fix an issue. The change was supposed to be short term, according to the
original PR #402.
