### PR TITLE
fix(google): added null check for autoscaler custom metric scaling policies

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy
@@ -474,14 +474,16 @@ class StandardGceAttributeValidator {
           utilization.with {
             validateNotEmpty(metric, "${path}.metric")
 
-            if (utilizationTarget <= 0) {
+            if (utilizationTarget!=null && utilizationTarget <= 0) {
               errors.rejectValue("${context}.${path}.utilizationTarget",
                 "${context}.${path}.utilizationTarget must be greater than zero.")
             }
 
-            validateNotEmpty(utilizationTargetType, "${path}.utilizationTargetType")
+            if(utilizationTarget!=null){
+              validateNotEmpty(utilizationTargetType, "${path}.utilizationTargetType")
+            }
 
-            if (singleInstanceAssignment < 0) {
+            if (singleInstanceAssignment!=null && singleInstanceAssignment < 0) {
               errors.rejectValue("${context}.${path}.singleInstanceAssignment",
                 "${context}.${path}.singleInstanceAssignment must be greater than zero.")
             }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy
@@ -474,16 +474,15 @@ class StandardGceAttributeValidator {
           utilization.with {
             validateNotEmpty(metric, "${path}.metric")
 
-            if (utilizationTarget!=null && utilizationTarget <= 0) {
-              errors.rejectValue("${context}.${path}.utilizationTarget",
-                "${context}.${path}.utilizationTarget must be greater than zero.")
-            }
-
-            if(utilizationTarget!=null){
+            if (utilizationTarget != null){
               validateNotEmpty(utilizationTargetType, "${path}.utilizationTargetType")
+              if (utilizationTarget <= 0) {
+                errors.rejectValue("${context}.${path}.utilizationTarget",
+                "${context}.${path}.utilizationTarget must be greater than zero.")
+              }
             }
 
-            if (singleInstanceAssignment!=null && singleInstanceAssignment < 0) {
+            if (singleInstanceAssignment != null && singleInstanceAssignment < 0) {
               errors.rejectValue("${context}.${path}.singleInstanceAssignment",
                 "${context}.${path}.singleInstanceAssignment must be greater than zero.")
             }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidatorSpec.groovy
@@ -879,6 +879,28 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   }
 
+  void "valid autoscaler customMetricUtilizations"(){
+    setup:
+    def errors = Mock(ValidationErrors)
+    def validator = new StandardGceAttributeValidator(DECORATOR, errors)
+
+    when:
+    validator.validateAutoscalingPolicy(new GoogleAutoscalingPolicy(
+      customMetricUtilizations: [ new GoogleAutoscalingPolicy.CustomMetricUtilization(utilizationTarget: 5,
+        metric: "myMetric", utilizationTargetType: UtilizationTargetType.DELTA_PER_MINUTE,singleInstanceAssignment: null) ]))
+
+    then:
+    0 * errors._
+
+    when:
+    validator.validateAutoscalingPolicy(new GoogleAutoscalingPolicy(
+      customMetricUtilizations: [ new GoogleAutoscalingPolicy.CustomMetricUtilization(utilizationTarget: null,
+        metric: "myMetric", utilizationTargetType: null, singleInstanceAssignment: 1) ]))
+
+    then:
+    0 * errors._
+  }
+
   @Unroll
   void "valid autoHealer maxUnavailable with fixed=#fixed and percent=#percent"() {
     setup:


### PR DESCRIPTION
To address the validation issue that is occurring while using custom metric utilisations in Autoscaler feature of creation of server group in google cloud provider.
As part of addressing the issue mentioned in [6784](https://github.com/spinnaker/spinnaker/issues/6784)

While selecting one of two scaling policies available(SingleInstanceAssignment and Utilization Target) the other one is null.Hence added validation to check for null.