### PR TITLE
Support upper case on the tag of image

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProvider.java
@@ -44,7 +44,7 @@ public class EcrImageProvider implements ImageRepositoryProvider {
   private static final Pattern REPOSITORY_NAME_PATTERN =
       Pattern.compile(
           "\\/(((?:[a-z0-9]+(?:[._-][a-z0-9]+)*\\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*){2,})");
-  private static final String IDENTIFIER_PATTERN = "(:([a-z0-9._-]+)|@(sha256:[0-9a-f]{64}))";
+  private static final String IDENTIFIER_PATTERN = "(:([a-zA-Z0-9._-]+)|@(sha256:[0-9a-f]{64}))";
   private static final Pattern REGION_PATTERN = Pattern.compile("(\\w+-\\w+-\\d+)");
   static final Pattern ECR_REPOSITORY_URI_PATTERN =
       Pattern.compile(


### PR DESCRIPTION
We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.


I'm using ECS via Spinnaker, but I can not use some ECS images.
The reason is why your regular expression.

https://github.com/spinnaker/clouddriver/blob/287acf36bd4ab4441f2ed8419b88261e0ff5474a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProvider.java#L47

This regexp cannot support upper case tags.
So I create PR to fix it.

You guys can check this regular expression below link.
https://regex101.com/r/wWPZFM/1


Thanks


