### PR TITLE
fix(cats/redis): explicitly remove an agent from the activeAgents map when it is unscheduled 

### DIFF
--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
@@ -40,13 +40,14 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.params.SetParams;
 
 public class ClusteredAgentScheduler extends CatsModuleAware
     implements AgentScheduler<AgentLock>, Runnable {
-  private static enum Status {
+  private enum Status {
     SUCCESS,
     FAILURE
   }
@@ -59,11 +60,33 @@ public class ClusteredAgentScheduler extends CatsModuleAware
   private final ExecutorService agentExecutionPool;
   private final Pattern enabledAgentPattern;
 
+  /**
+   * this contains all the known agents (from all cloud providers) that are candidates for execution
+   */
+  @Getter // visible for tests
   private final Map<String, AgentExecutionAction> agents = new ConcurrentHashMap<>();
+
+  /** This contains all the agents that are currently scheduled for execution */
+  @Getter // visible for tests
   private final Map<String, NextAttempt> activeAgents = new ConcurrentHashMap<>();
+
   private final NodeStatusProvider nodeStatusProvider;
   private final DynamicConfigService dynamicConfigService;
   private final ShardingFilter shardingFilter;
+
+  private static final long MIN_TTL_THRESHOLD = 500L;
+  private static final String SET_IF_NOT_EXIST = "NX";
+  private static final String SET_EXPIRE_TIME_MILLIS = "PX";
+  private static final String SUCCESS_RESPONSE = "OK";
+  private static final Long DEL_SUCCESS = 1L;
+
+  @Getter // visible for tests
+  private static final String DELETE_LOCK_KEY =
+      "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end";
+
+  @Getter // visible for tests
+  private static final String TTL_LOCK_KEY =
+      "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('set', KEYS[1], ARGV[1], 'PX', ARGV[2], 'XX') else return nil end";
 
   public ClusteredAgentScheduler(
       RedisClientDelegate redisClientDelegate,
@@ -170,22 +193,15 @@ public class ClusteredAgentScheduler extends CatsModuleAware
   private void runAgents() {
     Map<String, NextAttempt> thisRun = acquire();
     activeAgents.putAll(thisRun);
+    logger.debug(
+        "scheduling {} new agents, total number of active agents: {}",
+        thisRun.size(),
+        activeAgents.size());
     for (final Map.Entry<String, NextAttempt> toRun : thisRun.entrySet()) {
       final AgentExecutionAction exec = agents.get(toRun.getKey());
       agentExecutionPool.submit(new AgentJob(toRun.getValue(), exec, this));
     }
   }
-
-  private static final long MIN_TTL_THRESHOLD = 500L;
-  private static final String SET_IF_NOT_EXIST = "NX";
-  private static final String SET_EXPIRE_TIME_MILLIS = "PX";
-  private static final String SUCCESS_RESPONSE = "OK";
-  private static final Long DEL_SUCCESS = 1L;
-
-  private static final String DELETE_LOCK_KEY =
-      "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end";
-  private static final String TTL_LOCK_KEY =
-      "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('set', KEYS[1], ARGV[1], 'PX', ARGV[2], 'XX') else return nil end";
 
   private boolean acquireRunKey(String agentType, long timeout) {
     return redisClientDelegate.withCommandsClient(
@@ -271,10 +287,34 @@ public class ClusteredAgentScheduler extends CatsModuleAware
     agents.put(agent.getAgentType(), agentExecutionAction);
   }
 
+  /**
+   *
+   *
+   * <pre>
+   * Removes an agent from redis, {@link #agents} and {@link #activeAgents} maps.
+   *
+   * NOTE: we are explicitly removing the agent from the {@link #activeAgents} map. Normally, the agent is
+   * removed from it when {@link #agentCompleted(String, long)} is called after it executes via
+   * {@link AgentJob#run()}. But if for some reason that thread is killed before
+   * {@link #agentCompleted(String, long)} is executed, then this agent is not removed from the
+   * {@link #activeAgents} map, and that means it won't be executed again if this agent is scheduled
+   * again in future.
+   *
+   * PS: if accounts are not updated/deleted dynamically, this method will not be invoked, so the
+   *     agent can still remain in the {@link #activeAgents} map
+   * </pre>
+   *
+   * @param agent agent under consideration
+   */
   @Override
   public void unschedule(Agent agent) {
-    releaseRunKey(agent.getAgentType(), 0); // Delete lock key now.
-    agents.remove(agent.getAgentType());
+    try {
+      releaseRunKey(agent.getAgentType(), 0); // Delete lock key now.
+    } finally {
+      agents.remove(agent.getAgentType());
+      // explicitly remove it from the active agents map
+      activeAgents.remove(agent.getAgentType());
+    }
   }
 
   private static class NextAttempt {

--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentSchedulerSpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentSchedulerSpec.groovy
@@ -118,4 +118,48 @@ class ClusteredAgentSchedulerSpec extends Specification {
         2 * jedis.close()
         0 * _
     }
+
+    def 'test agent addition and removal from the agents and activeAgents maps in the schedule() -> run -> unschedule() flow'() {
+      when:
+      scheduler.schedule(agent, exec, inst)
+      then:
+      // scheduling an agent should add it to the agents map
+      scheduler.agents.containsKey(agent.agentType)
+      // unless we run this agent, it won't show up in the active agents map
+      !scheduler.activeAgents.containsKey(agent.agentType)
+
+      when:
+      lockPollingScheduler.runAll()
+      agentExecutionScheduler.runAll()
+
+      then:
+      // after running the agent, agents map should still contain it as we haven't explicitly
+      // removed it
+      scheduler.agents.containsKey(agent.agentType)
+      1 * jedis.set(_ as String, _ as String, _ as SetParams) >> 'OK'
+      1 * inst.executionStarted(agent)
+      1 * exec.executeAgent(agent)
+      1 * inst.executionCompleted(agent, _)
+
+      // normal execution of the agent will call agentCompleted() which calls releaseRunKey() which makes
+      // the following jedis call, and then it removes it from the activeAgents map
+      1 * jedis.eval(scheduler.TTL_LOCK_KEY, List.of(agent.agentType), _ as List)
+      !scheduler.activeAgents.containsKey(agent.agentType)
+
+      2 * jedis.close()
+      0 * _
+
+      when:
+      scheduler.unschedule(agent)
+
+      then:
+      // unschedule() should make this following jedis call
+      1 * jedis.eval(scheduler.DELETE_LOCK_KEY, List.of(agent.agentType), _ as List)
+
+      // unschedule() should remove the agent from both agents and activeAgents map
+      !scheduler.agents.containsKey(agent.agentType)
+      // in the context of this test, the agent was already removed from active agents before unschedule()
+      // was called
+      !scheduler.activeAgents.containsKey(agent.agentType)
+    }
 }

--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentSchedulerSpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentSchedulerSpec.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.cats.redis.cluster
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.agent.AgentExecution
 import com.netflix.spinnaker.cats.agent.CachingAgent
 import com.netflix.spinnaker.cats.agent.ExecutionInstrumentation
@@ -32,6 +34,7 @@ import redis.clients.jedis.JedisPool
 import redis.clients.jedis.params.SetParams
 import spock.lang.Specification
 import spock.lang.Subject
+import java.util.concurrent.Executors
 
 class ClusteredAgentSchedulerSpec extends Specification {
 
@@ -39,6 +42,7 @@ class ClusteredAgentSchedulerSpec extends Specification {
     ClusteredAgentScheduler scheduler
 
     Jedis jedis
+    JedisPool jedisPool
     CachingAgent agent
     ManualRunnableScheduler lockPollingScheduler
     ManualRunnableScheduler agentExecutionScheduler
@@ -52,7 +56,7 @@ class ClusteredAgentSchedulerSpec extends Specification {
         def interval = new DefaultAgentIntervalProvider(6000000)
         agent = new TestAgent()
         jedis = Mock(Jedis)
-        def jedisPool = Stub(JedisPool) {
+        jedisPool = Stub(JedisPool) {
             getResource() >> jedis
         }
         lockPollingScheduler = new ManualRunnableScheduler()
@@ -161,5 +165,168 @@ class ClusteredAgentSchedulerSpec extends Specification {
       // in the context of this test, the agent was already removed from active agents before unschedule()
       // was called
       !scheduler.activeAgents.containsKey(agent.agentType)
+    }
+
+  def 'test that a long-running/stuck agent is removed from the active agents map after sufficient time has elapsed'() {
+    given:
+    def arbitraryAgentInterval = 500l
+    // agent is configured with an interval of 500ms (so this agent is supposed to timeout after 2 * 500 = 1s)
+    agent = new TestAgent(arbitraryAgentInterval)
+
+    def agentExecutionScheduler = Executors.newCachedThreadPool(
+      new ThreadFactoryBuilder()
+        .setNameFormat(TestStuckAgentExecution.class.getSimpleName() + "-%d")
+        .build())
+
+    // this interval is only used if an agent doesn't provide its own interval... this value is not
+    // used in the tests since our test agent implements AgentIntervalAware
+    def interval = new DefaultAgentIntervalProvider(1)
+
+    def realScheduler = new ClusteredAgentScheduler(
+      new JedisClientDelegate(jedisPool),
+      new DefaultNodeIdentity(),
+      interval,
+      new DefaultNodeStatusProvider(),
+      lockPollingScheduler,
+      agentExecutionScheduler,
+      ".*",
+      null,
+      dcs,
+      new NoopShardingFilter()
+    )
+
+    // sleep for 5s
+    def agentExecution = new TestStuckAgentExecution(10*arbitraryAgentInterval)
+
+    when:
+    realScheduler.schedule(agent, agentExecution, inst)
+
+    then:
+    // scheduling an agent should add it to the agents map
+    realScheduler.agents.containsKey(agent.agentType)
+    // unless we run this agent, it won't show up in the active agents map
+    !realScheduler.activeAgents.containsKey(agent.agentType)
+
+    when:
+    // run the agent
+    lockPollingScheduler.runAll()
+
+    then:
+    // since this is a long running agent execution, after running it, the agents map should still contain it as
+    // it hasn't completed just yet
+    realScheduler.agents.containsKey(agent.agentType)
+    1 * jedis.set(_ as String, _ as String, _ as SetParams) >> 'OK'
+
+    // verify that the agent hasn't completed its work
+    // normal execution of the agent will call agentCompleted() which calls releaseRunKey() which makes
+    // the following jedis call, and then it removes it from the activeAgents map. But since it hasn't
+    // completed its work, the above wouldn't be true
+    0 * jedis.eval(realScheduler.TTL_LOCK_KEY, List.of(agent.agentType), _ as List)
+    // it should still be in the active agents map
+    realScheduler.activeAgents.containsKey(agent.agentType)
+
+    1 * jedis.close()
+
+    when:
+    // arbitrary sleep interval > agent timeout
+    Thread.sleep(4 * arbitraryAgentInterval)
+    lockPollingScheduler.runAll()
+
+    then:
+    // since enough time has elapsed, it should be removed from the active agents map.
+    !realScheduler.activeAgents.containsKey(agent.agentType)
+
+    // verify that ttl lock key hasn't been updated just yet
+    // (i.e. it was automatically removed from active agents map)
+    0 * jedis.eval(realScheduler.TTL_LOCK_KEY, List.of(agent.agentType), _ as List)
+  }
+
+    def 'test that an agent is not removed from the active agents map if sufficient time has not elapsed'() {
+      given:
+      def arbitraryAgentInterval = 500l
+      // agent is configured with an interval of 500ms (so this agent is supposed to timeout after 2 * 500 = 1s)
+      agent = new TestAgent(arbitraryAgentInterval)
+
+      def agentExecutionScheduler = Executors.newCachedThreadPool(
+        new ThreadFactoryBuilder()
+          .setNameFormat(TestStuckAgentExecution.class.getSimpleName() + "-%d")
+          .build())
+
+      // this interval is only used if an agent doesn't provide its own interval... this value is not
+      // used in the tests since our test agent implements AgentIntervalAware
+      def interval = new DefaultAgentIntervalProvider(1)
+
+      def realScheduler = new ClusteredAgentScheduler(
+        new JedisClientDelegate(jedisPool),
+        new DefaultNodeIdentity(),
+        interval,
+        new DefaultNodeStatusProvider(),
+        lockPollingScheduler,
+        agentExecutionScheduler,
+        ".*",
+        null,
+        dcs,
+        new NoopShardingFilter()
+      )
+
+      // sleep for 5s
+      def agentExecution = new TestStuckAgentExecution(10*arbitraryAgentInterval)
+      when:
+      realScheduler.schedule(agent, agentExecution, inst)
+
+      then:
+      // scheduling an agent should add it to the agents map
+      realScheduler.agents.containsKey(agent.agentType)
+      // unless we run this agent, it won't show up in the active agents map
+      !realScheduler.activeAgents.containsKey(agent.agentType)
+
+      when:
+      // run the agent
+      lockPollingScheduler.runAll()
+
+      then:
+      // after running the agent, agents map should still contain it as we haven't explicitly
+      // removed it
+      realScheduler.agents.containsKey(agent.agentType)
+      1 * jedis.set(_ as String, _ as String, _ as SetParams) >> 'OK'
+
+      // verify that the agent hasn't completed its work
+      // normal execution of the agent will call agentCompleted() which calls releaseRunKey() which makes
+      // the following jedis call, and then it removes it from the activeAgents map. But since it hasn't
+      // completed its work, the above wouldn't be true
+      0 * jedis.eval(realScheduler.TTL_LOCK_KEY, List.of(agent.agentType), _ as List)
+      // it should still be in the active agents map
+      realScheduler.activeAgents.containsKey(agent.agentType)
+
+      1 * jedis.close()
+
+      when:
+      // initiate the next attempt to schedule new agents
+      lockPollingScheduler.runAll()
+
+      then:
+      // since the agent is long running, and enough time hasn't elapsed, it will still be in the active agents map
+      realScheduler.activeAgents.containsKey(agent.agentType)
+    }
+
+    /**
+     * a test {@link AgentExecution} class that simulates a long-running/stuck agent execution
+     */
+    private class TestStuckAgentExecution implements AgentExecution {
+      private long sleepTime
+
+      TestStuckAgentExecution(long sleepTime) {
+        this.sleepTime = sleepTime
+      }
+
+      @Override
+      void executeAgent(Agent agent) {
+        try {
+          // an arbitrary long enough sleep value
+          Thread.sleep(sleepTime)
+        } catch(Exception ignored) {
+          // ignore
+        }
+      }
     }
 }

--- a/cats/cats-test/src/main/groovy/com/netflix/spinnaker/cats/test/TestAgent.groovy
+++ b/cats/cats-test/src/main/groovy/com/netflix/spinnaker/cats/test/TestAgent.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.cats.test
 
 import com.netflix.spinnaker.cats.agent.AgentDataType
+import com.netflix.spinnaker.cats.agent.AgentIntervalAware
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.agent.CachingAgent
 import com.netflix.spinnaker.cats.agent.DefaultCacheResult
@@ -26,8 +27,17 @@ import com.netflix.spinnaker.cats.provider.ProviderCache
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
 
-class TestAgent implements CachingAgent {
+class TestAgent implements CachingAgent, AgentIntervalAware {
+  private long agentInterval
 
+  TestAgent() {
+    // default max agent timeout of 1m
+    this(60000L)
+  }
+
+  TestAgent(long agentInterval) {
+    this.agentInterval = agentInterval
+  }
     String scope = UUID.randomUUID().toString()
     Set<String> authoritative = []
     Set<String> types = []
@@ -53,5 +63,10 @@ class TestAgent implements CachingAgent {
     @Override
     CacheResult loadData(ProviderCache cache) {
         new DefaultCacheResult(results)
+    }
+
+    @Override
+    Long getAgentInterval() {
+      return agentInterval
     }
 }


### PR DESCRIPTION
* There is an edge case where the `activeAgents` map in the `ClusteredAgentScheduler` may still contain an agent even after it has been unscheduled, which prevents the agent from being scheduled again in the future.

* The motivation for actively cleaning such entries from the map is to ensure that no agent is in such a bad state that it can't be rescheduled again. In a normal workflow, the agent is removed from the map when [agentCompleted(String, long)](https://github.com/spinnaker/clouddriver/blob/master/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java#L243-L249) is called from [run()](https://github.com/spinnaker/clouddriver/blob/master/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java#L313-L322) method after its execution. But, if for some reason, that thread is killed, and the agentCompleted(String, long) method is not called, then this agent stays in the [activeAgents](https://github.com/spinnaker/clouddriver/blob/master/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java#L63) map, which means it won't be rescheduled again. So by actively doing something like this, we enable it to be rescheduled.
