### PR TITLE
perf(web/cluster): make getForAccountAndNameAndType() more efficient

### DIFF
--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterControllerSpec.groovy
@@ -68,13 +68,15 @@ class ClusterControllerSpec extends Specification {
   void "should throw exception when looking for specific cluster that doesnt exist"() {
     setup:
       def clusterProvider1 = Mock(ClusterProvider)
+      clusterProvider1.getCloudProviderId() >> { "aws" }
       clusterController.clusterProviders = [clusterProvider1]
 
     when:
       clusterController.getForAccountAndNameAndType("app", "test", "cluster", "aws", true)
 
     then:
-      thrown NotFoundException
+      def e = thrown(NotFoundException)
+      e.getMessage() == "No clusters found (application: app, account: test, type: aws)"
   }
 
   void "should throw exception when no cluster provider exists for the cluster"() {
@@ -368,11 +370,7 @@ class ClusterControllerSpec extends Specification {
     }
 
     // the second cluster provider shouldn't be asked to look for the cluster
-    0 * clusterProvider2.getCluster("app", "account", "clusterName", true) >> {
-      def cluster = Mock(Cluster)
-      cluster.getType() >> "some-other-type"
-      cluster
-    }
+    0 * clusterProvider2.getCluster("app", "account", "clusterName", true)
 
     result.getServerGroups().size() == 1
     result.type == "aws"


### PR DESCRIPTION
The [getForAccountAndNameAndType](https://github.com/spinnaker/clouddriver/blob/e62a8ffcce5ccdd1139184e7ae64d9d1da560f8a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterController.groovy#L147) method can be made more efficient if the cloud provider to use is determined first.

Presently, it invokes all the cloud providers and then filters on the results via the type property.

Instead, if we first select the correct cloud provider using the type key, then we would do less work since we wouldn't unnecessarily be invoking all the other cloud providers. This PR adds a test to show the inefficiency and how it is fixed after the change.