### PR TITLE
fix(build): Bump protoc/protobuf/grpc to get binaries for mac m1

### DIFF
--- a/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
+++ b/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.google.protobuf'
 apply plugin: "org.junit.platform.gradle.plugin"
 
 ext {
-  protobufVersion = '3.6.1'
+  protobufVersion = '3.21.5'
 }
 
 protobuf {

--- a/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver-titus/clouddriver-titus.gradle
@@ -1,8 +1,8 @@
 apply plugin: "com.google.protobuf"
 
 ext {
-  protobufVersion = '[3.2.0,3.17.3]'
-  grpcVersion = '1.37.1'
+  protobufVersion = '3.21.5'
+  grpcVersion = '1.48.1'
 }
 
 dependencies {


### PR DESCRIPTION
Previous versions don't include osx-aarch_64.exe  artefacts so gradle build was failing on mac m1.

