### PR TITLE
fix(core): Remove sensitive payload data from logs

### DIFF
--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/cache/CatsOnDemandCacheUpdater.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/cache/CatsOnDemandCacheUpdater.java
@@ -72,8 +72,7 @@ public class CatsOnDemandCacheUpdater implements OnDemandCacheUpdater {
 
   private OnDemandCacheResult handle(
       OnDemandType type, Collection<OnDemandAgent> onDemandAgents, Map<String, ?> data) {
-    log.debug(
-        "Calling handle on data: {}, onDemandAgents: {}, type: {}", data, onDemandAgents, type);
+    log.debug("Calling handle onDemandAgents: {}, type: {}", onDemandAgents, type);
 
     boolean hasOnDemandResults = false;
     Map<String, List<String>> cachedIdentifiersByType = new HashMap<>();
@@ -155,12 +154,11 @@ public class CatsOnDemandCacheUpdater implements OnDemandCacheUpdater {
           agent.getMetricsSupport().recordTotalRunTimeNanos(elapsed);
 
           log.info(
-              "{}/{} handled {} in {}ms. Payload: {}",
+              "{}/{} handled {} in {}ms.",
               agent.getProviderName(),
               agent.getOnDemandAgentType(),
               type,
-              TimeUnit.NANOSECONDS.toMillis(elapsed),
-              data);
+              TimeUnit.NANOSECONDS.toMillis(elapsed));
         }
 
       } catch (Exception e) {


### PR DESCRIPTION
We found that `CatsOnDemandCacheUpdater.handle()` is printing the payload in the logs, exposing sensitive data / secrets. 

When the [lambda plugin](https://github.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker) is enabled, it will send requests with environment variables in the body (`envVariables` field) if they are set. Environment variables can be secrets such as github tokens. 

This can be reproduced by invoking a lambda function or editing an existing lambda function via deck.

Example log: 

```
2022-09-09 12:48:30.341  INFO 1 --- [.0-7002-exec-10] c.n.s.c.cache.CatsOnDemandCacheUpdater   : com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider/non-prod/us-east-2/LambdaCachingAgent-OnDemand handled Function in 2327ms. Payload: {architectures=[x86_64], handler=handler, tracingConfig={mode=PassThrough}, deadLetterConfig={targetArn=}, packageType=Zip, codeSha256=xxxxx+5Omcc=, layers=[], state=Active, task.id={id=XXXX}, functionArn=arn:aws:lambda:us-west-2:XXXX:build-helloworld-QA, runtime=go1.x, version=$LATEST, tags={Name=helloworld-QA}, aliasConfigurations=[], envVariables={SLACK_CHANNEL=XXXX, JIRA_URL=https://myjira.atlassian.net, JIRA_USER=ops@example.com, PARENT_JOB_NAMES=job1, GITHUB_TOKEN=XXXX, JENKINS_TOKEN=XXXX, JIRA_TOKEN=XXXX, SLACK_TOKEN=XXXX, JENKINS_URL=https://jenkins.example.com}, ...
``` 

Lambda plugin `envVariables` references: https://github.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/search?q=envVariables