### PR TITLE
 fix(cloudfoundry): Test failure due to change in behaviour of recursive comparison used by assertj-core while upgrading spring boot 2.4.x

### DIFF
--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ApplicationsTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ApplicationsTest.java
@@ -542,7 +542,10 @@ class ApplicationsTest {
     CloudFoundryServerGroup serverGroup =
         apps.findServerGroupByNameAndSpaceId(serverGroupName, spaceId);
 
-    assertThat(serverGroup).usingRecursiveComparison().isEqualTo(expectedCloudFoundryServerGroup);
+    assertThat(serverGroup)
+        .usingRecursiveComparison()
+        .usingOverriddenEquals()
+        .isEqualTo(expectedCloudFoundryServerGroup);
     // server group should be cached because of call to "findServerGroupId"
     verify(applicationService, never()).findById(serverGroupId);
   }


### PR DESCRIPTION
 During upgrade of spring boot from 2.3.x to 2.4.x, encountered the below test failure in clouddriver-cloudfoundry module:
 ```
 Failures (1):
  JUnit Jupiter:ApplicationsTest:findServerGroupByNameAndSpaceId()
    MethodSource [className = 'com.netflix.spinnaker.clouddriver.cloudfoundry.client.ApplicationsTest', methodName = 'findServerGroupByNameAndSpaceId', methodParameterTypes = '']
    => java.lang.AssertionError:
Expecting:
  <CloudFoundryServerGroup(account=pws, appsManagerUri=some-apps-man-uri/organizations/org-id/spaces/space-guid/applications/server-group-guid, metricsUri=some-metrics-uri/apps/server-group-guid, name=server-group, id=server-group-guid, memory=0, droplet=CloudFoundryDroplet(id=droplet-guid, name=server-group-droplet, stack=null, buildpacks=[], space=CloudFoundrySpace(id=space-guid, name=space-name, organization=CloudFoundryOrganization(id=org-id, name=org-name)), sourcePackage=CloudFoundryPackage(downloadUrl=http://capi.io/download/space-guid, checksumType=package-checksum-type, checksum=package-check-sum-value)), diskQuota=0, healthCheckType=null, healthCheckHttpEndpoint=null, state=STARTED, space=CloudFoundrySpace(id=space-guid, name=space-name, organization=CloudFoundryOrganization(id=org-id, name=org-name)), updatedTime=1659720517027, createdTime=1659720517027, env={}, serviceInstances=[], ciBuild=CloudFoundryBuildInfo(jobName=null, jobNumber=null, jobUrl=null), appArtifact=ArtifactInfo(name=null, version=null, url=null), pipelineId=null, instances=[], loadBalancerNames=null)>
to be equal to:
  <CloudFoundryServerGroup(account=pws, appsManagerUri=some-apps-man-uri/organizations/org-id/spaces/space-guid/applications/server-group-guid, metricsUri=some-metrics-uri/apps/server-group-guid, name=server-group, id=server-group-guid, memory=0, droplet=CloudFoundryDroplet(id=droplet-guid, name=null, stack=null, buildpacks=null, space=null, sourcePackage=null), diskQuota=0, healthCheckType=null, healthCheckHttpEndpoint=null, state=STARTED, space=CloudFoundrySpace(id=space-guid, name=space-name, organization=CloudFoundryOrganization(id=org-id, name=org-name)), updatedTime=1659720517027, createdTime=1659720517027, env={}, serviceInstances=[], ciBuild=CloudFoundryBuildInfo(jobName=null, jobNumber=null, jobUrl=null), appArtifact=ArtifactInfo(name=null, version=null, url=null), pipelineId=null, instances=[], loadBalancerNames=null)>
when recursively comparing field by field, but found the following 4 differences:

field/property 'droplet.buildpacks' differ:
- actual value   : []
- expected value : null

field/property 'droplet.name' differ:
- actual value   : "server-group-droplet"
- expected value : null

field/property 'droplet.sourcePackage' differ:
- actual value   : CloudFoundryPackage(downloadUrl=http://capi.io/download/space-guid, checksumType=package-checksum-type, checksum=package-check-sum-value)
- expected value : null

field/property 'droplet.space' differ:
- actual value   : CloudFoundrySpace(id=space-guid, name=space-name, organization=CloudFoundryOrganization(id=org-id, name=org-name))
- expected value : null

The recursive comparison was performed with this configuration:
- no overridden equals methods were used in the comparison (except for java types)
- these types were compared with the following comparators:
  - java.lang.Double -> DoubleComparator[precision=1.0E-15]
  - java.lang.Float -> FloatComparator[precision=1.0E-6]
- actual and expected objects and their fields were compared field by field recursively even if they were not of the same type, this allows for example to compare a Person to a PersonDto (call strictTypeChecking(true) to change that behavior).

       com.netflix.spinnaker.clouddriver.cloudfoundry.client.ApplicationsTest.findServerGroupByNameAndSpaceId(ApplicationsTest.java:545)
       java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
       java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
       java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
       java.base/java.lang.reflect.Method.invoke(Method.java:566)
       org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
       org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
       org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
       org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
       org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
       [...]
```

The root cause is breaking change introduced in assertj [3.17](https://assertj.github.io/doc/#assertj-core-3-17-0-release-notes) for recursive comparison implementation of usingRecursiveComparison() method by ignoring all overridden equals as default. Since spring boot [2.3.12](https://docs.spring.io/spring-boot/docs/2.3.12.RELEASE/reference/html/appendix-dependency-versions.html#dependency-versions-properties) uses assertj-core:3.16.1 and upgrade to spring boot [2.4.13](https://docs.spring.io/spring-boot/docs/2.4.13/reference/html/appendix-dependency-versions.html#dependency-versions-properties) brings assertj-core 3.18.1 as transitive dependency, this breaking change comes into effect.

The fix is to revert back to old behaviour by introducing usingOverriddenEquals() method while using assertj-core:3.18.1 introduced by spring boot 2.4.13.

This fix is applicable after upgrading clouddriver to spring boot 2.4.x, otherwise it will break the build and test.