### PR TITLE
fix(clouddriver): added null check for autoscaler custom metric scaling policies

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy
@@ -474,14 +474,14 @@ class StandardGceAttributeValidator {
           utilization.with {
             validateNotEmpty(metric, "${path}.metric")
 
-            if (utilizationTarget <= 0) {
+            if (utilizationTarget!=null && utilizationTarget <= 0) {
               errors.rejectValue("${context}.${path}.utilizationTarget",
                 "${context}.${path}.utilizationTarget must be greater than zero.")
+
+              validateNotEmpty(utilizationTargetType, "${path}.utilizationTargetType")
             }
 
-            validateNotEmpty(utilizationTargetType, "${path}.utilizationTargetType")
-
-            if (singleInstanceAssignment < 0) {
+            if (singleInstanceAssignment!=null && singleInstanceAssignment < 0) {
               errors.rejectValue("${context}.${path}.singleInstanceAssignment",
                 "${context}.${path}.singleInstanceAssignment must be greater than zero.")
             }


### PR DESCRIPTION
To address the validation issue that is occurring while using custom metric utilisations in Autoscaler feature of creation of server group in google cloud provider. 
As part of addressing the issue mentioned in [6784](https://github.com/spinnaker/spinnaker/issues/6784)

While selecting one of two  scaling policies available(SingleInstanceAssignment and Utilization Target) the other one is null.Hence added validation to check for null.