### PR TITLE
fix(caching): K8s cache affected when not enough permissions in service account

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -453,8 +453,14 @@ public class KubectlJobExecutor {
             parseManifestList());
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
-      throw new KubectlException(
-          "Failed to read " + kinds + " from " + namespace + ": " + status.getError());
+      boolean permissionError =
+          org.apache.commons.lang3.StringUtils.containsIgnoreCase(status.getError(), "forbidden");
+      if (permissionError) {
+        log.warn(status.getError());
+      } else {
+        throw new KubectlException(
+            "Failed to read " + kinds + " from " + namespace + ": " + status.getError());
+      }
     }
 
     if (status.getError().contains("No resources found")) {


### PR DESCRIPTION
k8s-kind listing is able to return partial results when not enough permissions in the service account exist but because we are throwing an error even partial entries are not being cached.
This fix will not throw an error when it is permission related only for k8s caching.
