### PR TITLE
feat(kubernetes): Add a check to verify if application name obtained from a kubernetes manifest exists in Front50

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.core.services
 
 import com.netflix.spinnaker.clouddriver.model.EntityTags
+import com.netflix.spinnaker.clouddriver.model.Front50Application
 import retrofit.client.Response
 import retrofit.http.*
 
@@ -31,6 +32,9 @@ interface Front50Service {
 
   @GET('/v2/applications/{applicationName}')
   Map getApplication(@Path('applicationName') String applicationName)
+
+  @GET('/v2/applications?restricted=false')
+  Set<Front50Application> getAllApplicationsUnrestricted()
 
   @GET('/v2/projects/{project}')
   Map getProject(@Path('project') String project)

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Front50Application.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Front50Application.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Front50Application {
+  private String name;
+}

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -79,6 +79,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-exceptions"
   implementation "io.spinnaker.kork:kork-moniker"
   implementation "io.spinnaker.kork:kork-secrets"
+  implementation "io.spinnaker.kork:kork-security"
   implementation "io.kubernetes:client-java:$kubernetesClientVersion"
   implementation "org.apache.commons:commons-lang3"
   implementation "org.springframework.boot:spring-boot-actuator"

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/CustomKubernetesCachingAgentFactory.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/CustomKubernetesCachingAgentFactory.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
-import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
@@ -42,7 +41,7 @@ public class CustomKubernetesCachingAgentFactory {
       Long agentInterval,
       KubernetesConfigurationProperties configurationProperties,
       KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
-      @Nullable Front50Service front50Service) {
+      @Nullable Front50ApplicationLoader front50ApplicationLoader) {
     return new Agent(
         kind,
         namedAccountCredentials,
@@ -53,7 +52,7 @@ public class CustomKubernetesCachingAgentFactory {
         agentInterval,
         configurationProperties,
         kubernetesSpinnakerKindMap,
-        front50Service);
+        front50ApplicationLoader);
   }
 
   /**
@@ -76,7 +75,7 @@ public class CustomKubernetesCachingAgentFactory {
         Long agentInterval,
         KubernetesConfigurationProperties configurationProperties,
         KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
-        @Nullable Front50Service front50Service) {
+        @Nullable Front50ApplicationLoader front50ApplicationLoader) {
       super(
           namedAccountCredentials,
           objectMapper,
@@ -86,7 +85,7 @@ public class CustomKubernetesCachingAgentFactory {
           agentInterval,
           configurationProperties,
           kubernetesSpinnakerKindMap,
-          front50Service);
+          front50ApplicationLoader);
       this.kind = kind;
     }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/CustomKubernetesCachingAgentFactory.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/CustomKubernetesCachingAgentFactory.java
@@ -24,10 +24,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import org.springframework.lang.Nullable;
 
 public class CustomKubernetesCachingAgentFactory {
   public static KubernetesCachingAgent create(
@@ -39,7 +41,8 @@ public class CustomKubernetesCachingAgentFactory {
       int agentCount,
       Long agentInterval,
       KubernetesConfigurationProperties configurationProperties,
-      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
+      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
+      @Nullable Front50Service front50Service) {
     return new Agent(
         kind,
         namedAccountCredentials,
@@ -49,7 +52,8 @@ public class CustomKubernetesCachingAgentFactory {
         agentCount,
         agentInterval,
         configurationProperties,
-        kubernetesSpinnakerKindMap);
+        kubernetesSpinnakerKindMap,
+        front50Service);
   }
 
   /**
@@ -71,7 +75,8 @@ public class CustomKubernetesCachingAgentFactory {
         int agentCount,
         Long agentInterval,
         KubernetesConfigurationProperties configurationProperties,
-        KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
+        KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
+        @Nullable Front50Service front50Service) {
       super(
           namedAccountCredentials,
           objectMapper,
@@ -80,7 +85,8 @@ public class CustomKubernetesCachingAgentFactory {
           agentCount,
           agentInterval,
           configurationProperties,
-          kubernetesSpinnakerKindMap);
+          kubernetesSpinnakerKindMap,
+          front50Service);
       this.kind = kind;
     }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/Front50ApplicationLoader.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/Front50ApplicationLoader.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.caching.agent;
+
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
+import com.netflix.spinnaker.clouddriver.model.Front50Application;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.lang.Nullable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * we could have a conditional on both kubernetes.cache.checkApplicationInFront50 and
+ * services.front50.enabled properties. But if the former is enabled and the latter is not, that
+ * means the downstream clients relying on this will fail, since the cache will be empty. So we
+ * explicitly leave out the front50 conditional and log an error message in the refreshCache()
+ * stating the same. We could have logged the error message in the downstream clients if if couldn't
+ * find the front50ApplicationLoader bean but that can be extremely noisy.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty("kubernetes.cache.checkApplicationInFront50")
+public class Front50ApplicationLoader {
+
+  @Nullable private final Front50Service front50Service;
+  private AtomicReference<Set<String>> cache;
+
+  Front50ApplicationLoader(@Nullable Front50Service front50Service) {
+    this.front50Service = front50Service;
+    this.cache = new AtomicReference<>(Collections.emptySet());
+  }
+
+  public Set<String> getData() {
+    return cache.get();
+  }
+
+  @Scheduled(
+      fixedDelayString = "${kubernetes.cache.refreshFront50ApplicationsCacheIntervalInMs:60000}")
+  protected void refreshCache() {
+    try {
+      log.info("refreshing front50 applications cache");
+      if (front50Service == null) {
+        log.info("front50 is disabled, cannot fetch applications");
+        return;
+      }
+      Set<Front50Application> response =
+          AuthenticatedRequest.allowAnonymous(front50Service::getAllApplicationsUnrestricted);
+      Set<String> applicationsKnownToFront50 =
+          response.stream().map(Front50Application::getName).collect(Collectors.toSet());
+      log.info("received {} applications from front50", applicationsKnownToFront50.size());
+      cache.set(applicationsKnownToFront50);
+    } catch (Exception e) {
+      log.warn("failed to update application cache with new front50 data. Error: ", e);
+    }
+  }
+}

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverter.java
@@ -63,8 +63,11 @@ public class KubernetesCacheDataConverter {
   // todo(lwander) investigate if this can cause flapping in UI for on demand updates -- no
   // consensus on this yet.
   @Getter private static final List<KubernetesKind> stickyKinds = Arrays.asList(SERVICE, POD);
+
+  @Getter
   private static final ImmutableSet<SpinnakerKind> logicalRelationshipKinds =
       ImmutableSet.of(LOAD_BALANCERS, SECURITY_GROUPS, SERVER_GROUPS, SERVER_GROUP_MANAGERS);
+
   private static final ImmutableSet<SpinnakerKind> clusterRelationshipKinds =
       ImmutableSet.of(SERVER_GROUPS, SERVER_GROUP_MANAGERS);
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgent.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.cats.agent.CachingAgent;
 import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesCachingPolicy;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
@@ -44,7 +45,17 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
-import java.util.*;
+import com.netflix.spinnaker.clouddriver.model.Front50Application;
+import com.netflix.spinnaker.moniker.Namer;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -53,6 +64,7 @@ import javax.annotation.Nonnull;
 import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
 
 /**
  * A kubernetes caching agent is a class that caches part of the kubernetes infrastructure. Every
@@ -87,6 +99,7 @@ public abstract class KubernetesCachingAgent
   protected final KubernetesConfigurationProperties configurationProperties;
 
   protected final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
+  @Nullable private final Front50Service front50Service;
 
   protected KubernetesCachingAgent(
       KubernetesNamedAccountCredentials namedAccountCredentials,
@@ -96,7 +109,8 @@ public abstract class KubernetesCachingAgent
       int agentCount,
       Long agentInterval,
       KubernetesConfigurationProperties configurationProperties,
-      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
+      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
+      @Nullable Front50Service front50Service) {
     this.accountName = namedAccountCredentials.getName();
     this.credentials = namedAccountCredentials.getCredentials();
     this.objectMapper = objectMapper;
@@ -106,6 +120,7 @@ public abstract class KubernetesCachingAgent
     this.agentInterval = agentInterval;
     this.configurationProperties = configurationProperties;
     this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
+    this.front50Service = front50Service;
   }
 
   protected Map<String, Object> defaultIntrospectionDetails() {
@@ -270,10 +285,45 @@ public abstract class KubernetesCachingAgent
     return buildCacheResult(ImmutableMap.of(resource.getKind(), ImmutableList.of(resource)));
   }
 
-  private Predicate<KubernetesManifest> removeIgnored(boolean onlySpinnakerManaged) {
+  /**
+   * method that determines if the provided manifest should be cached or not. It makes that
+   * determination based on the following rules:
+   *
+   * <p>- if a manifest's caching properties has ignore == true, then it will not be cached.
+   *
+   * <p>- Otherwise, if account is configured to be "onlySpinnakerManaged", and
+   * "moniker.spinnaker.io/application" annotation is empty, then it will not be cached.
+   *
+   * <p>- if {@link KubernetesConfigurationProperties#isCheckApplicationInFront50()} is true, and
+   * the application name obtained from the manifest is not known to front50, then it will not be
+   * cached.
+   *
+   * <p>- If none of the above criteria is satisfied, then the manifest will be cached.
+   *
+   * @param onlySpinnakerManaged account specific config knob to decide if a manifest should be
+   *     cached or not. Only applicable when a manifest's caching properties has ignore == false
+   * @param namer entity that helps in retrieving the application name from the manifest
+   * @param applicationsKnownToFront50 set of applications known to front50
+   * @return true, if manifest should be cached, false otherwise
+   */
+  private Predicate<KubernetesManifest> shouldCacheManifest(
+      boolean onlySpinnakerManaged,
+      Namer<KubernetesManifest> namer,
+      Set<String> applicationsKnownToFront50) {
     return m -> {
       KubernetesCachingProperties props = KubernetesManifestAnnotater.getCachingProperties(m);
-      return !props.isIgnore() && !(onlySpinnakerManaged && props.getApplication().isEmpty());
+      if (props.isIgnore()) {
+        return false;
+      }
+
+      if (onlySpinnakerManaged && props.getApplication().isEmpty()) {
+        return false;
+      }
+
+      if (this.configurationProperties.isCheckApplicationInFront50()) {
+        return applicationsKnownToFront50.contains(namer.deriveMoniker(m).getApp());
+      }
+      return true;
     };
   }
 
@@ -291,7 +341,11 @@ public abstract class KubernetesCachingAgent
                     .get(m.getKind())
                     .getHandler()
                     .removeSensitiveKeys(m))
-        .filter(removeIgnored(credentials.isOnlySpinnakerManaged()))
+        .filter(
+            shouldCacheManifest(
+                credentials.isOnlySpinnakerManaged(),
+                credentials.getNamer(),
+                getApplicationsFromFront50()))
         .forEach(
             rs -> {
               try {
@@ -352,5 +406,42 @@ public abstract class KubernetesCachingAgent
   public String getAgentType() {
     return String.format(
         "%s/%s[%d/%d]", accountName, this.getClass().getSimpleName(), agentIndex + 1, agentCount);
+  }
+
+  /**
+   * gets all applications from front50. We do this instead of getting individual applications one
+   * by one in downstream methods because:
+   *
+   * <p>1. we don't have to make a separate call for each individual application. This can get out
+   * of hand if we have a large number of applications.
+   *
+   * <p>2. get around the authentication issue as those individual calls require an authenticated
+   * user.
+   *
+   * @return set of application names obtained from front50
+   */
+  private Set<String> getApplicationsFromFront50() {
+    if (configurationProperties.isCheckApplicationInFront50()) {
+      // if front50 is not enabled, then we have no way to verify if the application exists. This is
+      // going to affect caching of these resources.
+      log.info("getting all applications known to front50");
+      if (this.front50Service != null) {
+        try {
+          Set<Front50Application> response =
+              AuthenticatedRequest.allowAnonymous(front50Service::getAllApplicationsUnrestricted);
+          Set<String> applicationsKnownToFront50 =
+              response.stream()
+                  .map(Front50Application::getName)
+                  .map(String::toLowerCase)
+                  .collect(Collectors.toSet());
+          log.info("received {} applications from front50", applicationsKnownToFront50.size());
+          return applicationsKnownToFront50;
+        } catch (Exception e) {
+          log.error("could not obtain any applications from front50. Error: ", e);
+        }
+      }
+    }
+
+    return Collections.emptySet();
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcher.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcher.java
@@ -19,14 +19,18 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
-import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.ResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -42,7 +46,7 @@ public class KubernetesCachingAgentDispatcher {
   private final Registry registry;
   private final KubernetesConfigurationProperties configurationProperties;
   private final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
-  @Nullable private final Front50Service front50Service;
+  @Nullable private final Front50ApplicationLoader front50ApplicationLoader;
 
   @Autowired
   public KubernetesCachingAgentDispatcher(
@@ -50,12 +54,12 @@ public class KubernetesCachingAgentDispatcher {
       Registry registry,
       KubernetesConfigurationProperties configurationProperties,
       KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
-      @Nullable Front50Service front50Service) {
+      @Nullable Front50ApplicationLoader front50ApplicationLoader) {
     this.objectMapper = objectMapper;
     this.registry = registry;
     this.configurationProperties = configurationProperties;
     this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
-    this.front50Service = front50Service;
+    this.front50ApplicationLoader = front50ApplicationLoader;
   }
 
   public Collection<KubernetesCachingAgent> buildAllCachingAgents(
@@ -91,7 +95,7 @@ public class KubernetesCachingAgentDispatcher {
                                 agentInterval,
                                 configurationProperties,
                                 kubernetesSpinnakerKindMap,
-                                front50Service))
+                                front50ApplicationLoader))
                     .filter(Objects::nonNull)
                     .forEach(result::add));
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcher.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcher.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -40,17 +42,20 @@ public class KubernetesCachingAgentDispatcher {
   private final Registry registry;
   private final KubernetesConfigurationProperties configurationProperties;
   private final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
+  @Nullable private final Front50Service front50Service;
 
   @Autowired
   public KubernetesCachingAgentDispatcher(
       ObjectMapper objectMapper,
       Registry registry,
       KubernetesConfigurationProperties configurationProperties,
-      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
+      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
+      @Nullable Front50Service front50Service) {
     this.objectMapper = objectMapper;
     this.registry = registry;
     this.configurationProperties = configurationProperties;
     this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
+    this.front50Service = front50Service;
   }
 
   public Collection<KubernetesCachingAgent> buildAllCachingAgents(
@@ -85,7 +90,8 @@ public class KubernetesCachingAgentDispatcher {
                                 credentials.getCacheThreads(),
                                 agentInterval,
                                 configurationProperties,
-                                kubernetesSpinnakerKindMap))
+                                kubernetesSpinnakerKindMap,
+                                front50Service))
                     .filter(Objects::nonNull)
                     .forEach(result::add));
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentFactory.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentFactory.java
@@ -19,9 +19,11 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import org.springframework.lang.Nullable;
 
 @FunctionalInterface
 public interface KubernetesCachingAgentFactory {
@@ -33,5 +35,6 @@ public interface KubernetesCachingAgentFactory {
       int agentCount,
       Long agentInterval,
       KubernetesConfigurationProperties configurationProperties,
-      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap);
+      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
+      @Nullable Front50Service front50Service);
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentFactory.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentFactory.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
-import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
@@ -36,5 +35,5 @@ public interface KubernetesCachingAgentFactory {
       Long agentInterval,
       KubernetesConfigurationProperties configurationProperties,
       KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
-      @Nullable Front50Service front50Service);
+      @Nullable Front50ApplicationLoader front50ApplicationLoader);
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgent.java
@@ -23,6 +23,7 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITA
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
@@ -32,6 +33,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAcco
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
+import org.springframework.lang.Nullable;
 
 /**
  * Instances of this class cache kubernetes core kinds for one particular account at regular
@@ -51,7 +53,8 @@ public class KubernetesCoreCachingAgent extends KubernetesCachingAgent {
       int agentCount,
       Long agentInterval,
       KubernetesConfigurationProperties configurationProperties,
-      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
+      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
+      @Nullable Front50Service front50Service) {
     super(
         namedAccountCredentials,
         objectMapper,
@@ -60,7 +63,8 @@ public class KubernetesCoreCachingAgent extends KubernetesCachingAgent {
         agentCount,
         agentInterval,
         configurationProperties,
-        kubernetesSpinnakerKindMap);
+        kubernetesSpinnakerKindMap,
+        front50Service);
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgent.java
@@ -23,7 +23,6 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITA
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
-import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
@@ -54,7 +53,7 @@ public class KubernetesCoreCachingAgent extends KubernetesCachingAgent {
       Long agentInterval,
       KubernetesConfigurationProperties configurationProperties,
       KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
-      @Nullable Front50Service front50Service) {
+      @Nullable Front50ApplicationLoader front50ApplicationLoader) {
     super(
         namedAccountCredentials,
         objectMapper,
@@ -64,7 +63,7 @@ public class KubernetesCoreCachingAgent extends KubernetesCachingAgent {
         agentInterval,
         configurationProperties,
         kubernetesSpinnakerKindMap,
-        front50Service);
+        front50ApplicationLoader);
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
-import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
@@ -52,7 +51,7 @@ public class KubernetesUnregisteredCustomResourceCachingAgent extends Kubernetes
       Long agentInterval,
       KubernetesConfigurationProperties configurationProperties,
       KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
-      @Nullable Front50Service front50Service) {
+      @Nullable Front50ApplicationLoader front50ApplicationLoader) {
     super(
         namedAccountCredentials,
         objectMapper,
@@ -62,7 +61,7 @@ public class KubernetesUnregisteredCustomResourceCachingAgent extends Kubernetes
         agentInterval,
         configurationProperties,
         kubernetesSpinnakerKindMap,
-        front50Service);
+        front50ApplicationLoader);
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
@@ -25,11 +25,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import org.springframework.lang.Nullable;
 
 /**
  * Instances of this class cache CRDs for one particular account at regular intervals.
@@ -49,7 +51,8 @@ public class KubernetesUnregisteredCustomResourceCachingAgent extends Kubernetes
       int agentCount,
       Long agentInterval,
       KubernetesConfigurationProperties configurationProperties,
-      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
+      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
+      @Nullable Front50Service front50Service) {
     super(
         namedAccountCredentials,
         objectMapper,
@@ -58,7 +61,8 @@ public class KubernetesUnregisteredCustomResourceCachingAgent extends Kubernetes
         agentCount,
         agentInterval,
         configurationProperties,
-        kubernetesSpinnakerKindMap);
+        kubernetesSpinnakerKindMap,
+        front50Service);
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -35,10 +35,9 @@ public class KubernetesConfigurationProperties {
 
   private Cache cache = new Cache();
 
-  // controls whether an application name obtained from a kubernetes manifest needs to be checked
-  // against front50. This can be needed in cases where we want front50 to be the definitive source
-  // of truth for applications. If you set this to true, please ensure that front50 is enabled.
-  private boolean checkApplicationInFront50 = false;
+  public KubernetesConfigurationProperties kubernetesConfigurationProperties() {
+    return new KubernetesConfigurationProperties();
+  }
 
   @Data
   public static class KubernetesJobExecutorProperties {
@@ -109,5 +108,13 @@ public class KubernetesConfigurationProperties {
      * Cache#cacheKinds}
      */
     private List<String> cacheOmitKinds = null;
+
+    /**
+     * controls whether an application name obtained from a kubernetes manifest needs to be checked
+     * against front50. This can be needed in cases where we want front50 to be the definitive
+     * source of truth for applications. If you set this to true, please ensure that front50 is
+     * enabled.
+     */
+    boolean checkApplicationInFront50 = false;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -35,6 +35,11 @@ public class KubernetesConfigurationProperties {
 
   private Cache cache = new Cache();
 
+  // controls whether an application name obtained from a kubernetes manifest needs to be checked
+  // against front50. This can be needed in cases where we want front50 to be the definitive source
+  // of truth for applications. If you set this to true, please ensure that front50 is enabled.
+  private boolean checkApplicationInFront50 = false;
+
   @Data
   public static class KubernetesJobExecutorProperties {
     private Retries retries = new Retries();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesCachingProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesCachingProperties.java
@@ -26,7 +26,10 @@ import lombok.Value;
 @NonnullByDefault
 @Value
 public class KubernetesCachingProperties {
+  /** if true, then the kubernetes manifest will not be cached */
   private final boolean ignore;
+
+  /** this stores the application name for a kubernetes manifest */
   private final String application;
 
   @Builder

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CustomKubernetesHandlerFactory.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CustomKubernetesHandlerFactory.java
@@ -19,8 +19,8 @@ package com.netflix.spinnaker.clouddriver.kubernetes.op.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
-import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.CustomKubernetesCachingAgentFactory;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.Front50ApplicationLoader;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgentFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
@@ -101,7 +101,7 @@ public class CustomKubernetesHandlerFactory {
         Long agentInterval,
         KubernetesConfigurationProperties configurationProperties,
         KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
-        @Nullable Front50Service front50Service) {
+        @Nullable Front50ApplicationLoader front50ApplicationLoader) {
       return CustomKubernetesCachingAgentFactory.create(
           kubernetesKind,
           namedAccountCredentials,
@@ -112,7 +112,7 @@ public class CustomKubernetesHandlerFactory {
           agentInterval,
           configurationProperties,
           kubernetesSpinnakerKindMap,
-          front50Service);
+          front50ApplicationLoader);
     }
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CustomKubernetesHandlerFactory.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CustomKubernetesHandlerFactory.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.op.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.CustomKubernetesCachingAgentFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgentFactory;
@@ -31,6 +32,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest.Status;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import javax.annotation.Nonnull;
+import org.springframework.lang.Nullable;
 
 public class CustomKubernetesHandlerFactory {
   public static KubernetesHandler create(
@@ -98,7 +100,8 @@ public class CustomKubernetesHandlerFactory {
         int agentCount,
         Long agentInterval,
         KubernetesConfigurationProperties configurationProperties,
-        KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
+        KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
+        @Nullable Front50Service front50Service) {
       return CustomKubernetesCachingAgentFactory.create(
           kubernetesKind,
           namedAccountCredentials,
@@ -108,7 +111,8 @@ public class CustomKubernetesHandlerFactory {
           agentCount,
           agentInterval,
           configurationProperties,
-          kubernetesSpinnakerKindMap);
+          kubernetesSpinnakerKindMap,
+          front50Service);
     }
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.artifact.ArtifactReplacer;
 import com.netflix.spinnaker.clouddriver.kubernetes.artifact.ArtifactReplacer.ReplaceResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.artifact.Replacer;
@@ -42,6 +43,7 @@ import java.util.*;
 import javax.annotation.Nonnull;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.lang.Nullable;
 
 public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatch {
   protected static final ObjectMapper objectMapper = new ObjectMapper();
@@ -110,7 +112,8 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
       int agentCount,
       Long agentInterval,
       KubernetesConfigurationProperties configurationProperties,
-      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
+      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
+      @Nullable Front50Service front50Service) {
     return cachingAgentFactory()
         .buildCachingAgent(
             namedAccountCredentials,
@@ -120,7 +123,8 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
             agentCount,
             agentInterval,
             configurationProperties,
-            kubernetesSpinnakerKindMap);
+            kubernetesSpinnakerKindMap,
+            front50Service);
   }
 
   // used for stripping sensitive values

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java
@@ -22,11 +22,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spectator.api.Registry;
-import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.artifact.ArtifactReplacer;
 import com.netflix.spinnaker.clouddriver.kubernetes.artifact.ArtifactReplacer.ReplaceResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.artifact.Replacer;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.InfrastructureCacheKey;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.Front50ApplicationLoader;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCachingAgentFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.KubernetesManifestProvider;
@@ -113,7 +113,7 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
       Long agentInterval,
       KubernetesConfigurationProperties configurationProperties,
       KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
-      @Nullable Front50Service front50Service) {
+      @Nullable Front50ApplicationLoader front50ApplicationLoader) {
     return cachingAgentFactory()
         .buildCachingAgent(
             namedAccountCredentials,
@@ -124,7 +124,7 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
             agentInterval,
             configurationProperties,
             kubernetesSpinnakerKindMap,
-            front50Service);
+            front50ApplicationLoader);
   }
 
   // used for stripping sensitive values

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcherTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcherTest.java
@@ -46,7 +46,8 @@ public class KubernetesCachingAgentDispatcherTest {
             new ObjectMapper(),
             null,
             new KubernetesConfigurationProperties(),
-            new KubernetesSpinnakerKindMap(new ArrayList<>()));
+            new KubernetesSpinnakerKindMap(new ArrayList<>()),
+            null);
     KubernetesNamedAccountCredentials creds = mockCredentials(1);
     Collection<KubernetesCachingAgent> agents = dispatcher.buildAllCachingAgents(creds);
 
@@ -61,7 +62,8 @@ public class KubernetesCachingAgentDispatcherTest {
             new ObjectMapper(),
             null,
             new KubernetesConfigurationProperties(),
-            new KubernetesSpinnakerKindMap(new ArrayList<>()));
+            new KubernetesSpinnakerKindMap(new ArrayList<>()),
+            null);
     KubernetesNamedAccountCredentials creds = mockCredentials(2);
     Collection<KubernetesCachingAgent> agents = dispatcher.buildAllCachingAgents(creds);
 
@@ -78,7 +80,8 @@ public class KubernetesCachingAgentDispatcherTest {
             new ObjectMapper(),
             null,
             configProperties,
-            new KubernetesSpinnakerKindMap(new ArrayList<>()));
+            new KubernetesSpinnakerKindMap(new ArrayList<>()),
+            null);
     KubernetesNamedAccountCredentials creds = mockCredentials(2);
     Collection<KubernetesCachingAgent> agents = dispatcher.buildAllCachingAgents(creds);
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
@@ -22,8 +22,11 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITA
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableCollection;
@@ -31,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.io.Resources;
 import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.cats.agent.CacheResult;
@@ -39,6 +43,7 @@ import com.netflix.spinnaker.cats.cache.DefaultJsonCacheData;
 import com.netflix.spinnaker.cats.mem.InMemoryCache;
 import com.netflix.spinnaker.cats.provider.DefaultProviderCache;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesAccountProperties.ManagedAccount;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
@@ -51,8 +56,10 @@ import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesManifestName
 import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.*;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
-import com.netflix.spinnaker.moniker.Namer;
+import com.netflix.spinnaker.clouddriver.model.Front50Application;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.IntStream;
 import lombok.Value;
@@ -104,16 +111,15 @@ final class KubernetesCoreCachingAgentTest {
           new KubernetesConfigMapHandler());
   private static final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap =
       new KubernetesSpinnakerKindMap(handlers);
-  private static final Namer<KubernetesManifest> NAMER = new KubernetesManifestNamer();
 
   /** A test Deployment manifest */
-  private static KubernetesManifest deploymentManifest() {
+  private static KubernetesManifest deploymentManifest(String deploymentName) {
     KubernetesManifest deployment = new KubernetesManifest();
     deployment.put("metadata", new HashMap<>());
     deployment.setNamespace(NAMESPACE1);
     deployment.setKind(KubernetesKind.DEPLOYMENT);
     deployment.setApiVersion(KubernetesApiVersion.APPS_V1);
-    deployment.setName(DEPLOYMENT_NAME);
+    deployment.setName(deploymentName);
     return deployment;
   }
 
@@ -128,7 +134,7 @@ final class KubernetesCoreCachingAgentTest {
   }
 
   /** Returns a mock KubernetesCredentials object */
-  private static KubernetesCredentials mockKubernetesCredentials() {
+  private static KubernetesCredentials mockKubernetesCredentials(String deploymentName) {
     KubernetesCredentials credentials = mock(KubernetesCredentials.class);
     when(credentials.getGlobalKinds()).thenReturn(kindProperties.keySet().asList());
     when(credentials.getKindProperties(any(KubernetesKind.class)))
@@ -139,9 +145,9 @@ final class KubernetesCoreCachingAgentTest {
             KubernetesCoordinates.builder()
                 .kind(KubernetesKind.DEPLOYMENT)
                 .namespace(NAMESPACE1)
-                .name(DEPLOYMENT_NAME)
+                .name(deploymentName)
                 .build()))
-        .thenReturn(deploymentManifest());
+        .thenReturn(deploymentManifest(deploymentName));
     when(credentials.get(
             KubernetesCoordinates.builder()
                 .kind(KubernetesKind.STORAGE_CLASS)
@@ -158,15 +164,16 @@ final class KubernetesCoreCachingAgentTest {
                   String namespace = (String) args[1];
                   ImmutableList.Builder<KubernetesManifest> result = new ImmutableList.Builder<>();
                   if (kinds.contains(KubernetesKind.DEPLOYMENT) && NAMESPACE1.equals(namespace)) {
-                    result.add(deploymentManifest());
+                    result.add(deploymentManifest(deploymentName));
                   }
                   if (kinds.contains(KubernetesKind.STORAGE_CLASS)) {
                     result.add(storageClassManifest());
                   }
                   return result.build();
                 });
-    when(credentials.getNamer()).thenReturn(NAMER);
+    when(credentials.getNamer()).thenReturn(new KubernetesManifestNamer());
     when(credentials.isValidKind(any(KubernetesKind.class))).thenReturn(true);
+
     return credentials;
   }
 
@@ -174,10 +181,19 @@ final class KubernetesCoreCachingAgentTest {
    * Returns a KubernetesNamedAccountCredentials that contains a mock KubernetesCredentials object
    */
   private static KubernetesNamedAccountCredentials getNamedAccountCredentials() {
+    return getNamedAccountCredentials(DEPLOYMENT_NAME);
+  }
+
+  /**
+   * Returns a KubernetesNamedAccountCredentials with a custom deployment name that contains a mock
+   * KubernetesCredentials object
+   */
+  private static KubernetesNamedAccountCredentials getNamedAccountCredentials(
+      String deploymentName) {
     ManagedAccount managedAccount = new ManagedAccount();
     managedAccount.setName(ACCOUNT);
 
-    KubernetesCredentials mockCredentials = mockKubernetesCredentials();
+    KubernetesCredentials mockCredentials = mockKubernetesCredentials(deploymentName);
     KubernetesCredentials.Factory credentialFactory = mock(KubernetesCredentials.Factory.class);
     when(credentialFactory.build(managedAccount)).thenReturn(mockCredentials);
     return new KubernetesNamedAccountCredentials(managedAccount, credentialFactory);
@@ -203,7 +219,42 @@ final class KubernetesCoreCachingAgentTest {
                     agentCount,
                     10L,
                     configurationProperties,
-                    kubernetesSpinnakerKindMap))
+                    kubernetesSpinnakerKindMap,
+                    null))
+        .collect(toImmutableList());
+  }
+
+  /**
+   * Given a KubernetesNamedAccountCredentials object, the number of caching agents to build and
+   * whether front50 needs to be queried for presence of an application, builds a set of caching
+   * agents responsible for caching the account's data and returns a collection of those agents
+   */
+  private static ImmutableCollection<KubernetesCoreCachingAgent> createCachingAgents(
+      KubernetesNamedAccountCredentials credentials,
+      int agentCount,
+      Front50Service front50Service,
+      boolean checkApplicationInFront50) {
+    KubernetesConfigurationProperties kubernetesConfigurationProperties =
+        new KubernetesConfigurationProperties();
+
+    if (!checkApplicationInFront50) {
+      return createCachingAgents(credentials, agentCount, kubernetesConfigurationProperties);
+    }
+
+    kubernetesConfigurationProperties.setCheckApplicationInFront50(true);
+    return IntStream.range(0, agentCount)
+        .mapToObj(
+            i ->
+                new KubernetesCoreCachingAgent(
+                    credentials,
+                    objectMapper,
+                    new NoopRegistry(),
+                    i,
+                    agentCount,
+                    10L,
+                    kubernetesConfigurationProperties,
+                    kubernetesSpinnakerKindMap,
+                    front50Service))
         .collect(toImmutableList());
   }
 
@@ -273,12 +324,68 @@ final class KubernetesCoreCachingAgentTest {
         .extracting(deployment -> deployment.getAttributes().get("name"))
         .containsExactly(DEPLOYMENT_NAME);
 
-    assertThat(loadDataResult.getResults()).containsKey(STORAGE_CLASS_KIND);
-    Collection<CacheData> storageClasses = loadDataResult.getResults().get(STORAGE_CLASS_KIND);
-    assertThat(storageClasses).extracting(CacheData::getId).contains(storageClassKey);
-    assertThat(storageClasses)
-        .extracting(storageClass -> storageClass.getAttributes().get("name"))
-        .containsExactly(STORAGE_CLASS_NAME);
+    // storage class kind should be cached
+    validateStorageClassInCacheResult(storageClassKey, loadDataResult.getResults());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testCheckingOfApplicationsInFront50ForLoadData(boolean checkApplicationInFront50)
+      throws JsonProcessingException {
+    // setup:
+    String deploymentKey =
+        Keys.InfrastructureCacheKey.createKey(
+            KubernetesKind.DEPLOYMENT, ACCOUNT, NAMESPACE1, DEPLOYMENT_NAME);
+
+    Front50Service front50Service = mock(Front50Service.class);
+
+    ImmutableCollection<KubernetesCoreCachingAgent> cachingAgents =
+        createCachingAgents(
+            getNamedAccountCredentials(), 1, front50Service, checkApplicationInFront50);
+
+    when(front50Service.getAllApplicationsUnrestricted())
+        .thenReturn(getApplicationsFromFront50("applications-response-from-front50.json"));
+    // when:
+    LoadDataResult loadDataResult = processLoadData(cachingAgents, ImmutableMap.of());
+
+    // then:
+    if (checkApplicationInFront50) {
+      verify(front50Service).getAllApplicationsUnrestricted();
+    } else {
+      verifyNoInteractions(front50Service);
+    }
+
+    assertThat(loadDataResult.getResults()).containsKey(DEPLOYMENT_KIND);
+    Collection<CacheData> deployments = loadDataResult.getResults().get(DEPLOYMENT_KIND);
+    assertThat(deployments).extracting(CacheData::getId).containsExactly(deploymentKey);
+    assertThat(deployments)
+        .extracting(deployment -> deployment.getAttributes().get("name"))
+        .containsExactly(DEPLOYMENT_NAME);
+  }
+
+  @Test
+  public void testK8sManifestWithNoApplicationInFront50ShouldNotBeCachedInLoadData()
+      throws JsonProcessingException {
+    // setup:
+    String deploymentName = "some-name-not-in-front50";
+
+    Front50Service front50Service = mock(Front50Service.class);
+    ImmutableCollection<KubernetesCoreCachingAgent> cachingAgents =
+        createCachingAgents(getNamedAccountCredentials(deploymentName), 1, front50Service, true);
+
+    when(front50Service.getAllApplicationsUnrestricted())
+        .thenReturn(getApplicationsFromFront50("applications-response-from-front50.json"));
+
+    // when:
+    LoadDataResult loadDataResult = processLoadData(cachingAgents, ImmutableMap.of());
+
+    // then:
+    verify(front50Service).getAllApplicationsUnrestricted();
+
+    // the deployment should not be cached as its application is not known to front50
+    assertThat(loadDataResult.getResults()).doesNotContainKey(DEPLOYMENT_KIND);
+    Collection<CacheData> deployments = loadDataResult.getResults().get(DEPLOYMENT_KIND);
+    assertThat(deployments).isNullOrEmpty();
   }
 
   /**
@@ -463,5 +570,30 @@ final class KubernetesCoreCachingAgentTest {
         .filter(dataType -> dataType.getAuthority() == AUTHORITATIVE)
         .map(AgentDataType::getTypeName)
         .collect(toImmutableList());
+  }
+
+  private void validateStorageClassInCacheResult(
+      String storageClassKey, Map<String, Collection<CacheData>> cacheResults) {
+    assertThat(cacheResults).containsKey(STORAGE_CLASS_KIND);
+    Collection<CacheData> storageClasses = cacheResults.get(STORAGE_CLASS_KIND);
+    assertThat(storageClasses).extracting(CacheData::getId).contains(storageClassKey);
+    assertThat(storageClasses)
+        .extracting(storageClass -> storageClass.getAttributes().get("name"))
+        .containsExactly(STORAGE_CLASS_NAME);
+  }
+
+  private Set<Front50Application> getApplicationsFromFront50(String fileName)
+      throws JsonProcessingException {
+    return objectMapper.readValue(
+        getResource(fileName), new TypeReference<Set<Front50Application>>() {});
+  }
+
+  private String getResource(String name) {
+    try {
+      return Resources.toString(
+          KubernetesCoreCachingAgentTest.class.getResource(name), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgentTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgentTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.netflix.spectator.api.NoopRegistry;
-import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesAccountProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
@@ -82,7 +81,7 @@ public class KubernetesUnregisteredCustomResourceCachingAgentTest {
   private static KubernetesUnregisteredCustomResourceCachingAgent createCachingAgent(
       KubernetesNamedAccountCredentials credentials,
       KubernetesConfigurationProperties configurationProperties,
-      @Nullable Front50Service front50Service) {
+      @Nullable Front50ApplicationLoader front50ApplicationLoader) {
     return new KubernetesUnregisteredCustomResourceCachingAgent(
         credentials,
         objectMapper,
@@ -92,6 +91,6 @@ public class KubernetesUnregisteredCustomResourceCachingAgentTest {
         10L,
         configurationProperties,
         new KubernetesSpinnakerKindMap(new ArrayList<>()),
-        front50Service);
+        front50ApplicationLoader);
   }
 }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgentTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgentTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesAccountProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
@@ -35,6 +36,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+import org.springframework.lang.Nullable;
 
 @RunWith(JUnitPlatform.class)
 public class KubernetesUnregisteredCustomResourceCachingAgentTest {
@@ -54,7 +56,7 @@ public class KubernetesUnregisteredCustomResourceCachingAgentTest {
     configurationProperties.getCache().setCacheAll(false);
     configurationProperties.getCache().setCacheKinds(Arrays.asList("deployment", CRD_NAME));
     KubernetesUnregisteredCustomResourceCachingAgent cachingAgent =
-        createCachingAgent(getNamedAccountCredentials(), configurationProperties);
+        createCachingAgent(getNamedAccountCredentials(), configurationProperties, null);
 
     List<KubernetesKind> filteredPrimaryKinds = cachingAgent.filteredPrimaryKinds();
 
@@ -79,7 +81,8 @@ public class KubernetesUnregisteredCustomResourceCachingAgentTest {
 
   private static KubernetesUnregisteredCustomResourceCachingAgent createCachingAgent(
       KubernetesNamedAccountCredentials credentials,
-      KubernetesConfigurationProperties configurationProperties) {
+      KubernetesConfigurationProperties configurationProperties,
+      @Nullable Front50Service front50Service) {
     return new KubernetesUnregisteredCustomResourceCachingAgent(
         credentials,
         objectMapper,
@@ -88,6 +91,7 @@ public class KubernetesUnregisteredCustomResourceCachingAgentTest {
         1,
         10L,
         configurationProperties,
-        new KubernetesSpinnakerKindMap(new ArrayList<>()));
+        new KubernetesSpinnakerKindMap(new ArrayList<>()),
+        front50Service);
   }
 }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -110,7 +110,7 @@ final class KubernetesDataProviderIntegrationTest {
       new KubernetesSpinnakerKindMap(handlers);
   private static final KubernetesCachingAgentDispatcher dispatcher =
       new KubernetesCachingAgentDispatcher(
-          objectMapper, registry, new KubernetesConfigurationProperties(), kindMap);
+          objectMapper, registry, new KubernetesConfigurationProperties(), kindMap, null);
   private static final GlobalResourcePropertyRegistry resourcePropertyRegistry =
       new GlobalResourcePropertyRegistry(
           handlers, new KubernetesUnregisteredCustomResourceHandler());

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/names/KubernetesManifestNamerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/names/KubernetesManifestNamerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.names;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiVersion;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.moniker.Moniker;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+
+public class KubernetesManifestNamerTest {
+  @Test
+  public void testDeriveMoniker() {
+    // setup:
+    KubernetesManifestNamer kubernetesManifestNamer = new KubernetesManifestNamer();
+
+    // when:
+    Moniker moniker = kubernetesManifestNamer.deriveMoniker(deploymentManifest("testapp-abc"));
+
+    // then:
+    assertThat(moniker.getApp()).isEqualTo("testapp");
+  }
+
+  /** A test Deployment manifest */
+  private static KubernetesManifest deploymentManifest(String deploymentName) {
+    KubernetesManifest deployment = new KubernetesManifest();
+    deployment.put("metadata", new HashMap<>());
+    deployment.setNamespace("namespace");
+    deployment.setKind(KubernetesKind.DEPLOYMENT);
+    deployment.setApiVersion(KubernetesApiVersion.APPS_V1);
+    deployment.setName(deploymentName);
+    return deployment;
+  }
+}

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/applications-response-from-front50.json
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/applications-response-from-front50.json
@@ -1,0 +1,26 @@
+[
+  {
+    "cloudProviders": null,
+    "createTs": null,
+    "description": null,
+    "email": "test@abc.com",
+    "instancePort": 80,
+    "lastModifiedBy": "test@abc.com",
+    "name": "MY",
+    "permissions": {},
+    "trafficGuards": [],
+    "updateTs": "1627312672356"
+  },
+  {
+    "cloudProviders": null,
+    "createTs": null,
+    "description": null,
+    "email": "test1@abc.com",
+    "instancePort": 80,
+    "lastModifiedBy": "test1@abc.com",
+    "name": "APP2",
+    "permissions": {},
+    "trafficGuards": [],
+    "updateTs": "1627312672359"
+  }
+]


### PR DESCRIPTION
This PR introduces a check to verify if the application obtained from a k8s manifest actually exists in front50 or not. This check can be configured by setting: 
```
kubernetes.checkApplicationInFront50: true # defaults to false
```

Old behavior: 
- A manifest would be cached or not depending on the following rules:
```
- if a manifest's caching properties has ignore == true, then it will not be cached.
- Otherwise, if an account is configured to be "onlySpinnakerManaged", and
   "moniker.spinnaker.io/application" annotation is empty, then it will not be cached.
  
  In all other cases/combinations, it will be cached.
  ```
  
  New Behavior:
- A manifest would be cached or not depending on the following rules:
```
- if a manifest's caching properties has ignore == true, then it will not be cached.
- Otherwise, if an account is configured to be "onlySpinnakerManaged", and
   "moniker.spinnaker.io/application" annotation is empty, then it will not be cached.
- Otherwise, if kubernetes.checkApplicationInFront50: true, and
   the application name obtained from the manifest is not known to front50, then it will not be
   cached.
   
     In all other cases/combinations, it will be cached.
  ```

Implication:
* by setting `onlySpinnakerManaged: true` per account, it is possible to teach spinnaker to skip caching manifests not known to spinnaker. However, if someone creates a manifest and adds a non-empty `"moniker.spinnaker.io/application"` annotation to it, it will still be cached, bypassing the `onlySpinnakerManaged` intended behavior. By introducing the new rule mentioned above, such manifests will not be cached anymore, if the application name obtained from this manifest is not known to front50.

* If `onlySpinnakerManaged: false` is set per account, then only those manifests will be cached whose application names are known to front50.

Benefits:
- unnecessary caching of such manifests is prevented.
- applications which are not known to front50 are not created.

