### PR TITLE
chore(kubernetes): stop specifying the version of io.kubernetes:client-java

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -80,7 +80,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-moniker"
   implementation "io.spinnaker.kork:kork-secrets"
   implementation "io.spinnaker.kork:kork-security"
-  implementation "io.kubernetes:client-java:$kubernetesClientVersion"
+  implementation "io.kubernetes:client-java"
   implementation "org.apache.commons:commons-lang3"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -58,7 +58,7 @@ dependencies {
   testImplementation "io.spinnaker.kork:kork-test"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "org.spockframework:spock-core"
-  testImplementation "io.kubernetes:client-java:$kubernetesClientVersion"
+  testImplementation "io.kubernetes:client-java"
 
   // Add each included cloud provider project as a runtime dependency
   gradle.includedCloudProviderProjects.each {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,6 @@ spinnakerGradleVersion=8.23.0
 targetJava11=true
 kotlinVersion=1.4.10
 
-kubernetesClientVersion=11.0.1
-
 # To enable a composite reference to a project, set the
 #  project property `'<projectName>Composite=true'`.
 #


### PR DESCRIPTION
since spring 2.4.13 brings it in (transitively).  The version from spring boot takes precedence, so the value we specify here is ignored.

Another approach would be to make the version here match what spring boot brings in (currently 11.0.3), but then future changes could again invalidate what's here.  If some future version of spring boot stops bringing in io.kubernetes:client-java, builds will fail with unspecified version, at which point we can restore kubernetesClientVersion.

Snippets of ./gradlew clouddriver-web:dependencies

before:
```
+--- project :clouddriver-kubernetes
|    +--- io.kubernetes:client-java:11.0.1 -> 11.0.3
```
after:
```
+--- project :clouddriver-kubernetes
|    +--- io.kubernetes:client-java -> 11.0.3
```
Related orca PR: https://github.com/spinnaker/orca/pull/4310