### PR TITLE
chore(dockerfile): upgrade to latest alpine image

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine3.12
+FROM python:3.7-alpine3.16
 LABEL maintainer="sig-platform@spinnaker.io"
 
 # KUBECTL_RELEASE kept one minor version behind latest to maximise compatibility overlap


### PR DESCRIPTION
This resolves a performance issue in JDK11 when Spinnaker is running in
a cluster with containerd.