### PR TITLE
fix(kubernetes): teach KubernetesManifest to support kubernetes resources where the spec is not a map

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
@@ -190,11 +190,11 @@ public class KubernetesManifest extends HashMap<String, Object> {
   @JsonIgnore
   @SuppressWarnings("unchecked")
   public KubernetesManifestSelector getManifestSelector() {
-    if (!containsKey("spec")) {
+    Map<String, Object> spec = getSpecAsMap();
+    if (spec == null) {
       return null;
     }
 
-    Map<String, Object> spec = (Map<String, Object>) get("spec");
     if (!spec.containsKey("selector")) {
       return null;
     }
@@ -233,13 +233,26 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
-  @SuppressWarnings("unchecked")
-  public Integer getReplicas() {
+  private Map<String, Object> getSpecAsMap() {
     if (!containsKey("spec")) {
       return null;
     }
 
-    Map<String, Object> spec = (Map<String, Object>) get("spec");
+    Object specObject = get("spec");
+    if (!(specObject instanceof Map)) {
+      return null;
+    }
+
+    return (Map<String, Object>) specObject;
+  }
+
+  @JsonIgnore
+  @SuppressWarnings("unchecked")
+  public Integer getReplicas() {
+    Map<String, Object> spec = getSpecAsMap();
+    if (spec == null) {
+      return null;
+    }
     if (!spec.containsKey("replicas")) {
       return null;
     }
@@ -250,22 +263,20 @@ public class KubernetesManifest extends HashMap<String, Object> {
   @JsonIgnore
   @SuppressWarnings("unchecked")
   public void setReplicas(Number replicas) {
-    if (!containsKey("spec")) {
+    Map<String, Object> spec = getSpecAsMap();
+    if (spec == null) {
       return;
     }
-
-    Map<String, Object> spec = (Map<String, Object>) get("spec");
     spec.put("replicas", replicas.intValue());
   }
 
   @JsonIgnore
   @SuppressWarnings("unchecked")
   public Optional<Map<String, String>> getSpecTemplateLabels() {
-    if (!containsKey("spec")) {
+    Map<String, Object> spec = getSpecAsMap();
+    if (spec == null) {
       return Optional.empty();
     }
-
-    Map<String, Object> spec = (Map<String, Object>) get("spec");
     if (!spec.containsKey("template")) {
       return Optional.empty();
     }
@@ -296,11 +307,11 @@ public class KubernetesManifest extends HashMap<String, Object> {
   @JsonIgnore
   @SuppressWarnings("unchecked")
   public Optional<Map<String, String>> getSpecTemplateAnnotations() {
-    if (!containsKey("spec")) {
+    Map<String, Object> spec = getSpecAsMap();
+    if (spec == null) {
       return Optional.empty();
     }
 
-    Map<String, Object> spec = (Map<String, Object>) get("spec");
     if (!spec.containsKey("template")) {
       return Optional.empty();
     }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesManifestSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesManifestSpec.groovy
@@ -114,4 +114,19 @@ class KubernetesManifestSpec extends Specification {
     manifest.getApiVersion().toString() == CRD_API_VERSION
     manifest.getSpecTemplateAnnotations() == Optional.empty()
   }
+
+  void "correctly reads fields a custom resource where spec is a list"() {
+    when:
+    def sourceJson = KubernetesManifest.class.getResource("crd-manifest-spec-is-list.json").getText("utf-8")
+    def testPayload =  gsonObj.fromJson(sourceJson, Object)
+    KubernetesManifest manifest = objectToManifest(testPayload)
+
+    then:
+    manifest.getName() == CRD_NAME
+    manifest.getKindName() == CRD_KIND
+    manifest.getApiVersion().toString() == CRD_API_VERSION
+    manifest.getReplicas() == null
+    manifest.getSpecTemplateLabels() == Optional.empty()
+    manifest.getSpecTemplateAnnotations() == Optional.empty()
+  }
 }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
@@ -331,6 +331,13 @@ final class KubernetesDeployManifestOperationTest {
         .containsExactlyInAnyOrder("my-name-v000", "myconfig-v001");
   }
 
+  @Test
+  void deploysCrdWhereSpecIsList() {
+    KubernetesDeployManifestDescription deployManifestDescription =
+        baseDeployDescription("deploy/crd-manifest-spec-is-list.yml");
+    deploy(deployManifestDescription);
+  }
+
   private static KubernetesDeployManifestDescription baseDeployDescription(String manifest) {
     KubernetesDeployManifestDescription deployManifestDescription =
         new KubernetesDeployManifestDescription()

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/crd-manifest-spec-is-list.json
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/crd-manifest-spec-is-list.json
@@ -1,0 +1,16 @@
+{
+  "apiVersion": "test.example/v1alpha1",
+  "kind": "Custom1",
+  "metadata": {
+    "labels": {
+      "app": "app1"
+    },
+    "name": "default-custom1"
+  },
+  "spec": [
+    {
+      "id": "my-id",
+      "description": "my-description"
+    }
+  ]
+}

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/deploy/crd-manifest-spec-is-list.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/deploy/crd-manifest-spec-is-list.yml
@@ -1,0 +1,9 @@
+apiVersion: test.example/v1alpha1
+kind: Custom1
+metadata:
+  name: default-custom1
+  labels:
+    app: app1
+spec:
+  - id: my-id
+    description: my-description


### PR DESCRIPTION
Before this change, attempts to deploy a manifest where the spec was a list, e.g.
```
apiVersion: test.example/v1alpha1
kind: Custom1
metadata:
  name: default-custom1
  labels:
    app: app1
spec:
  - id: my-id
    description: my-description
```
would result in
![image](https://user-images.githubusercontent.com/82477955/202320985-be5c98f7-c044-452e-90eb-a8653bf0b873.png)

With these changes, spinnaker is able to deploy it.