### PR TITLE
fix(provider/azure): Allow internal load balancers to show up

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
@@ -71,10 +71,12 @@ class AzureNetworkClient extends AzureBaseClient {
         if (item.inner().location() == region) {
           try {
             def lbItem = AzureLoadBalancerDescription.build(item.inner())
-            lbItem.dnsName = getDnsNameForPublicIp(
-              AzureUtilities.getResourceGroupNameFromResourceId(item.id()),
-              AzureUtilities.getNameFromResourceId(item.publicIPAddressIds()?.first())
-            )
+            if (item.publicIPAddressIds() && !item.publicIPAddressIds().isEmpty()) {
+              lbItem.dnsName = getDnsNameForPublicIp(
+                AzureUtilities.getResourceGroupNameFromResourceId(item.id()),
+                AzureUtilities.getNameFromResourceId(item.publicIPAddressIds()?.first())
+              )
+            }
             lbItem.lastReadTime = currentTime
             result += lbItem
           } catch (RuntimeException re) {
@@ -721,7 +723,6 @@ class AzureNetworkClient extends AzureBaseClient {
         log.error(errMsg)
         throw new RuntimeException(errMsg)
       }
-
       loadBalancer.loadBalancingRules().each { name, rule ->
         // Use reflection to modify the backend of load balancer because Azure Java SDK doesn't provide a way to do this
         Object o = loadBalancer.update()

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescription.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model
 
 import com.microsoft.azure.management.network.LoadBalancer
 import com.microsoft.azure.management.network.TransportProtocol
+import com.microsoft.azure.management.network.implementation.FrontendIPConfigurationInner
 import com.microsoft.azure.management.network.implementation.LoadBalancerInner
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
@@ -96,7 +97,11 @@ class AzureLoadBalancerDescription extends AzureResourceOpsDescription {
     description.tags.putAll(azureLoadBalancer.tags)
     description.region = azureLoadBalancer.location()
     description.internal = azureLoadBalancer.tags?.internal != null
-    description.publicIpName = AzureUtilities.getNameFromResourceId(azureLoadBalancer?.frontendIPConfigurations().first().publicIPAddress().id())
+
+    def frontendIPConfigurations = azureLoadBalancer?.frontendIPConfigurations()
+    if (frontendIPConfigurations != null && !frontendIPConfigurations.isEmpty()) {
+      description.publicIpName = AzureUtilities.getNameFromResourceId(frontendIPConfigurations?.first()?.publicIPAddress()?.id())
+    }
 
     // Each load balancer backend address pool corresponds to a server group (except the "default_LB_BAP")
     description.serverGroups = []


### PR DESCRIPTION
Fixes a bug where internal load balancers would cause a NullPointerException.

This does *not* allow internal load balancers to be created through the UI.

## Testing done

1. Create internal load balancer (**must be Standard SKU**)
2. Create default backend pool
3. Create health probe
4. Create load balancing rule
5. Deploy to load balancer
6. Deploy again to the load balancer