### PR TITLE
chore(deps): remove version specification from org.yaml:snakeyaml

### DIFF
--- a/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
+++ b/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
@@ -63,7 +63,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.springframework.cloud:spring-cloud-context"
-  implementation "org.yaml:snakeyaml:1.24"
+  implementation "org.yaml:snakeyaml"
   implementation "com.google.protobuf:protobuf-java:$protobufVersion"
   implementation "com.google.protobuf:protobuf-java-util:$protobufVersion"
   implementation "commons-fileupload:commons-fileupload:1.4"

--- a/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver-titus/clouddriver-titus.gradle
@@ -41,7 +41,7 @@ dependencies {
   implementation "org.slf4j:slf4j-api"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
-  implementation "org.yaml:snakeyaml:1.24"
+  implementation "org.yaml:snakeyaml"
 
   testImplementation "cglib:cglib-nodep"
   testImplementation "junit:junit"


### PR DESCRIPTION
Spring boot 2.4.13 brings in version 1.27 of org.yaml:snakeyaml (see https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.4.13/spring-boot-dependencies-2.4.13.pom) which takes precendence over what we specified here (1.24), so there's no functional change.  See these snippets of ./gradlew clouddriver-titus:dependencies before
```
+--- org.yaml:snakeyaml:1.24 -> 1.27
```
and after this change:
```
+--- org.yaml:snakeyaml -> 1.27
```
The equivalent thing happens in clouddriver-cloudfoundry.
