### PR TITLE
test(integration): Prevent interference between tests

### DIFF
--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/DeployManifestIT.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/DeployManifestIT.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -587,7 +588,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "bind-config-map";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String cmName = "myconfig";
+    String cmName = "myconfig" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
     String version = "v005";
 
     // deploy versioned configmap
@@ -662,7 +663,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "bind-secret";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String secretName = "mysecret";
+    String secretName = "mysecret" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
     String version = "v009";
 
     // deploy versioned secret
@@ -812,7 +813,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "add-config-map-version";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String cmName = "myconfig";
+    String cmName = "myconfig" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/configmap.yml")
@@ -845,7 +846,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "add-secret-version";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String secretName = "mysecret";
+    String secretName = "mysecret" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/secret.yml")
@@ -881,7 +882,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "new-config-map-version";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String cmName = "myconfig";
+    String cmName = "myconfig" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/configmap.yml")
@@ -932,7 +933,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "new-secret-version";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String secretName = "mysecret";
+    String secretName = "mysecret" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/secret.yml")
@@ -984,7 +985,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "unversioned-config-map";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String cmName = "myconfig";
+    String cmName = "myconfig" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/configmap.yml")
@@ -1019,7 +1020,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "unversioned-secret";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String secretName = "mysecret";
+    String secretName = "mysecret" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/secret.yml")

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/DeployManifestIT.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/DeployManifestIT.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.logging.log4j.util.Strings;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -589,7 +588,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "bind-config-map";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String cmName = genereateManifestName("myconfig");
+    String cmName = generateManifestName("myconfig");
     String version = "v005";
 
     // deploy versioned configmap
@@ -664,7 +663,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "bind-secret";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String secretName = genereateManifestName("mysecret");
+    String secretName = generateManifestName("mysecret");
     String version = "v009";
 
     // deploy versioned secret
@@ -814,7 +813,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "add-config-map-version";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String cmName = genereateManifestName("myconfig");
+    String cmName = generateManifestName("myconfig");
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/configmap.yml")
@@ -847,7 +846,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "add-secret-version";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String secretName = genereateManifestName("mysecret");
+    String secretName = generateManifestName("mysecret");
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/secret.yml")
@@ -883,7 +882,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "new-config-map-version";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String cmName = genereateManifestName("myconfig");
+    String cmName = generateManifestName("myconfig");
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/configmap.yml")
@@ -934,7 +933,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "new-secret-version";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String secretName = genereateManifestName("mysecret");
+    String secretName = generateManifestName("mysecret");
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/secret.yml")
@@ -986,7 +985,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "unversioned-config-map";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String cmName = genereateManifestName("myconfig");
+    String cmName = generateManifestName("myconfig");
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/configmap.yml")
@@ -1021,7 +1020,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "unversioned-secret";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String secretName = genereateManifestName("mysecret");
+    String secretName = generateManifestName("mysecret");
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/secret.yml")
@@ -1586,8 +1585,7 @@ public class DeployManifestIT extends BaseTest {
             hasSize(greaterThan(0)));
   }
 
-  @NotNull
-  private static String genereateManifestName(String myconfig) {
+  private static String generateManifestName(String myconfig) {
     return myconfig + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
   }
 }

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/DeployManifestIT.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/DeployManifestIT.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.logging.log4j.util.Strings;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -588,7 +589,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "bind-config-map";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String cmName = "myconfig" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
+    String cmName = genereateManifestName("myconfig");
     String version = "v005";
 
     // deploy versioned configmap
@@ -663,7 +664,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "bind-secret";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String secretName = "mysecret" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
+    String secretName = genereateManifestName("mysecret");
     String version = "v009";
 
     // deploy versioned secret
@@ -813,7 +814,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "add-config-map-version";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String cmName = "myconfig" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
+    String cmName = genereateManifestName("myconfig");
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/configmap.yml")
@@ -846,7 +847,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "add-secret-version";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String secretName = "mysecret" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
+    String secretName = genereateManifestName("mysecret");
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/secret.yml")
@@ -882,7 +883,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "new-config-map-version";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String cmName = "myconfig" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
+    String cmName = genereateManifestName("myconfig");
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/configmap.yml")
@@ -933,7 +934,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "new-secret-version";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String secretName = "mysecret" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
+    String secretName = genereateManifestName("mysecret");
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/secret.yml")
@@ -985,7 +986,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "unversioned-config-map";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String cmName = "myconfig" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
+    String cmName = genereateManifestName("myconfig");
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/configmap.yml")
@@ -1020,7 +1021,7 @@ public class DeployManifestIT extends BaseTest {
     // ------------------------- given --------------------------
     String appName = "unversioned-secret";
     System.out.println("> Using namespace: " + account1Ns + ", appName: " + appName);
-    String secretName = "mysecret" + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
+    String secretName = genereateManifestName("mysecret");
 
     List<Map<String, Object>> manifest =
         KubeTestUtils.loadYaml("classpath:manifests/secret.yml")
@@ -1583,5 +1584,10 @@ public class DeployManifestIT extends BaseTest {
         .body(
             "spinnakerKindMap.'crontab.stable.example.com'.findAll{ e -> e != null }",
             hasSize(greaterThan(0)));
+  }
+
+  @NotNull
+  private static String genereateManifestName(String myconfig) {
+    return myconfig + Long.toHexString(UUID.randomUUID().getLeastSignificantBits());
   }
 }


### PR DESCRIPTION
* Prevent resources versioning test from interfering to each other. It currently makes sure to be equivalent. But flags like ServerSide Apply and fields like FieldManager might cause equivalent resources to increase the version number.
