### PR TITLE
feat(artifacts/s3): make the AmazonS3 client used for retrieving s3 a…

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactConfiguration.java
@@ -35,7 +35,9 @@ class S3ArtifactConfiguration {
 
   @Bean
   public CredentialsTypeProperties<S3ArtifactCredentials, S3ArtifactAccount>
-      s3CredentialsProperties(Optional<S3ArtifactValidator> s3ArtifactValidator) {
+      s3CredentialsProperties(
+          Optional<S3ArtifactValidator> s3ArtifactValidator,
+          S3ArtifactProviderProperties s3ArtifactProviderProperties) {
     return CredentialsTypeProperties.<S3ArtifactCredentials, S3ArtifactAccount>builder()
         .type(S3ArtifactCredentials.CREDENTIALS_TYPE)
         .credentialsClass(S3ArtifactCredentials.class)
@@ -44,7 +46,8 @@ class S3ArtifactConfiguration {
         .credentialsParser(
             a -> {
               try {
-                return new S3ArtifactCredentials(a, s3ArtifactValidator);
+                return new S3ArtifactCredentials(
+                    a, s3ArtifactValidator, s3ArtifactProviderProperties);
               } catch (Exception e) {
                 log.warn("Failure instantiating s3 artifact account {}: ", a, e);
                 return null;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactProviderProperties.java
@@ -27,4 +27,55 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 final class S3ArtifactProviderProperties implements ArtifactProvider<S3ArtifactAccount> {
   private boolean enabled;
   private List<S3ArtifactAccount> accounts = new ArrayList<>();
+
+  /**
+   * See
+   * https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html#setClientExecutionTimeout-int-
+   */
+  private Integer clientExecutionTimeout;
+
+  /**
+   * See
+   * https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html#setConnectionMaxIdleMillis-long-
+   */
+  private Long connectionMaxIdleMillis;
+
+  /**
+   * See
+   * https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html#setConnectionTimeout-int-
+   */
+  private Integer connectionTimeout;
+
+  /**
+   * See
+   * https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html#setConnectionTTL-long-
+   * The units are milliseconds.
+   */
+  private Long connectionTTL;
+
+  /**
+   * See
+   * https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html#setMaxConnections-int-
+   */
+  private Integer maxConnections;
+
+  /**
+   * See
+   * https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html#setRequestTimeout-int-
+   * The units are milliseconds.
+   */
+  private Integer requestTimeout;
+
+  /**
+   * See
+   * https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html#setSocketTimeout-int-
+   * The units are milliseconds.
+   */
+  private Integer socketTimeout;
+
+  /**
+   * See
+   * https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html#setValidateAfterInactivityMillis-int-
+   */
+  private Integer validateAfterInactivityMillis;
 }


### PR DESCRIPTION
…rtifacts configurable

It's possible that some of these settings are useful per-s3-artifact-account (i.e. in
S3ArtifactAccount) as opposed to shared across accounts (where they are in
S3ArtifactProviderProperties).  Until then, it's simpler to set them in one place.
