### PR TITLE
chore(configserver): use version 0.14.2 of com.github.wnameless.json:json-flattener

### DIFF
--- a/clouddriver-configserver/clouddriver-configserver.gradle
+++ b/clouddriver-configserver/clouddriver-configserver.gradle
@@ -20,5 +20,5 @@ dependencies {
   implementation "org.apache.commons:commons-lang3"
   implementation "org.springframework.cloud:spring-cloud-context"
   implementation "org.springframework.cloud:spring-cloud-config-server"
-  implementation "com.github.wnameless.json:json-flattener:0.11.1"
+  implementation "com.github.wnameless.json:json-flattener:0.14.2"
 }


### PR DESCRIPTION
to stay up to date, and to resolve CVE-2022-42889 which org.apache.commons:commons-text:1.9 is subject to.  See https://nvd.nist.gov/vuln/detail/CVE-2022-42889.

Snippet of `./gradlew clouddriver-web:dependencies` before this change:
```
|    |    \--- com.github.wnameless.json:json-flattener:0.11.1
|    |         +--- com.fasterxml.jackson.core:jackson-databind:2.11.3 -> 2.12.6.1 (*)
|    |         +--- org.apache.commons:commons-text:1.9
|    |         |    \--- org.apache.commons:commons-lang3:3.11 -> 3.9
|    |         \--- com.github.wnameless.json:json-base:1.2.0
```
and with this change:
```
|    |    \--- com.github.wnameless.json:json-flattener:0.14.2
|    |         +--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 -> 2.12.6.1 (*)
|    |         +--- org.apache.commons:commons-text:1.10.0
|    |         |    \--- org.apache.commons:commons-lang3:3.12.0 -> 3.11
|    |         \--- com.github.wnameless.json:json-base:2.0.0
```