### PR TITLE
chore(protobuf): Update protobuf for M1 support

### DIFF
--- a/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
+++ b/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.google.protobuf'
 apply plugin: "org.junit.platform.gradle.plugin"
 
 ext {
-  protobufVersion = '3.6.1'
+  protobufVersion = '3.21.2'
 }
 
 protobuf {

--- a/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver-titus/clouddriver-titus.gradle
@@ -1,8 +1,8 @@
 apply plugin: "com.google.protobuf"
 
 ext {
-  protobufVersion = '[3.2.0,3.17.3]'
-  grpcVersion = '1.37.1'
+  protobufVersion = '3.21.2'
+  grpcVersion = '1.47.0'
 }
 
 dependencies {


### PR DESCRIPTION
This makes it possible to build clouddriver on M1 Macs.

Needs testing - ref. #5706.