### PR TITLE
fix(kubectl): add metrics to retries, make log messages more descriptive and support retries for all kubectl actions

### DIFF
--- a/clouddriver-core/clouddriver-core.gradle
+++ b/clouddriver-core/clouddriver-core.gradle
@@ -13,6 +13,7 @@ dependencies {
   annotationProcessor "org.projectlombok:lombok"
   testAnnotationProcessor "org.projectlombok:lombok"
 
+  api "org.apache.commons:commons-exec"
   // This is because some classes in this module use the Groovy @Immutable annotation,
   // which appears to require consumers to have core groovy on the classpath
   api "org.codehaus.groovy:groovy"
@@ -43,7 +44,6 @@ dependencies {
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "io.reactivex:rxjava"
   implementation "net.jodah:failsafe:1.0.4"
-  implementation "org.apache.commons:commons-exec"
   implementation "org.codehaus.groovy:groovy-all"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "redis.clients:jedis"

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
@@ -70,6 +70,7 @@ public class JobRequest {
     this.workingDir = workingDir;
   }
 
+  // only used in tests
   public JobRequest(CommandLine commandLine, InputStream inputStream) {
     this.tokenizedCommand = new ArrayList<>();
     this.commandLine = commandLine;

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
@@ -15,18 +15,21 @@
  */
 package com.netflix.spinnaker.clouddriver.jobs;
 
+import com.netflix.spinnaker.kork.annotations.VisibleForTesting;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.exec.CommandLine;
 
 @Getter
 public class JobRequest {
   private final List<String> tokenizedCommand;
-  private final CommandLine commandLine;
+  @VisibleForTesting @Getter @Setter private CommandLine commandLine;
   private final Map<String, String> environment;
   private final InputStream inputStream;
   private final File workingDir;
@@ -67,6 +70,13 @@ public class JobRequest {
     this.environment = environment;
     this.inputStream = inputStream;
     this.workingDir = workingDir;
+  }
+
+  public JobRequest(CommandLine commandLine, InputStream inputStream) {
+    this.tokenizedCommand = new ArrayList<>();
+    this.commandLine = commandLine;
+    this.environment = System.getenv();
+    this.inputStream = inputStream;
   }
 
   private CommandLine createCommandLine(List<String> tokenizedCommand) {

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
@@ -70,10 +70,6 @@ public class JobRequest {
     this.workingDir = workingDir;
   }
 
-  public JobRequest(CommandLine commandLine) {
-    this(commandLine, new ByteArrayInputStream(new byte[0]));
-  }
-
   public JobRequest(CommandLine commandLine, InputStream inputStream) {
     this.tokenizedCommand = new ArrayList<>();
     this.commandLine = commandLine;

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
@@ -15,7 +15,6 @@
  */
 package com.netflix.spinnaker.clouddriver.jobs;
 
-import com.netflix.spinnaker.kork.annotations.VisibleForTesting;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
@@ -23,13 +22,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.Getter;
-import lombok.Setter;
 import org.apache.commons.exec.CommandLine;
 
 @Getter
 public class JobRequest {
   private final List<String> tokenizedCommand;
-  @VisibleForTesting @Getter @Setter private CommandLine commandLine;
+  private final CommandLine commandLine;
   private final Map<String, String> environment;
   private final InputStream inputStream;
   private final File workingDir;
@@ -72,11 +70,16 @@ public class JobRequest {
     this.workingDir = workingDir;
   }
 
+  public JobRequest(CommandLine commandLine) {
+    this(commandLine, new ByteArrayInputStream(new byte[0]));
+  }
+
   public JobRequest(CommandLine commandLine, InputStream inputStream) {
     this.tokenizedCommand = new ArrayList<>();
     this.commandLine = commandLine;
     this.environment = System.getenv();
     this.inputStream = inputStream;
+    this.workingDir = null;
   }
 
   private CommandLine createCommandLine(List<String> tokenizedCommand) {
@@ -95,6 +98,9 @@ public class JobRequest {
 
   @Override
   public String toString() {
-    return String.join(" ", tokenizedCommand);
+    if (!tokenizedCommand.isEmpty()) {
+      return String.join(" ", tokenizedCommand);
+    }
+    return commandLine.toString();
   }
 }

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -87,6 +87,7 @@ dependencies {
   implementation "org.springframework.cloud:spring-cloud-context"
   implementation "org.springframework.cloud:spring-cloud-config-server"
   implementation "io.github.resilience4j:resilience4j-retry"
+  implementation "io.github.resilience4j:resilience4j-micrometer"
 
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -80,6 +80,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-moniker"
   implementation "io.spinnaker.kork:kork-secrets"
   implementation "io.kubernetes:client-java:$kubernetesClientVersion"
+  implementation "org.apache.commons:commons-exec"
   implementation "org.apache.commons:commons-lang3"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -80,7 +80,6 @@ dependencies {
   implementation "io.spinnaker.kork:kork-moniker"
   implementation "io.spinnaker.kork:kork-secrets"
   implementation "io.kubernetes:client-java:$kubernetesClientVersion"
-  implementation "org.apache.commons:commons-exec"
   implementation "org.apache.commons:commons-lang3"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
@@ -90,6 +89,7 @@ dependencies {
   implementation "io.github.resilience4j:resilience4j-retry"
   implementation "io.github.resilience4j:resilience4j-micrometer"
 
+  testImplementation "org.apache.commons:commons-exec"
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -65,6 +65,14 @@ public class KubernetesConfigurationProperties {
 
       // only applicable when exponentialBackoff = true
       long exponentialBackOffIntervalMs = 10000;
+
+      private Metrics metrics = new Metrics();
+
+      @Data
+      public static class Metrics {
+        // flag to capture retry metrics. Turned off by default
+        private boolean enabled;
+      }
     }
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -35,6 +35,9 @@ public class KubernetesConfigurationProperties {
 
   private Cache cache = new Cache();
 
+  private KubectlProperties kubectl = new KubectlProperties();
+  private OAuthProperties oAuth = new OAuthProperties();
+
   @Data
   public static class KubernetesJobExecutorProperties {
     private Retries retries = new Retries();
@@ -104,5 +107,17 @@ public class KubernetesConfigurationProperties {
      * Cache#cacheKinds}
      */
     private List<String> cacheOmitKinds = null;
+  }
+
+  /** kubectl configuration properties */
+  @Data
+  public static class KubectlProperties {
+    private String executable = "kubectl";
+  }
+
+  /** oAuth configuration properties */
+  @Data
+  public static class OAuthProperties {
+    private String executable = "oauth2l";
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -82,7 +82,7 @@ public class KubectlJobExecutor {
   // @Getter is required so that this can be used in tests
   @Getter private final Optional<RetryRegistry> retryRegistry;
 
-  @Nullable private final MeterRegistry meterRegistry;
+  private final MeterRegistry meterRegistry;
 
   @Autowired
   KubectlJobExecutor(
@@ -95,12 +95,6 @@ public class KubectlJobExecutor {
 
     this.retryRegistry =
         initializeRetryRegistry(kubernetesConfigurationProperties.getJobExecutor().getRetries());
-  }
-
-  KubectlJobExecutor(
-      JobExecutor jobExecutor,
-      KubernetesConfigurationProperties kubernetesConfigurationProperties) {
-    this(jobExecutor, kubernetesConfigurationProperties, null);
   }
 
   public String logs(
@@ -905,7 +899,11 @@ public class KubectlJobExecutor {
           .getEventPublisher()
           .onEntryAdded(event -> event.getAddedEntry().getEventPublisher().onEvent(eventConsumer));
 
-      if (meterRegistry != null) {
+      if (this.kubernetesConfigurationProperties
+          .getJobExecutor()
+          .getRetries()
+          .getMetrics()
+          .isEnabled()) {
         TaggedRetryMetrics.ofRetryRegistry(retryRegistry).bindTo(meterRegistry);
       }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -72,7 +72,8 @@ public class KubectlJobExecutor {
   private static final String KUBECTL_COMMAND_OPTION_KUBECONFIG = "--kubeconfig=";
   private static final String KUBECTL_COMMAND_OPTION_CONTEXT = "--context=";
 
-  private final JobExecutor jobExecutor;
+  // @Getter is required so that the clouddriver-extensions implementation can use this job executor
+  @Getter private final JobExecutor jobExecutor;
 
   private final Gson gson = new Gson();
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -978,7 +978,7 @@ public class KubectlJobExecutor {
   JobRequest createJobRequest(List<String> command, Optional<KubernetesManifest> manifest) {
     // depending on the presence of the manifest, an appropriate job request is created
     if (manifest.isPresent()) {
-      String manifestAsJson = gson.toJson(manifest);
+      String manifestAsJson = gson.toJson(manifest.get());
       return new JobRequest(
           command, new ByteArrayInputStream(manifestAsJson.getBytes(StandardCharsets.UTF_8)));
     }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -61,7 +61,6 @@ import javax.annotation.Nullable;
 import javax.annotation.WillClose;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.exec.CommandLine;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -975,7 +974,8 @@ public class KubectlJobExecutor {
    * @param manifest the manifest to be used by the command. This is optional.
    * @return a job request object
    */
-  private JobRequest createJobRequest(List<String> command, Optional<KubernetesManifest> manifest) {
+  @VisibleForTesting
+  JobRequest createJobRequest(List<String> command, Optional<KubernetesManifest> manifest) {
     // depending on the presence of the manifest, an appropriate job request is created
     if (manifest.isPresent()) {
       String manifestAsJson = gson.toJson(manifest);
@@ -1121,13 +1121,6 @@ public class KubectlJobExecutor {
         this.namespace = manifest.get().getNamespace();
         this.resource = manifest.get().getFullResourceName();
       }
-    }
-
-    public KubectlActionIdentifier(
-        KubernetesCredentials credentials,
-        CommandLine commandLine,
-        Optional<KubernetesManifest> manifest) {
-      this(credentials, Arrays.asList(commandLine.toStrings()), manifest);
     }
 
     /**

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -62,7 +62,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -74,8 +73,6 @@ public class KubectlJobExecutor {
   private static final String KUBECTL_COMMAND_OPTION_CONTEXT = "--context=";
 
   private final JobExecutor jobExecutor;
-  private final String executable;
-  private final String oAuthExecutable;
 
   private final Gson gson = new Gson();
 
@@ -89,13 +86,9 @@ public class KubectlJobExecutor {
   @Autowired
   KubectlJobExecutor(
       JobExecutor jobExecutor,
-      @Value("${kubernetes.kubectl.executable:kubectl}") String executable,
-      @Value("${kubernetes.o-auth.executable:oauth2l}") String oAuthExecutable,
       KubernetesConfigurationProperties kubernetesConfigurationProperties,
       @Nullable MeterRegistry meterRegistry) {
     this.jobExecutor = jobExecutor;
-    this.executable = executable;
-    this.oAuthExecutable = oAuthExecutable;
     this.kubernetesConfigurationProperties = kubernetesConfigurationProperties;
     this.meterRegistry = meterRegistry;
 
@@ -105,10 +98,8 @@ public class KubectlJobExecutor {
 
   KubectlJobExecutor(
       JobExecutor jobExecutor,
-      @Value("${kubernetes.kubectl.executable:kubectl}") String executable,
-      @Value("${kubernetes.o-auth.executable:oauth2l}") String oAuthExecutable,
       KubernetesConfigurationProperties kubernetesConfigurationProperties) {
-    this(jobExecutor, executable, oAuthExecutable, kubernetesConfigurationProperties, null);
+    this(jobExecutor, kubernetesConfigurationProperties, null);
   }
 
   public String logs(
@@ -588,7 +579,7 @@ public class KubectlJobExecutor {
     if (!Strings.isNullOrEmpty(credentials.getKubectlExecutable())) {
       command.add(credentials.getKubectlExecutable());
     } else {
-      command.add(executable);
+      command.add(this.kubernetesConfigurationProperties.getKubectl().getExecutable());
     }
 
     if (credentials.getKubectlRequestTimeoutSeconds() != null) {
@@ -663,7 +654,7 @@ public class KubectlJobExecutor {
 
   private String getOAuthToken(KubernetesCredentials credentials) {
     List<String> command = new ArrayList<>();
-    command.add(oAuthExecutable);
+    command.add(this.kubernetesConfigurationProperties.getOAuth().getExecutable());
     command.add("fetch");
     command.add("--json");
     command.add(credentials.getOAuthServiceAccount());

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/ManifestFetcher.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/ManifestFetcher.java
@@ -42,7 +42,7 @@ public final class ManifestFetcher {
     return base;
   }
 
-  static KubernetesManifest getManifest(String basePath) {
+  public static KubernetesManifest getManifest(String basePath) {
     return getManifest(ManifestFetcher.class, basePath).get(0);
   }
 
@@ -56,7 +56,7 @@ public final class ManifestFetcher {
         .collect(ImmutableList.toImmutableList());
   }
 
-  private static String getResource(Class<?> referenceClass, String name) {
+  public static String getResource(Class<?> referenceClass, String name) {
     try {
       return Resources.toString(referenceClass.getResource(name), StandardCharsets.UTF_8);
     } catch (IOException e) {

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
@@ -110,7 +110,7 @@ final class KubectlJobExecutorTest {
       assertTrue(kubectlJobExecutor.getRetryRegistry().isPresent());
       RetryRegistry retryRegistry = kubectlJobExecutor.getRetryRegistry().get();
       assertThat(retryRegistry.getAllRetries().size()).isEqualTo(1);
-      assertThat(retryRegistry.getAllRetries().get(0).getName()).isEqualTo("mock-account.topPod.");
+      assertThat(retryRegistry.getAllRetries().get(0).getName()).isEqualTo("mock-account");
 
       // verify retry metrics
       Retry.Metrics retryMetrics = retryRegistry.getAllRetries().get(0).getMetrics();
@@ -294,8 +294,7 @@ final class KubectlJobExecutorTest {
     assertTrue(kubectlJobExecutor.getRetryRegistry().isPresent());
     RetryRegistry retryRegistry = kubectlJobExecutor.getRetryRegistry().get();
     assertThat(retryRegistry.getAllRetries().size()).isEqualTo(1);
-    assertThat(retryRegistry.getAllRetries().get(0).getName())
-        .isEqualTo("mock-account.topPod.test-pod");
+    assertThat(retryRegistry.getAllRetries().get(0).getName()).isEqualTo("mock-account");
 
     // verify retry metrics
     Retry.Metrics retryMetrics = retryRegistry.getAllRetries().get(0).getMetrics();
@@ -314,12 +313,16 @@ final class KubectlJobExecutorTest {
                     iLoggingEvent
                         .getFormattedMessage()
                         .contains(
-                            "Action: mock-account.topPod.test-pod failed after "
+                            "Kubectl command for mock-account failed after "
                                 + kubernetesConfigurationProperties
                                     .getJobExecutor()
                                     .getRetries()
                                     .getMaxAttempts()
-                                + " attempts"))
+                                + " attempts. Exception: com.netflix.spinnaker.clouddriver.kubernetes.op."
+                                + "job.KubectlJobExecutor$KubectlException: command: 'kubectl "
+                                + "--request-timeout=0 --namespace=test-namespace top po test-pod "
+                                + "--containers' in account: mock-account failed. Error: Unable to "
+                                + "connect to the server: net/http: TLS handshake timeout"))
             .collect(Collectors.toList());
 
     // we should only see 1 failed retry attempt message per thread
@@ -396,8 +399,7 @@ final class KubectlJobExecutorTest {
     assertTrue(kubectlJobExecutor.getRetryRegistry().isPresent());
     RetryRegistry retryRegistry = kubectlJobExecutor.getRetryRegistry().get();
     assertThat(retryRegistry.getAllRetries().size()).isEqualTo(1);
-    assertThat(retryRegistry.getAllRetries().get(0).getName())
-        .isEqualTo("mock-account.topPod.test-pod");
+    assertThat(retryRegistry.getAllRetries().get(0).getName()).isEqualTo("mock-account");
 
     // verify retry metrics
     Retry.Metrics retryMetrics = retryRegistry.getAllRetries().get(0).getMetrics();
@@ -417,7 +419,9 @@ final class KubectlJobExecutorTest {
                     iLoggingEvent
                         .getFormattedMessage()
                         .contains(
-                            "mock-account.topPod.test-pod will not be retried as retries are not enabled for error: un-retryable error"))
+                            "Not retrying command: 'kubectl --request-timeout=0 --namespace=test-namespace"
+                                + " top po test-pod --containers' in account: mock-account as retries are not"
+                                + " enabled for error: un-retryable error"))
             .collect(Collectors.toList());
 
     // we should only see 1 failed retry attempt message per thread
@@ -475,8 +479,7 @@ final class KubectlJobExecutorTest {
     assertTrue(kubectlJobExecutor.getRetryRegistry().isPresent());
     RetryRegistry retryRegistry = kubectlJobExecutor.getRetryRegistry().get();
     assertThat(retryRegistry.getAllRetries().size()).isEqualTo(1);
-    assertThat(retryRegistry.getAllRetries().get(0).getName())
-        .isEqualTo("mock-account.topPod.test-pod");
+    assertThat(retryRegistry.getAllRetries().get(0).getName()).isEqualTo("mock-account");
 
     // verify retry metrics
     Retry.Metrics retryMetrics = retryRegistry.getAllRetries().get(0).getMetrics();
@@ -495,7 +498,12 @@ final class KubectlJobExecutorTest {
                     iLoggingEvent
                         .getFormattedMessage()
                         .contains(
-                            "Action: mock-account.topPod.test-pod succeeded after 1 retry attempt(s)"))
+                            "Kubectl command for mock-account is now successful in attempt #2. Last "
+                                + "attempt had failed with exception: com.netflix.spinnaker.clouddriver"
+                                + ".kubernetes.op.job.KubectlJobExecutor$KubectlException: command: "
+                                + "'kubectl --request-timeout=0 --namespace=test-namespace top po test-pod"
+                                + " --containers' in account: mock-account failed. Error: Unable to connect to"
+                                + " the server: net/http: TLS handshake timeout"))
             .collect(Collectors.toList());
 
     // we should only see 1 succeeded retry attempt message

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
@@ -705,7 +705,7 @@ final class KubectlJobExecutorTest {
             commandLine, new ByteArrayInputStream(manifestAsJson.getBytes(StandardCharsets.UTF_8)));
       }
 
-      return new JobRequest(commandLine);
+      return new JobRequest(commandLine, new ByteArrayInputStream(new byte[0]));
     }
   }
 }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
@@ -46,6 +46,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPodMet
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -92,7 +93,11 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+            jobExecutor,
+            "kubectl",
+            "oauth2l",
+            kubernetesConfigurationProperties,
+            new SimpleMeterRegistry());
     Collection<KubernetesPodMetric> podMetrics =
         kubectlJobExecutor.topPod(mockKubernetesCredentials(), "test", "");
     assertThat(podMetrics).isEmpty();
@@ -132,7 +137,11 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", new KubernetesConfigurationProperties());
+            jobExecutor,
+            "kubectl",
+            "oauth2l",
+            new KubernetesConfigurationProperties(),
+            new SimpleMeterRegistry());
     Collection<KubernetesPodMetric> podMetrics =
         kubectlJobExecutor.topPod(mockKubernetesCredentials(), NAMESPACE, "");
     assertThat(podMetrics).hasSize(2);
@@ -189,7 +198,11 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+            jobExecutor,
+            "kubectl",
+            "oauth2l",
+            kubernetesConfigurationProperties,
+            new SimpleMeterRegistry());
 
     // then
     KubectlJobExecutor.KubectlException thrown =
@@ -241,7 +254,11 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+            jobExecutor,
+            "kubectl",
+            "oauth2l",
+            kubernetesConfigurationProperties,
+            new SimpleMeterRegistry());
 
     for (int i = 1; i <= numberOfThreads; i++) {
       futures.add(
@@ -347,7 +364,11 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+            jobExecutor,
+            "kubectl",
+            "oauth2l",
+            kubernetesConfigurationProperties,
+            new SimpleMeterRegistry());
 
     for (int i = 1; i <= numberOfThreads; i++) {
       futures.add(
@@ -435,7 +456,11 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+            jobExecutor,
+            "kubectl",
+            "oauth2l",
+            kubernetesConfigurationProperties,
+            new SimpleMeterRegistry());
 
     Collection<KubernetesPodMetric> podMetrics =
         kubectlJobExecutor.topPod(mockKubernetesCredentials(), NAMESPACE, "test-pod");
@@ -528,7 +553,11 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+            jobExecutor,
+            "kubectl",
+            "oauth2l",
+            kubernetesConfigurationProperties,
+            new SimpleMeterRegistry());
 
     JobExecutionException thrown =
         assertThrows(

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
@@ -19,17 +19,22 @@ package com.netflix.spinnaker.clouddriver.kubernetes.op.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.io.Resources;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spinnaker.clouddriver.jobs.JobExecutionException;
 import com.netflix.spinnaker.clouddriver.jobs.JobExecutor;
 import com.netflix.spinnaker.clouddriver.jobs.JobRequest;
@@ -39,24 +44,44 @@ import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurati
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPodMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPodMetric.ContainerMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+import org.slf4j.LoggerFactory;
 
 @RunWith(JUnitPlatform.class)
 final class KubectlJobExecutorTest {
   private static final String NAMESPACE = "test-namespace";
+  JobExecutor jobExecutor;
+  KubernetesConfigurationProperties kubernetesConfigurationProperties;
 
-  @ParameterizedTest
+  @BeforeEach
+  public void setup() {
+    jobExecutor = mock(JobExecutor.class);
+    kubernetesConfigurationProperties = new KubernetesConfigurationProperties();
+    kubernetesConfigurationProperties.getJobExecutor().getRetries().setBackOffInMs(500);
+  }
+
+  @ParameterizedTest(name = "{index} ==> retries enabled = {0}")
   @ValueSource(booleans = {true, false})
   void topPodEmptyOutput(boolean retriesEnabled) {
-    JobExecutor jobExecutor = mock(JobExecutor.class);
     when(jobExecutor.runJob(any(JobRequest.class)))
         .thenReturn(
             JobResult.<String>builder().result(Result.SUCCESS).output("").error("").build());
@@ -78,7 +103,6 @@ final class KubectlJobExecutorTest {
 
   @Test
   void topPodMultipleContainers() throws Exception {
-    JobExecutor jobExecutor = mock(JobExecutor.class);
     when(jobExecutor.runJob(any(JobRequest.class)))
         .thenReturn(
             JobResult.<String>builder()
@@ -135,9 +159,62 @@ final class KubectlJobExecutorTest {
     }
   }
 
+  @DisplayName("test to verify how kubectl errors are handled when retries are disabled")
   @Test
-  void kubectlRetryHandlingForConfiguredErrorsThatContinueFailingAfterMaxRetryAttempts() {
-    JobExecutor jobExecutor = mock(JobExecutor.class);
+  void kubectlJobExecutorErrorHandlingWhenRetriesAreDisabled() {
+    // when
+    when(jobExecutor.runJob(any(JobRequest.class)))
+        .thenReturn(
+            JobResult.<String>builder()
+                .result(Result.FAILURE)
+                .output("")
+                .error("some error")
+                .build());
+
+    KubectlJobExecutor kubectlJobExecutor =
+        new KubectlJobExecutor(
+            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+
+    // then
+    KubectlJobExecutor.KubectlException thrown =
+        assertThrows(
+            KubectlJobExecutor.KubectlException.class,
+            () -> kubectlJobExecutor.topPod(mockKubernetesCredentials(), "test", ""));
+
+    assertTrue(thrown.getMessage().contains("some error"));
+    // should only be called once as no retries are performed for this error
+    verify(jobExecutor).runJob(any(JobRequest.class));
+  }
+
+  @DisplayName(
+      "parameterized test to verify retry behavior for configured retryable errors that fail even after all "
+          + "attempts are exhausted")
+  @ParameterizedTest(
+      name = "{index} ==> number of simultaneous executions of the action under test = {0}")
+  @ValueSource(ints = {1, 10})
+  void kubectlRetryHandlingForConfiguredErrorsThatContinueFailingAfterMaxRetryAttempts(
+      int numberOfThreads) {
+    // setup
+    kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(true);
+
+    // to test log messages
+    Logger logger = (Logger) LoggerFactory.getLogger(KubectlJobExecutor.class);
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+    logger.addAppender(listAppender);
+    listAppender.start();
+
+    final ExecutorService executor =
+        Executors.newFixedThreadPool(
+            numberOfThreads,
+            new ThreadFactoryBuilder()
+                .setNameFormat(KubectlJobExecutorTest.class.getSimpleName() + "-%d")
+                .build());
+
+    final ArrayList<Future<ImmutableList<KubernetesPodMetric>>> futures =
+        new ArrayList<>(numberOfThreads);
+
+    // when
     when(jobExecutor.runJob(any(JobRequest.class)))
         .thenReturn(
             JobResult.<String>builder()
@@ -146,33 +223,183 @@ final class KubectlJobExecutorTest {
                 .error("Unable to connect to the server: net/http: TLS handshake timeout")
                 .build());
 
-    KubernetesConfigurationProperties kubernetesConfigurationProperties =
-        new KubernetesConfigurationProperties();
+    KubectlJobExecutor kubectlJobExecutor =
+        new KubectlJobExecutor(
+            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+
+    for (int i = 1; i <= numberOfThreads; i++) {
+      futures.add(
+          executor.submit(
+              () -> kubectlJobExecutor.topPod(mockKubernetesCredentials(), NAMESPACE, "test-pod")));
+    }
+
+    // then
+    for (Future<ImmutableList<KubernetesPodMetric>> future : futures) {
+      try {
+        future.get();
+      } catch (final ExecutionException e) {
+        assertTrue(e.getCause() instanceof KubectlJobExecutor.KubectlException);
+        assertTrue(
+            e.getMessage()
+                .contains("Unable to connect to the server: net/http: TLS handshake timeout"));
+      } catch (final InterruptedException ignored) {
+      }
+    }
+
+    executor.shutdown();
+
+    // verify that the kubectl job executor made max configured attempts per thread to execute the
+    // action
+    verify(
+            jobExecutor,
+            times(
+                kubernetesConfigurationProperties.getJobExecutor().getRetries().getMaxAttempts()
+                    * numberOfThreads))
+        .runJob(any(JobRequest.class));
+
+    // verify retry registry
+    assertTrue(kubectlJobExecutor.getRetryRegistry().isPresent());
+    RetryRegistry retryRegistry = kubectlJobExecutor.getRetryRegistry().get();
+    assertThat(retryRegistry.getAllRetries().size()).isEqualTo(1);
+    assertThat(retryRegistry.getAllRetries().get(0).getName())
+        .isEqualTo("mock-account.topPod.test-pod");
+
+    // verify retry metrics
+    Retry.Metrics retryMetrics = retryRegistry.getAllRetries().get(0).getMetrics();
+    assertThat(retryMetrics.getNumberOfSuccessfulCallsWithRetryAttempt()).isEqualTo(0);
+    assertThat(retryMetrics.getNumberOfSuccessfulCallsWithoutRetryAttempt()).isEqualTo(0);
+    // in this test, all threads failed. So number of unique failed calls == 1 per thread.
+    assertThat(retryMetrics.getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(numberOfThreads);
+    assertThat(retryMetrics.getNumberOfFailedCallsWithoutRetryAttempt()).isEqualTo(0);
+
+    // verify that no duplicate messages are shown in the logs
+    List<ILoggingEvent> logsList = listAppender.list;
+    List<ILoggingEvent> numberOfFailedRetryAttemptLogMessages =
+        logsList.stream()
+            .filter(
+                iLoggingEvent ->
+                    iLoggingEvent
+                        .getFormattedMessage()
+                        .contains(
+                            "Action: mock-account.topPod.test-pod failed after "
+                                + kubernetesConfigurationProperties
+                                    .getJobExecutor()
+                                    .getRetries()
+                                    .getMaxAttempts()
+                                + " attempts"))
+            .collect(Collectors.toList());
+
+    // we should only see 1 failed retry attempt message per thread
+    assertThat(numberOfFailedRetryAttemptLogMessages.size()).isEqualTo(numberOfThreads);
+  }
+
+  @DisplayName(
+      "parameterized test to verify retry behavior for errors that are not configured to be retryable")
+  @ParameterizedTest(
+      name = "{index} ==> number of simultaneous executions of the action under test = {0}")
+  @ValueSource(ints = {1, 10})
+  void kubectlMultiThreadedRetryHandlingForErrorsThatAreNotConfiguredToBeRetryable(
+      int numberOfThreads) {
+    // setup
     kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(true);
-    kubernetesConfigurationProperties.getJobExecutor().getRetries().setBackOffInMs(500);
+
+    // to test log messages
+    Logger logger = (Logger) LoggerFactory.getLogger(KubectlJobExecutor.class);
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+    logger.addAppender(listAppender);
+    listAppender.start();
+
+    final ExecutorService executor =
+        Executors.newFixedThreadPool(
+            numberOfThreads,
+            new ThreadFactoryBuilder()
+                .setNameFormat(KubectlJobExecutorTest.class.getSimpleName() + "-%d")
+                .build());
+
+    final ArrayList<Future<ImmutableList<KubernetesPodMetric>>> futures =
+        new ArrayList<>(numberOfThreads);
+
+    // when
+    when(jobExecutor.runJob(any(JobRequest.class)))
+        .thenReturn(
+            JobResult.<String>builder()
+                .result(Result.FAILURE)
+                .output("")
+                .error("un-retryable error")
+                .build());
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
             jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
 
-    KubectlJobExecutor.KubectlException thrown =
-        assertThrows(
-            KubectlJobExecutor.KubectlException.class,
-            () -> kubectlJobExecutor.topPod(mockKubernetesCredentials(), "test", "test-pod"));
+    for (int i = 1; i <= numberOfThreads; i++) {
+      futures.add(
+          executor.submit(
+              () -> kubectlJobExecutor.topPod(mockKubernetesCredentials(), NAMESPACE, "test-pod")));
+    }
 
-    // should be called 3 times as there were max 3 attempts made
-    verify(jobExecutor, times(3)).runJob(any(JobRequest.class));
+    // then
+    for (Future<ImmutableList<KubernetesPodMetric>> future : futures) {
+      try {
+        future.get();
+      } catch (final ExecutionException e) {
+        assertTrue(e.getCause() instanceof KubectlJobExecutor.KubectlException);
+        assertTrue(e.getMessage().contains("un-retryable error"));
+      } catch (final InterruptedException ignored) {
+      }
+    }
 
-    // at the end of retries, the exception should still be thrown
-    assertTrue(
-        thrown
-            .getMessage()
-            .contains("Unable to connect to the server: net/http: TLS handshake timeout"));
+    executor.shutdown();
+
+    // verify that the kubectl job executor tried once to execute the action once per thread
+    verify(jobExecutor, times(numberOfThreads)).runJob(any(JobRequest.class));
+
+    // verify retry registry
+    assertTrue(kubectlJobExecutor.getRetryRegistry().isPresent());
+    RetryRegistry retryRegistry = kubectlJobExecutor.getRetryRegistry().get();
+    assertThat(retryRegistry.getAllRetries().size()).isEqualTo(1);
+    assertThat(retryRegistry.getAllRetries().get(0).getName())
+        .isEqualTo("mock-account.topPod.test-pod");
+
+    // verify retry metrics
+    Retry.Metrics retryMetrics = retryRegistry.getAllRetries().get(0).getMetrics();
+    assertThat(retryMetrics.getNumberOfSuccessfulCallsWithRetryAttempt()).isEqualTo(0);
+    assertThat(retryMetrics.getNumberOfSuccessfulCallsWithoutRetryAttempt()).isEqualTo(0);
+    assertThat(retryMetrics.getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(0);
+    // in this test, all threads failed without retrying. So number of unique failed calls == 1 per
+    // thread.
+    assertThat(retryMetrics.getNumberOfFailedCallsWithoutRetryAttempt()).isEqualTo(numberOfThreads);
+
+    // verify that no duplicate messages are shown in the logs
+    List<ILoggingEvent> logsList = listAppender.list;
+    List<ILoggingEvent> numberOfFailedRetryAttemptLogMessages =
+        logsList.stream()
+            .filter(
+                iLoggingEvent ->
+                    iLoggingEvent
+                        .getFormattedMessage()
+                        .contains(
+                            "mock-account.topPod.test-pod will not be retried as retries are not enabled for error: un-retryable error"))
+            .collect(Collectors.toList());
+
+    // we should only see 1 failed retry attempt message per thread
+    assertThat(numberOfFailedRetryAttemptLogMessages.size()).isEqualTo(numberOfThreads);
   }
 
   @Test
-  void kubectlRetryHandlingForConfiguredErrorsThatSucceedsAfterAFewRetries() throws IOException {
-    JobExecutor jobExecutor = mock(JobExecutor.class);
+  void kubectlRetryHandlingForConfiguredErrorsThatSucceedAfterAFewRetries() throws IOException {
+    // setup
+    kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(true);
+
+    // to test log messages
+    Logger logger = (Logger) LoggerFactory.getLogger(KubectlJobExecutor.class);
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+    logger.addAppender(listAppender);
+    listAppender.start();
+
+    // when
     when(jobExecutor.runJob(any(JobRequest.class)))
         .thenReturn(
             JobResult.<String>builder()
@@ -190,22 +417,51 @@ final class KubectlJobExecutorTest {
                 .error("")
                 .build());
 
-    KubernetesConfigurationProperties kubernetesConfigurationProperties =
-        new KubernetesConfigurationProperties();
-    kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(true);
-    kubernetesConfigurationProperties.getJobExecutor().getRetries().setBackOffInMs(500);
-
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
             jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
 
     Collection<KubernetesPodMetric> podMetrics =
         kubectlJobExecutor.topPod(mockKubernetesCredentials(), NAMESPACE, "test-pod");
-    assertThat(podMetrics).hasSize(2);
 
-    // should only be called twice as it failed on the first call but succeeded in the second one
+    // then
+
+    // job executor should be called twice - as it failed on the first call but succeeded
+    // in the second one
     verify(jobExecutor, times(2)).runJob(any(JobRequest.class));
 
+    // verify retry registry
+    assertTrue(kubectlJobExecutor.getRetryRegistry().isPresent());
+    RetryRegistry retryRegistry = kubectlJobExecutor.getRetryRegistry().get();
+    assertThat(retryRegistry.getAllRetries().size()).isEqualTo(1);
+    assertThat(retryRegistry.getAllRetries().get(0).getName())
+        .isEqualTo("mock-account.topPod.test-pod");
+
+    // verify retry metrics
+    Retry.Metrics retryMetrics = retryRegistry.getAllRetries().get(0).getMetrics();
+    // in this test, the action succeeded eventually. So number of unique calls == 1.
+    assertThat(retryMetrics.getNumberOfSuccessfulCallsWithRetryAttempt()).isEqualTo(1);
+    assertThat(retryMetrics.getNumberOfSuccessfulCallsWithoutRetryAttempt()).isEqualTo(0);
+    assertThat(retryMetrics.getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(0);
+    assertThat(retryMetrics.getNumberOfFailedCallsWithoutRetryAttempt()).isEqualTo(0);
+
+    // verify that no duplicate messages are shown in the logs
+    List<ILoggingEvent> logsList = listAppender.list;
+    List<ILoggingEvent> numberOfSucceededRetryAttemptsLogMessages =
+        logsList.stream()
+            .filter(
+                iLoggingEvent ->
+                    iLoggingEvent
+                        .getFormattedMessage()
+                        .contains(
+                            "Action: mock-account.topPod.test-pod succeeded after 1 retry attempt(s)"))
+            .collect(Collectors.toList());
+
+    // we should only see 1 succeeded retry attempt message
+    assertThat(numberOfSucceededRetryAttemptsLogMessages.size()).isEqualTo(1);
+
+    // verify output of the command
+    assertThat(podMetrics).hasSize(2);
     ImmutableSetMultimap<String, ContainerMetric> expectedMetrics =
         ImmutableSetMultimap.<String, ContainerMetric>builder()
             .putAll(
@@ -244,50 +500,14 @@ final class KubectlJobExecutorTest {
     }
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void kubectlJobExecutorHandlingForErrorsThatAreNotConfiguredToBeRetryable(
-      boolean retriesEnabled) {
-    JobExecutor jobExecutor = mock(JobExecutor.class);
-    when(jobExecutor.runJob(any(JobRequest.class)))
-        .thenReturn(
-            JobResult.<String>builder()
-                .result(Result.FAILURE)
-                .output("")
-                .error("un-retryable error")
-                .build());
-
-    KubernetesConfigurationProperties kubernetesConfigurationProperties =
-        new KubernetesConfigurationProperties();
-    kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(retriesEnabled);
-
-    KubectlJobExecutor kubectlJobExecutor =
-        new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
-
-    KubectlJobExecutor.KubectlException thrown =
-        assertThrows(
-            KubectlJobExecutor.KubectlException.class,
-            () -> kubectlJobExecutor.topPod(mockKubernetesCredentials(), "test", ""));
-
-    assertTrue(thrown.getMessage().contains("un-retryable error"));
-    // should only be called once as no retries are performed for this error
-    verify(jobExecutor).runJob(any(JobRequest.class));
-  }
-
-  @ParameterizedTest
+  @ParameterizedTest(name = "{index} ==> retries enabled = {0}")
   @ValueSource(booleans = {true, false})
   void kubectlJobExecutorRaisesException(boolean retriesEnabled) {
-    JobExecutor jobExecutor = mock(JobExecutor.class);
     when(jobExecutor.runJob(any(JobRequest.class)))
         .thenThrow(new JobExecutionException("unknown exception", new IOException()));
 
-    KubernetesConfigurationProperties kubernetesConfigurationProperties =
-        new KubernetesConfigurationProperties();
-
     if (retriesEnabled) {
       kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(true);
-      kubernetesConfigurationProperties.getJobExecutor().getRetries().setBackOffInMs(500);
     }
 
     KubectlJobExecutor kubectlJobExecutor =

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
@@ -93,11 +93,7 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor,
-            "kubectl",
-            "oauth2l",
-            kubernetesConfigurationProperties,
-            new SimpleMeterRegistry());
+            jobExecutor, kubernetesConfigurationProperties, new SimpleMeterRegistry());
     Collection<KubernetesPodMetric> podMetrics =
         kubectlJobExecutor.topPod(mockKubernetesCredentials(), "test", "");
     assertThat(podMetrics).isEmpty();
@@ -137,11 +133,7 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor,
-            "kubectl",
-            "oauth2l",
-            new KubernetesConfigurationProperties(),
-            new SimpleMeterRegistry());
+            jobExecutor, new KubernetesConfigurationProperties(), new SimpleMeterRegistry());
     Collection<KubernetesPodMetric> podMetrics =
         kubectlJobExecutor.topPod(mockKubernetesCredentials(), NAMESPACE, "");
     assertThat(podMetrics).hasSize(2);
@@ -198,11 +190,7 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor,
-            "kubectl",
-            "oauth2l",
-            kubernetesConfigurationProperties,
-            new SimpleMeterRegistry());
+            jobExecutor, kubernetesConfigurationProperties, new SimpleMeterRegistry());
 
     // then
     KubectlJobExecutor.KubectlException thrown =
@@ -254,11 +242,7 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor,
-            "kubectl",
-            "oauth2l",
-            kubernetesConfigurationProperties,
-            new SimpleMeterRegistry());
+            jobExecutor, kubernetesConfigurationProperties, new SimpleMeterRegistry());
 
     for (int i = 1; i <= numberOfThreads; i++) {
       futures.add(
@@ -367,11 +351,7 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor,
-            "kubectl",
-            "oauth2l",
-            kubernetesConfigurationProperties,
-            new SimpleMeterRegistry());
+            jobExecutor, kubernetesConfigurationProperties, new SimpleMeterRegistry());
 
     for (int i = 1; i <= numberOfThreads; i++) {
       futures.add(
@@ -460,11 +440,7 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor,
-            "kubectl",
-            "oauth2l",
-            kubernetesConfigurationProperties,
-            new SimpleMeterRegistry());
+            jobExecutor, kubernetesConfigurationProperties, new SimpleMeterRegistry());
 
     Collection<KubernetesPodMetric> podMetrics =
         kubectlJobExecutor.topPod(mockKubernetesCredentials(), NAMESPACE, "test-pod");
@@ -561,11 +537,7 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor,
-            "kubectl",
-            "oauth2l",
-            kubernetesConfigurationProperties,
-            new SimpleMeterRegistry());
+            jobExecutor, kubernetesConfigurationProperties, new SimpleMeterRegistry());
 
     JobExecutionException thrown =
         assertThrows(

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
@@ -35,7 +35,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.Gson;
-import com.netflix.spinnaker.clouddriver.data.task.InMemoryTaskRepository;
 import com.netflix.spinnaker.clouddriver.jobs.JobExecutionException;
 import com.netflix.spinnaker.clouddriver.jobs.JobExecutor;
 import com.netflix.spinnaker.clouddriver.jobs.JobRequest;
@@ -581,9 +580,7 @@ final class KubectlJobExecutorTest {
         kubectlJobExecutor.deploy(
             mockKubernetesCredentials(
                 "src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/job/mock-kubectl-stdin-command.sh"),
-            inputManifest,
-            new InMemoryTaskRepository().create("starting", "starting"),
-            "starting");
+            inputManifest);
 
     // even after retries occur, the inputStream should not empty. This is verified by
     // checking the stdout generated from the script
@@ -619,9 +616,7 @@ final class KubectlJobExecutorTest {
                 kubectlJobExecutor.deploy(
                     mockKubernetesCredentials(
                         "src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/job/mock-kubectl-stdin-command.sh"),
-                    inputManifest,
-                    new InMemoryTaskRepository().create("starting", "starting"),
-                    "starting"));
+                    inputManifest));
 
     assertThat(thrown.getMessage()).contains("Deploy failed for manifest: job my-job");
     // verify that the final error contained stdin data

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/job/mock-kubectl-stdin-command.sh
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/job/mock-kubectl-stdin-command.sh
@@ -20,9 +20,9 @@
 # being tested is simply the fact that the retry attempts for such calls continue to read
 # data from stdin. To simulate retries, we exit the script with an error that is configured
 # to be retryable as long as $1 != "success"
-input=`cat -`
+input=$(cat -)
 # simulate error case
-if [[ "$1" != "success" ]]
+if [ "$1" != "success" ]
 then
   echo "\n########################" >&2
   echo "data received from stdin: $input" >&2
@@ -30,5 +30,5 @@ then
   echo "########################" >&2
   exit 1
 else
-  echo $input
+  echo "$input"
 fi

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/job/mock-kubectl-stdin-command.sh
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/job/mock-kubectl-stdin-command.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2021 Salesforce.com, Inc.
+# Copyright 2021 Netflix, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,12 +19,16 @@
 # This script is meant to mock kubectl apply -f - commands in unit tests. The functionality
 # being tested is simply the fact that the retry attempts for such calls continue to read
 # data from stdin. To simulate retries, we exit the script with an error that is configured
-# to be retryable
-echo "########################"
-echo " printing data read from stdin"
+# to be retryable as long as $1 != "success"
 input=`cat -`
-echo $input
-echo "########################"
 # simulate error case
-echo "TLS handshake timeout" >&2
-exit 1
+if [[ "$1" != "success" ]]
+then
+  echo "\n########################" >&2
+  echo "data received from stdin: $input" >&2
+  echo "Error: TLS handshake timeout" >&2
+  echo "########################" >&2
+  exit 1
+else
+  echo $input
+fi

--- a/clouddriver-kubernetes/src/test/scripts/mock-kubectl-stdin-error-generating-script.sh
+++ b/clouddriver-kubernetes/src/test/scripts/mock-kubectl-stdin-error-generating-script.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# Copyright 2021 Salesforce.com, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+# This script is meant to mock kubectl apply -f - commands in unit tests. The functionality
+# being tested is simply the fact that the retry attempts for such calls continue to read
+# data from stdin. To simulate retries, we exit the script with an error that is configured
+# to be retryable
+echo "########################"
+echo " printing data read from stdin"
+input=`cat -`
+echo $input
+echo "########################"
+# simulate error case
+echo "TLS handshake timeout" >&2
+exit 1


### PR DESCRIPTION
## Purpose

* add tests to show duplicate logs aren't being printed when multiple threads are running the same command
* add metrics support for capturing retries.
* refactor criteria that decides if an error should be retried. This is needed so that metrics are reported correctly
* refactor tests
* add short custom log messages for retries instead of the default verbose ones

## Testing
* unit tests

* Integration testing via deployment of the itest images to clouddriver pods in dev2 shard1:

Evidence of logs showing that retries help in fixing the problem in subsequent attempts:
```
{"@timestamp":"2021-11-12T16:55:15.987+00:00","@version":1,"message":"Retrying kubectl command for <redacted> Attempt #1 failed with exception: com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor$KubectlException: command: 'kubectl --namespace=test -o json get job <redacted>' in account: <redacted> failed. Error: Unable to connect to the server: net/http: TLS handshake timeout\n","logger_name":"com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor","thread_name":"http-nio-7002-exec-13","level":"INFO","level_value":20000}
{"@timestamp":"2021-11-12T16:55:32.037+00:00","@version":1,"message":"Kubectl command for a<redacted> is now successful in attempt #2. Last attempt had failed with exception: com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor$KubectlException: command: 'kubectl --namespace=test -o json get job <redacted>' in account: <redacted> failed. Error: Unable to connect to the server: net/http: TLS handshake timeout\n","logger_name":"com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor","thread_name":"http-nio-7002-exec-13","level":"INFO","level_value":20000}
```
