### PR TITLE
chore(dependencies): pin version of com.github.tomakehurst:wiremock

### DIFF
--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -55,7 +55,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
 
-  testImplementation "com.github.tomakehurst:wiremock:latest.release"
+  testImplementation "com.github.tomakehurst:wiremock-jre8-standalone"
   testImplementation "io.spinnaker.kork:kork-aws"
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit-pioneer:junit-pioneer:0.3.0"

--- a/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
+++ b/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
@@ -74,6 +74,6 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-engine"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.mockito:mockito-core"
-  testImplementation "com.github.tomakehurst:wiremock:latest.release"
+  testImplementation "com.github.tomakehurst:wiremock-jre8-standalone"
   testImplementation "ru.lanwen.wiremock:wiremock-junit5:1.2.0"
 }


### PR DESCRIPTION
for more predictable builds, and to avoid failures like:
```
org.junit.jupiter.api.extension.ParameterResolutionException: Failed to resolve parameter [com.github.tomakehurst.wiremock.WireMockServer arg0] in method [void com.netflix.spinnaker.clouddriver.artifacts.http.HttpArtifactCredentialsTest.downloadWithBasicAuth(com.github.tomakehurst.wiremock.WireMockServer) throws java.io.IOException]: jakarta/servlet/DispatcherType
```
that come with version 3.0.0-beta2 of com.github.tomakehurst:wiremock released on 30-dec-22.

Use com.github.tomakehurst:wiremock-jre8-standalone as it's the more modern version of wiremock, and has fewer dependencies than wiremock-jre8.

Currently, we end up with version 2.31.0 via spring-cloud-dependencies.  See https://github.com/spring-cloud/spring-cloud-release/blob/v2020.0.5/spring-cloud-dependencies/pom.xml#L25 and https://github.com/spring-cloud/spring-cloud-contract/blob/v3.0.5/spring-cloud-contract-dependencies/pom.xml#L18.
