### PR TITLE
fix(azure): increase health interval

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -201,12 +201,17 @@ public class AzureComputeClient extends AzureBaseClient {
   Boolean waitForScaleSetHealthy(String resourceGroupName, String serverGroupName, long timeoutMillis) {
     def now = System.nanoTime()
     def currentTime = System.nanoTime()
+
+    // TODO: use available health probes to determine the sleep time
+    def sleepTimeSeconds = 5
+
     while (currentTime - now < timeoutMillis * 1000000) {
       def instances = getServerGroupInstances(resourceGroupName, serverGroupName)
       if (!instances.any { it.healthState != HealthState.Up }) {
         return true
       }
-      Thread.sleep(100)
+
+      Thread.sleep(sleepTimeSeconds * 1000)
       currentTime = System.nanoTime()
     }
 


### PR DESCRIPTION
#### Problem
- Azure healthy instance checks create many calls to the resource pages on Azure ultimately resulting in "Too many requests" errors on the portal pages.

#### Solution
- increase the timeout to 5 seconds 