### PR TITLE
fix(ECS): support upper case on the tag of image

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProvider.java
@@ -44,7 +44,7 @@ public class EcrImageProvider implements ImageRepositoryProvider {
   private static final Pattern REPOSITORY_NAME_PATTERN =
       Pattern.compile(
           "\\/(((?:[a-z0-9]+(?:[._-][a-z0-9]+)*\\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*){2,})");
-  private static final String IDENTIFIER_PATTERN = "(:([a-z0-9._-]+)|@(sha256:[0-9a-f]{64}))";
+  private static final String IDENTIFIER_PATTERN = "(:([a-zA-Z0-9._-]+)|@(sha256:[0-9a-f]{64}))";
   private static final Pattern REGION_PATTERN = Pattern.compile("(\\w+-\\w+-\\d+)");
   static final Pattern ECR_REPOSITORY_URI_PATTERN =
       Pattern.compile(


### PR DESCRIPTION
I'm using ECS via Spinnaker, but I can not use some ECS images.
The reason is why your regular expression.

https://github.com/spinnaker/clouddriver/blob/287acf36bd4ab4441f2ed8419b88261e0ff5474a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProvider.java#L47

This regular expression cannot support upper case tags.
So I create PR to fix it.

You guys can check this regular expression below link.
https://regex101.com/r/wWPZFM/1
