### PR TITLE
refactor(web): Clean up redundant spring property in gradle file

### DIFF
--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -1,13 +1,6 @@
 apply plugin: 'io.spinnaker.package'
 
-ext {
-  springConfigLocation = System.getProperty('spring.config.additional-location', "${System.getProperty('user.home')}/.spinnaker/".toString())
-}
-
 mainClassName = 'com.netflix.spinnaker.clouddriver.Main'
-run {
-  systemProperty('spring.config.additional-location', project.springConfigLocation)
-}
 
 configurations.all {
   exclude group: 'javax.servlet', module: 'servlet-api'


### PR DESCRIPTION
The property spring.config.additional-location is redundant in clouddriver-web.gradle file. This property is set by class com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder in com.netflix.spinnaker.clouddriver.Main. So removing it from gradle file.
