### PR TITLE
fix(provider/azure): Fix CreateAzureServerGroupWithAzureLoadBalancerAtomicOperation and DestroyAzureServerGroupAtomicOperation after migrating to latest Azure SDK

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
@@ -705,6 +705,8 @@ class AzureNetworkClient extends AzureBaseClient {
           Method setRangeMethod = o.getClass().getMethod("toBackend", String.class)
           setRangeMethod.setAccessible(true)
           setRangeMethod.invoke(o, serverGroupName)
+          LoadBalancingRule lbrule = o as LoadBalancingRule;
+          lbrule.innerModel().withBackendAddressPools(List.of(lbrule.innerModel().backendAddressPool()))
         } catch (NoSuchMethodException e) {
           log.error("Failed to use reflection to set backend of rule in Load Balancer, detail: {}", e.getMessage())
           return
@@ -763,6 +765,8 @@ class AzureNetworkClient extends AzureBaseClient {
             Method setRangeMethod = o.getClass().getMethod("toBackend", String.class)
             setRangeMethod.setAccessible(true)
             setRangeMethod.invoke(o, AzureLoadBalancerResourceTemplate.DEFAULT_BACKEND_POOL)
+            LoadBalancingRule lbrule = o as LoadBalancingRule;
+            lbrule.innerModel().withBackendAddressPools(List.of(lbrule.innerModel().backendAddressPool()))
           } catch (NoSuchMethodException e) {
             log.error("Failed to use reflection to set backend of rule in Load Balancer, detail: {}", e.getMessage())
             return


### PR DESCRIPTION
After the migration of the SDK to com.azure.resourcemanager:azure-resourcemanager:2.19.0 `CreateAzureServerGroupWithAzureLoadBalancerAtomicOperation` started to fail because the `com.netflix.spinnaker.clouddriver.azure.client.AzureNetworkClient#enableServerGroupWithLoadBalancer `function is not able to update the load-balancing rule

The reason is that the old SDK, defines only one `backendAddressPool` property in `LoadBalancingRuleInner`. But with the new SDK, two properties are defined `backendAddressPool & backendAddressPools`.  The atomic operation updates the `backendAddressPool` to point to the new server group, while the list contains the default backend pool.  Because of this, Azure API is throwing `LoadBalancingRuleBackendAdressPoolAndBackendAddressPoolsCannotBeSetAtTheSameTimeWithDifferentValue` exception. The fix is to set both properties to use the same value.

Closes https://github.com/spinnaker/spinnaker/issues/6736
