### PR TITLE
feat(Aws-Lambda): Added Endpoints to delete Concurrencies

### DIFF
--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/converters/DeleteLambdaProvisionedConcurrencyAtomicOperationConverter.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/converters/DeleteLambdaProvisionedConcurrencyAtomicOperationConverter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.lambda.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.lambda.deploy.description.DeleteLambdaProvisionedConcurrencyDescription;
+import com.netflix.spinnaker.clouddriver.lambda.deploy.ops.DeleteLambdaProvisionedConcurrencyAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component("deleteLambdaProvisionedConcurrency")
+public class DeleteLambdaProvisionedConcurrencyAtomicOperationConverter
+    extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new DeleteLambdaProvisionedConcurrencyAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public DeleteLambdaProvisionedConcurrencyDescription convertDescription(Map input) {
+    DeleteLambdaProvisionedConcurrencyDescription converted =
+        getObjectMapper().convertValue(input, DeleteLambdaProvisionedConcurrencyDescription.class);
+    converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
+
+    return converted;
+  }
+}

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/converters/DeleteLambdaReservedConcurrencyAtomicOperationConverter.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/converters/DeleteLambdaReservedConcurrencyAtomicOperationConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.lambda.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.lambda.deploy.description.DeleteLambdaReservedConcurrencyDescription;
+import com.netflix.spinnaker.clouddriver.lambda.deploy.ops.DeleteLambdaReservedConcurrencyAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component("deleteLambdaReservedConcurrency")
+public class DeleteLambdaReservedConcurrencyAtomicOperationConverter
+    extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new DeleteLambdaReservedConcurrencyAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public DeleteLambdaReservedConcurrencyDescription convertDescription(Map input) {
+    DeleteLambdaReservedConcurrencyDescription converted =
+        getObjectMapper().convertValue(input, DeleteLambdaReservedConcurrencyDescription.class);
+    converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
+
+    return converted;
+  }
+}

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/description/DeleteLambdaProvisionedConcurrencyDescription.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/description/DeleteLambdaProvisionedConcurrencyDescription.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.lambda.deploy.description;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class DeleteLambdaProvisionedConcurrencyDescription
+    extends AbstractLambdaFunctionDescription {
+  String functionName;
+  String qualifier;
+}

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/description/DeleteLambdaReservedConcurrencyDescription.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/description/DeleteLambdaReservedConcurrencyDescription.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.lambda.deploy.description;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class DeleteLambdaReservedConcurrencyDescription extends AbstractLambdaFunctionDescription {
+  String functionName;
+}

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/DeleteLambdaProvisionedConcurrencyAtomicOperation.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/DeleteLambdaProvisionedConcurrencyAtomicOperation.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.lambda.deploy.ops;
+
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.model.DeleteProvisionedConcurrencyConfigRequest;
+import com.amazonaws.services.lambda.model.DeleteProvisionedConcurrencyConfigResult;
+import com.netflix.spinnaker.clouddriver.lambda.deploy.description.DeleteLambdaProvisionedConcurrencyDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import java.util.List;
+
+public class DeleteLambdaProvisionedConcurrencyAtomicOperation
+    extends AbstractLambdaAtomicOperation<
+        DeleteLambdaProvisionedConcurrencyDescription, DeleteProvisionedConcurrencyConfigResult>
+    implements AtomicOperation<DeleteProvisionedConcurrencyConfigResult> {
+
+  public DeleteLambdaProvisionedConcurrencyAtomicOperation(
+      DeleteLambdaProvisionedConcurrencyDescription description) {
+    super(description, "DELETE_LAMBDA_FUNCTION_PROVISIONED_CONCURRENCY");
+  }
+
+  @Override
+  public DeleteProvisionedConcurrencyConfigResult operate(List priorOutputs) {
+    updateTaskStatus(
+        "Initializing Atomic Operation AWS Lambda for DeleteProvisionedConcurrency...");
+    return deleteProvisionedFunctionConcurrency(
+        description.getFunctionName(), description.getQualifier());
+  }
+
+  private DeleteProvisionedConcurrencyConfigResult deleteProvisionedFunctionConcurrency(
+      String functionName, String qualifier) {
+    AWSLambda client = getLambdaClient();
+    DeleteProvisionedConcurrencyConfigRequest req =
+        new DeleteProvisionedConcurrencyConfigRequest()
+            .withFunctionName(functionName)
+            .withQualifier(qualifier);
+
+    DeleteProvisionedConcurrencyConfigResult result =
+        client.deleteProvisionedConcurrencyConfig(req);
+    updateTaskStatus("Finished Atomic Operation AWS Lambda for DeleteProvisionedConcurrency...");
+    return result;
+  }
+}

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/DeleteLambdaReservedConcurrencyAtomicOperation.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/DeleteLambdaReservedConcurrencyAtomicOperation.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.lambda.deploy.ops;
+
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.model.DeleteFunctionConcurrencyRequest;
+import com.amazonaws.services.lambda.model.DeleteFunctionConcurrencyResult;
+import com.netflix.spinnaker.clouddriver.lambda.deploy.description.DeleteLambdaReservedConcurrencyDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import java.util.List;
+
+public class DeleteLambdaReservedConcurrencyAtomicOperation
+    extends AbstractLambdaAtomicOperation<
+        DeleteLambdaReservedConcurrencyDescription, DeleteFunctionConcurrencyResult>
+    implements AtomicOperation<DeleteFunctionConcurrencyResult> {
+
+  public DeleteLambdaReservedConcurrencyAtomicOperation(
+      DeleteLambdaReservedConcurrencyDescription description) {
+    super(description, "DELETE_LAMBDA_FUNCTION_RESERVED_CONCURRENCY");
+  }
+
+  @Override
+  public DeleteFunctionConcurrencyResult operate(List priorOutputs) {
+    updateTaskStatus("Initializing Atomic Operation AWS Lambda for DeleteReservedConcurrency...");
+    return deleteReservedFunctionConcurrency(description.getFunctionName());
+  }
+
+  private DeleteFunctionConcurrencyResult deleteReservedFunctionConcurrency(String functionName) {
+    AWSLambda client = getLambdaClient();
+    DeleteFunctionConcurrencyRequest req =
+        new DeleteFunctionConcurrencyRequest().withFunctionName(functionName);
+
+    DeleteFunctionConcurrencyResult result = client.deleteFunctionConcurrency(req);
+    updateTaskStatus("Finished Atomic Operation AWS Lambda for DeleteReservedConcurrency...");
+    return result;
+  }
+}

--- a/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/DeleteLambdaProvisionedConcurrencyAtomicOperationTest.java
+++ b/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/DeleteLambdaProvisionedConcurrencyAtomicOperationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.lambda.deploy.ops;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.model.DeleteProvisionedConcurrencyConfigRequest;
+import com.amazonaws.services.lambda.model.DeleteProvisionedConcurrencyConfigResult;
+import com.netflix.spinnaker.clouddriver.lambda.cache.model.LambdaFunction;
+import com.netflix.spinnaker.clouddriver.lambda.deploy.description.DeleteLambdaProvisionedConcurrencyDescription;
+import com.netflix.spinnaker.clouddriver.lambda.provider.view.LambdaFunctionProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class DeleteLambdaProvisionedConcurrencyAtomicOperationTest
+    implements LambdaTestingDefaults {
+  @Test
+  void testDeleteProvisionedConcurrency() {
+    DeleteLambdaProvisionedConcurrencyDescription deleteDesc =
+        new DeleteLambdaProvisionedConcurrencyDescription();
+    deleteDesc.setFunctionName(fName).setQualifier(version);
+
+    DeleteLambdaProvisionedConcurrencyAtomicOperation deleteOperation =
+        spy(new DeleteLambdaProvisionedConcurrencyAtomicOperation(deleteDesc));
+    doNothing().when(deleteOperation).updateTaskStatus(anyString());
+
+    AWSLambda lambdaClient = mock(AWSLambda.class);
+    LambdaFunction cachedFunction = getMockedFunctionDefintion();
+
+    LambdaFunctionProvider lambdaFunctionProvider = mock(LambdaFunctionProvider.class);
+    ReflectionTestUtils.setField(deleteOperation, "lambdaFunctionProvider", lambdaFunctionProvider);
+
+    doReturn(lambdaClient).when(deleteOperation).getLambdaClient();
+    doReturn(cachedFunction)
+        .when(lambdaFunctionProvider)
+        .getFunction(anyString(), anyString(), anyString());
+
+    DeleteProvisionedConcurrencyConfigRequest deleteRequest =
+        new DeleteProvisionedConcurrencyConfigRequest();
+    deleteRequest.withQualifier(version).withFunctionName(fName);
+    DeleteProvisionedConcurrencyConfigResult mockDeleteResult =
+        new DeleteProvisionedConcurrencyConfigResult();
+    doReturn(mockDeleteResult).when(lambdaClient).deleteProvisionedConcurrencyConfig(deleteRequest);
+
+    DeleteProvisionedConcurrencyConfigResult output = deleteOperation.operate(null);
+    verify(deleteOperation, atLeastOnce()).updateTaskStatus(anyString());
+    assertThat(output).isEqualTo(mockDeleteResult);
+  }
+}

--- a/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/DeleteLambdaReservedConcurrencyAtomicOperationTest.java
+++ b/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/DeleteLambdaReservedConcurrencyAtomicOperationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.lambda.deploy.ops;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.model.DeleteFunctionConcurrencyRequest;
+import com.amazonaws.services.lambda.model.DeleteFunctionConcurrencyResult;
+import com.netflix.spinnaker.clouddriver.lambda.cache.model.LambdaFunction;
+import com.netflix.spinnaker.clouddriver.lambda.deploy.description.DeleteLambdaReservedConcurrencyDescription;
+import com.netflix.spinnaker.clouddriver.lambda.provider.view.LambdaFunctionProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class DeleteLambdaReservedConcurrencyAtomicOperationTest implements LambdaTestingDefaults {
+  @Test
+  void testDeleteReservedConcurrency() {
+    DeleteLambdaReservedConcurrencyDescription deleteDesc =
+        new DeleteLambdaReservedConcurrencyDescription();
+    deleteDesc.setFunctionName(fName);
+
+    DeleteLambdaReservedConcurrencyAtomicOperation deleteOperation =
+        spy(new DeleteLambdaReservedConcurrencyAtomicOperation(deleteDesc));
+    doNothing().when(deleteOperation).updateTaskStatus(anyString());
+
+    AWSLambda lambdaClient = mock(AWSLambda.class);
+    LambdaFunction cachedFunction = getMockedFunctionDefintion();
+
+    LambdaFunctionProvider lambdaFunctionProvider = mock(LambdaFunctionProvider.class);
+    ReflectionTestUtils.setField(deleteOperation, "lambdaFunctionProvider", lambdaFunctionProvider);
+
+    doReturn(lambdaClient).when(deleteOperation).getLambdaClient();
+    doReturn(cachedFunction)
+        .when(lambdaFunctionProvider)
+        .getFunction(anyString(), anyString(), anyString());
+
+    DeleteFunctionConcurrencyRequest deleteRequest = new DeleteFunctionConcurrencyRequest();
+    deleteRequest.withFunctionName(fName);
+    DeleteFunctionConcurrencyResult mockDeleteResult = new DeleteFunctionConcurrencyResult();
+    doReturn(mockDeleteResult).when(lambdaClient).deleteFunctionConcurrency(deleteRequest);
+
+    DeleteFunctionConcurrencyResult output = deleteOperation.operate(null);
+    verify(deleteOperation, atLeastOnce()).updateTaskStatus(anyString());
+    assertThat(output).isEqualTo(mockDeleteResult);
+  }
+}


### PR DESCRIPTION
This PR is to solve an issue found on this plugin [AWS Lambda](https://github.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker), we are adding the possibility to delete both Provisioned and Reserved Concurrencies when deploying and routing a lambda stages.

The updates on the plugin are on this PR [Plugin PR](https://github.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/pull/117).