### PR TITLE
fix(artifacts/bitbuket): added ACCEPT Header when using token auth

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentials.java
@@ -29,6 +29,7 @@ import com.squareup.okhttp.OkHttpClient;
 import java.util.Optional;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 
 @NonnullByDefault
 @Slf4j
@@ -49,7 +50,7 @@ public class BitbucketArtifactCredentials
     Optional<String> token = account.getTokenAsString();
     if (token.isPresent()) {
       headers.set(AUTHORIZATION, "Bearer " + token.get());
-      headers.set(ACCEPT, "application/json");
+      headers.set(ACCEPT, MediaType.APPLICATION_JSON_VALUE);
       log.info("Loaded credentials for Bitbucket Artifact Account {}", account.getName());
       return headers.build();
     }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentials.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.bitbucket;
 
+import static org.springframework.http.HttpHeaders.ACCEPT;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.google.common.collect.ImmutableList;
@@ -48,6 +49,7 @@ public class BitbucketArtifactCredentials
     Optional<String> token = account.getTokenAsString();
     if (token.isPresent()) {
       headers.set(AUTHORIZATION, "Bearer " + token.get());
+      headers.set(ACCEPT, "application/json");
       log.info("Loaded credentials for Bitbucket Artifact Account {}", account.getName());
       return headers.build();
     }

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentialsTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentialsTest.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.artifacts.bitbucket;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.ACCEPT;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -33,6 +34,7 @@ import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junitpioneer.jupiter.TempDirectory;
+import org.springframework.http.MediaType;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
 @ExtendWith({WiremockResolver.class, TempDirectory.class})
@@ -47,7 +49,12 @@ class BitbucketArtifactCredentialsTest {
     BitbucketArtifactAccount account =
         BitbucketArtifactAccount.builder().name("my-bitbucket-account").token("abc").build();
 
-    runTestCase(server, account, m -> m.withHeader(AUTHORIZATION, equalTo("Bearer abc")));
+    runTestCase(
+        server,
+        account,
+        m ->
+            m.withHeader(AUTHORIZATION, equalTo("Bearer abc"))
+                .withHeader(ACCEPT, equalTo(MediaType.APPLICATION_JSON_VALUE)));
   }
 
   @Test
@@ -63,7 +70,12 @@ class BitbucketArtifactCredentialsTest {
             .tokenFile(authFile.toAbsolutePath().toString())
             .build();
 
-    runTestCase(server, account, m -> m.withHeader(AUTHORIZATION, equalTo("Bearer zzz")));
+    runTestCase(
+        server,
+        account,
+        m ->
+            m.withHeader(AUTHORIZATION, equalTo("Bearer zzz"))
+                .withHeader(ACCEPT, equalTo(MediaType.APPLICATION_JSON_VALUE)));
   }
 
   @Test
@@ -79,11 +91,21 @@ class BitbucketArtifactCredentialsTest {
             .tokenFile(authFile.toAbsolutePath().toString())
             .build();
 
-    runTestCase(server, account, m -> m.withHeader(AUTHORIZATION, equalTo("Bearer zzz")));
+    runTestCase(
+        server,
+        account,
+        m ->
+            m.withHeader(AUTHORIZATION, equalTo("Bearer zzz"))
+                .withHeader(ACCEPT, equalTo(MediaType.APPLICATION_JSON_VALUE)));
 
     Files.write(authFile, "aaa".getBytes());
 
-    runTestCase(server, account, m -> m.withHeader(AUTHORIZATION, equalTo("Bearer aaa")));
+    runTestCase(
+        server,
+        account,
+        m ->
+            m.withHeader(AUTHORIZATION, equalTo("Bearer aaa"))
+                .withHeader(ACCEPT, equalTo(MediaType.APPLICATION_JSON_VALUE)));
   }
 
   @Test


### PR DESCRIPTION
When using an invalid token without the header `Accept: application/json` we get 302 response back and `okHttpClient.newCall(request).execute().isSuccessful()` returns true thus sending orca the incorrect ResponseBody

<img width="977" alt="Screen Shot 2022-11-16 at 8 37 49 AM" src="https://user-images.githubusercontent.com/43676929/202239908-07db9af3-dd7a-4ab9-a478-64084cb303de.png">
<img width="1233" alt="Screen Shot 2022-11-16 at 8 31 06 AM" src="https://user-images.githubusercontent.com/43676929/202240589-2c5b3fff-f021-4e5a-b656-ccddfadc946f.png">

**-----------------------------------------------------------------------------------------------------------------**

With the header in place we get 401 `okHttpClient.newCall(request).execute().isSuccessful()` returns false thus throwing the correct exception and error log from clouddriver
tested on spinnaker and using curl:
<img width="1011" alt="Screen Shot 2022-11-16 at 8 40 18 AM" src="https://user-images.githubusercontent.com/43676929/202240478-b9b08a84-bb67-47c0-8bbf-a738f1836fae.png">
<img width="1150" alt="Screen Shot 2022-11-16 at 8 30 10 AM" src="https://user-images.githubusercontent.com/43676929/202240543-a1cdf795-0154-467a-81db-db0268cd117e.png">
