### PR TITLE
chore(build): give local builds as much memory as we do in CI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kubernetesClientVersion=11.0.1
 #
 #fiatComposite=true
 #korkComposite=true
+
+org.gradle.jvmargs=-Xmx6g -Xms6g


### PR DESCRIPTION
See e.g. https://github.com/spinnaker/clouddriver/blob/25bed1fa85a9f75dcdc4faa453fb33baf2d7b8aa/.github/workflows/build.yml#L10
