### PR TITLE
fix(provider/azure): Fix scale health

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -199,10 +199,10 @@ public class AzureComputeClient extends AzureBaseClient {
    * check the scale set's health status, wait for the timeout return true when healthy, false if we hit the timeout
    */
   Boolean waitForScaleSetHealthy(String resourceGroupName, String serverGroupName, long timeoutMillis) {
-    def instances = getServerGroupInstances(resourceGroupName, serverGroupName)
     def now = System.nanoTime()
     def currentTime = System.nanoTime()
     while (currentTime - now < timeoutMillis * 1000000) {
+      def instances = getServerGroupInstances(resourceGroupName, serverGroupName)
       if (!instances.any { it.healthState != HealthState.Up }) {
         return true
       }


### PR DESCRIPTION
Before this change, if a scale set was unhealthy at the outset and became healthy after a period of time, the instance state never got updated, so Spinnaker always saw it was unhealthy.