### PR TITLE
fix(kubectl): add metrics to retries, make log messages more descriptive and support retries for all kubectl actions

### DIFF
--- a/clouddriver-core/clouddriver-core.gradle
+++ b/clouddriver-core/clouddriver-core.gradle
@@ -13,6 +13,9 @@ dependencies {
   annotationProcessor "org.projectlombok:lombok"
   testAnnotationProcessor "org.projectlombok:lombok"
 
+  // Because a JobRequest constructor takes a org.apache.commons.exec.CommandLine argument
+  api "org.apache.commons:commons-exec"
+
   // This is because some classes in this module use the Groovy @Immutable annotation,
   // which appears to require consumers to have core groovy on the classpath
   api "org.codehaus.groovy:groovy"
@@ -43,7 +46,6 @@ dependencies {
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "io.reactivex:rxjava"
   implementation "net.jodah:failsafe:1.0.4"
-  implementation "org.apache.commons:commons-exec"
   implementation "org.codehaus.groovy:groovy"
   implementation "org.codehaus.groovy:groovy-templates"
   implementation "org.springframework.boot:spring-boot-actuator"

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.jobs;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.Getter;
@@ -53,8 +54,8 @@ public class JobRequest {
     this(tokenizedCommand, System.getenv(), inputStream, workingDir);
   }
 
-  public JobRequest(List<String> tokenizedCommand, File workingDor) {
-    this(tokenizedCommand, System.getenv(), new ByteArrayInputStream(new byte[0]), workingDor);
+  public JobRequest(List<String> tokenizedCommand, File workingDir) {
+    this(tokenizedCommand, System.getenv(), new ByteArrayInputStream(new byte[0]), workingDir);
   }
 
   public JobRequest(
@@ -67,6 +68,15 @@ public class JobRequest {
     this.environment = environment;
     this.inputStream = inputStream;
     this.workingDir = workingDir;
+  }
+
+  // only used in tests
+  public JobRequest(CommandLine commandLine, InputStream inputStream) {
+    this.tokenizedCommand = new ArrayList<>();
+    this.commandLine = commandLine;
+    this.environment = System.getenv();
+    this.inputStream = inputStream;
+    this.workingDir = null;
   }
 
   private CommandLine createCommandLine(List<String> tokenizedCommand) {
@@ -85,6 +95,9 @@ public class JobRequest {
 
   @Override
   public String toString() {
-    return String.join(" ", tokenizedCommand);
+    if (!tokenizedCommand.isEmpty()) {
+      return String.join(" ", tokenizedCommand);
+    }
+    return commandLine.toString();
   }
 }

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -90,6 +90,7 @@ dependencies {
   implementation "io.github.resilience4j:resilience4j-retry"
   implementation "io.github.resilience4j:resilience4j-micrometer"
 
+  testImplementation "org.apache.commons:commons-exec"
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -90,6 +90,7 @@ dependencies {
   implementation "io.github.resilience4j:resilience4j-retry"
   implementation "io.github.resilience4j:resilience4j-micrometer"
 
+  testImplementation "io.spinnaker.kork:kork-test"
   testImplementation "org.apache.commons:commons-exec"
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -88,6 +88,7 @@ dependencies {
   implementation "org.springframework.cloud:spring-cloud-context"
   implementation "org.springframework.cloud:spring-cloud-config-server"
   implementation "io.github.resilience4j:resilience4j-retry"
+  implementation "io.github.resilience4j:resilience4j-micrometer"
 
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -35,6 +35,9 @@ public class KubernetesConfigurationProperties {
 
   private Cache cache = new Cache();
 
+  private KubectlProperties kubectl = new KubectlProperties();
+  private OAuthProperties oAuth = new OAuthProperties();
+
   public KubernetesConfigurationProperties kubernetesConfigurationProperties() {
     return new KubernetesConfigurationProperties();
   }
@@ -69,6 +72,14 @@ public class KubernetesConfigurationProperties {
 
       // only applicable when exponentialBackoff = true
       long exponentialBackOffIntervalMs = 10000;
+
+      private Metrics metrics = new Metrics();
+
+      @Data
+      public static class Metrics {
+        // flag to capture retry metrics. Turned off by default
+        private boolean enabled;
+      }
     }
   }
 
@@ -119,5 +130,17 @@ public class KubernetesConfigurationProperties {
      * enabled.
      */
     boolean checkApplicationInFront50 = false;
+  }
+
+  /** kubectl configuration properties */
+  @Data
+  public static class KubectlProperties {
+    private String executable = "kubectl";
+  }
+
+  /** oAuth configuration properties */
+  @Data
+  public static class OAuthProperties {
+    private String executable = "oauth2l";
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -36,11 +36,19 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesSelectorList;
+import io.github.resilience4j.core.EventConsumer;
+import io.github.resilience4j.micrometer.tagged.TaggedRetryMetrics;
 import io.github.resilience4j.retry.IntervalFunction;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
+import io.github.resilience4j.retry.event.RetryEvent;
+import io.github.resilience4j.retry.event.RetryOnErrorEvent;
+import io.github.resilience4j.retry.event.RetryOnIgnoredErrorEvent;
+import io.github.resilience4j.retry.event.RetryOnRetryEvent;
+import io.github.resilience4j.retry.event.RetryOnSuccessEvent;
 import io.kubernetes.client.openapi.models.V1DeleteOptions;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
@@ -51,43 +59,43 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.WillClose;
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class KubectlJobExecutor {
   private static final Logger log = LoggerFactory.getLogger(KubectlJobExecutor.class);
   private static final String NOT_FOUND_STRING = "(NotFound)";
+  private static final String KUBECTL_COMMAND_OPTION_TOKEN = "--token=";
+  private static final String KUBECTL_COMMAND_OPTION_KUBECONFIG = "--kubeconfig=";
+  private static final String KUBECTL_COMMAND_OPTION_CONTEXT = "--context=";
+
   private final JobExecutor jobExecutor;
-  private final String executable;
-  private final String oAuthExecutable;
 
   private final Gson gson = new Gson();
 
   private final KubernetesConfigurationProperties kubernetesConfigurationProperties;
 
-  private final Optional<RetryRegistry> retryRegistry;
+  // @Getter is required so that this can be used in tests
+  @Getter private final Optional<RetryRegistry> retryRegistry;
+
+  private final MeterRegistry meterRegistry;
 
   @Autowired
   public KubectlJobExecutor(
       JobExecutor jobExecutor,
-      @Value("${kubernetes.kubectl.executable:kubectl}") String executable,
-      @Value("${kubernetes.o-auth.executable:oauth2l}") String oAuthExecutable,
-      KubernetesConfigurationProperties kubernetesConfigurationProperties) {
+      KubernetesConfigurationProperties kubernetesConfigurationProperties,
+      MeterRegistry meterRegistry) {
     this.jobExecutor = jobExecutor;
-    this.executable = executable;
-    this.oAuthExecutable = oAuthExecutable;
     this.kubernetesConfigurationProperties = kubernetesConfigurationProperties;
-    this.retryRegistry =
-        getRetryRegistry(kubernetesConfigurationProperties.getJobExecutor().getRetries());
+    this.meterRegistry = meterRegistry;
 
-    log.info(
-        "kubectl job executor configured with {}",
-        kubernetesConfigurationProperties.getJobExecutor());
+    this.retryRegistry =
+        initializeRetryRegistry(kubernetesConfigurationProperties.getJobExecutor().getRetries());
   }
 
   public String logs(
@@ -97,20 +105,14 @@ public class KubectlJobExecutor {
     command.add(podName);
     command.add("-c=" + containerName);
 
+    String resource = podName + "/" + containerName;
     JobResult<String> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".logs." + podName, new JobRequest(command));
+            new KubectlActionIdentifier(credentials, command), new JobRequest(command));
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException(
-          "Failed to get logs from "
-              + podName
-              + "/"
-              + containerName
-              + " in "
-              + namespace
-              + ": "
-              + status.getError());
+          "Failed to get logs from " + resource + " in " + namespace + ": " + status.getError());
     }
 
     return status.getOutput();
@@ -119,17 +121,18 @@ public class KubectlJobExecutor {
   public String jobLogs(
       KubernetesCredentials credentials, String namespace, String jobName, String containerName) {
     List<String> command = kubectlNamespacedAuthPrefix(credentials, namespace);
+    String resource = "job/" + jobName;
     command.add("logs");
-    command.add("job/" + jobName);
+    command.add(resource);
     command.add("-c=" + containerName);
 
     JobResult<String> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".jobLogs." + jobName, new JobRequest(command));
+            new KubectlActionIdentifier(credentials, command), new JobRequest(command));
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException(
-          "Failed to get logs from job/" + jobName + " in " + namespace + ": " + status.getError());
+          "Failed to get logs from " + resource + " in " + namespace + ": " + status.getError());
     }
 
     return status.getOutput();
@@ -169,7 +172,8 @@ public class KubectlJobExecutor {
     }
 
     JobResult<String> status =
-        executeKubectlJob(credentials.getAccountName() + ".delete." + id, new JobRequest(command));
+        executeKubectlJob(
+            new KubectlActionIdentifier(credentials, command), new JobRequest(command));
 
     persistKubectlJobOutput(credentials, status, id, task, opName);
 
@@ -204,16 +208,15 @@ public class KubectlJobExecutor {
     command = kubectlLookupInfo(command, kind, name, null);
     command.add("--replicas=" + replicas);
 
+    String resource = kind + "/" + name;
     JobResult<String> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".scale." + kind.toString() + "/" + name,
-            new JobRequest(command));
-
-    persistKubectlJobOutput(credentials, status, kind + "/" + name, task, opName);
+            new KubectlActionIdentifier(credentials, command), new JobRequest(command));
+    persistKubectlJobOutput(credentials, status, resource, task, opName);
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException(
-          "Failed to scale " + kind + "/" + name + " from " + namespace + ": " + status.getError());
+          "Failed to scale " + resource + " from " + namespace + ": " + status.getError());
     }
 
     return null;
@@ -222,22 +225,19 @@ public class KubectlJobExecutor {
   public List<Integer> historyRollout(
       KubernetesCredentials credentials, KubernetesKind kind, String namespace, String name) {
     List<String> command = kubectlNamespacedAuthPrefix(credentials, namespace);
-
+    String resource = kind + "/" + name;
     command.add("rollout");
     command.add("history");
-    command.add(kind.toString() + "/" + name);
+    command.add(resource);
 
     JobResult<String> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".historyRollout." + kind.toString() + "/" + name,
-            new JobRequest(command));
+            new KubectlActionIdentifier(credentials, command), new JobRequest(command));
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException(
           "Failed to get rollout history of "
-              + kind
-              + "/"
-              + name
+              + resource
               + " from "
               + namespace
               + ": "
@@ -279,26 +279,19 @@ public class KubectlJobExecutor {
       int revision) {
     List<String> command = kubectlNamespacedAuthPrefix(credentials, namespace);
 
+    String resource = kind + "/" + name;
     command.add("rollout");
     command.add("undo");
-    command.add(kind.toString() + "/" + name);
+    command.add(resource);
     command.add("--to-revision=" + revision);
 
     JobResult<String> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".undoRollout." + kind.toString() + "/" + name,
-            new JobRequest(command));
+            new KubectlActionIdentifier(credentials, command), new JobRequest(command));
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException(
-          "Failed to undo rollout "
-              + kind
-              + "/"
-              + name
-              + " from "
-              + namespace
-              + ": "
-              + status.getError());
+          "Failed to undo rollout " + resource + " from " + namespace + ": " + status.getError());
     }
 
     return null;
@@ -308,25 +301,18 @@ public class KubectlJobExecutor {
       KubernetesCredentials credentials, KubernetesKind kind, String namespace, String name) {
     List<String> command = kubectlNamespacedAuthPrefix(credentials, namespace);
 
+    String resource = kind + "/" + name;
     command.add("rollout");
     command.add("pause");
-    command.add(kind.toString() + "/" + name);
+    command.add(resource);
 
     JobResult<String> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".pauseRollout." + kind.toString() + "/" + name,
-            new JobRequest(command));
+            new KubectlActionIdentifier(credentials, command), new JobRequest(command));
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException(
-          "Failed to pause rollout "
-              + kind
-              + "/"
-              + name
-              + " from "
-              + namespace
-              + ": "
-              + status.getError());
+          "Failed to pause rollout " + resource + " from " + namespace + ": " + status.getError());
     }
 
     return null;
@@ -341,27 +327,20 @@ public class KubectlJobExecutor {
       String opName) {
     List<String> command = kubectlNamespacedAuthPrefix(credentials, namespace);
 
+    String resource = kind + "/" + name;
     command.add("rollout");
     command.add("resume");
-    command.add(kind.toString() + "/" + name);
+    command.add(resource);
 
     JobResult<String> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".resumeRollout." + kind.toString() + "/" + name,
-            new JobRequest(command));
+            new KubectlActionIdentifier(credentials, command), new JobRequest(command));
 
-    persistKubectlJobOutput(credentials, status, kind + "/" + name, task, opName);
+    persistKubectlJobOutput(credentials, status, resource, task, opName);
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException(
-          "Failed to resume rollout "
-              + kind
-              + "/"
-              + name
-              + " from "
-              + namespace
-              + ": "
-              + status.getError());
+          "Failed to resume rollout " + resource + " from " + namespace + ": " + status.getError());
     }
 
     return null;
@@ -376,23 +355,21 @@ public class KubectlJobExecutor {
       String opName) {
     List<String> command = kubectlNamespacedAuthPrefix(credentials, namespace);
 
+    String resource = kind + "/" + name;
     command.add("rollout");
     command.add("restart");
-    command.add(kind.toString() + "/" + name);
+    command.add(resource);
 
     JobResult<String> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".rollingRestart." + kind.toString() + "/" + name,
-            new JobRequest(command));
+            new KubectlActionIdentifier(credentials, command), new JobRequest(command));
 
-    persistKubectlJobOutput(credentials, status, kind + "/" + name, task, opName);
+    persistKubectlJobOutput(credentials, status, resource, task, opName);
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException(
           "Failed to complete rolling restart of "
-              + kind
-              + "/"
-              + name
+              + resource
               + " from "
               + namespace
               + ": "
@@ -412,8 +389,7 @@ public class KubectlJobExecutor {
 
     JobResult<String> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".get." + kind.toString() + "/" + name,
-            new JobRequest(command));
+            new KubectlActionIdentifier(credentials, command), new JobRequest(command));
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       if (status.getError().contains(NOT_FOUND_STRING)) {
@@ -459,15 +435,21 @@ public class KubectlJobExecutor {
             "involvedObject.name=%s,involvedObject.kind=%s",
             name, StringUtils.capitalize(kind.toString())));
 
+    String resource = kind + "/" + name;
     JobResult<ImmutableList<KubernetesManifest>> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".eventsFor." + kind.toString() + "/" + name,
+            new KubectlActionIdentifier(credentials, command),
             new JobRequest(command),
             parseManifestList());
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException(
-          "Failed to read events for: " + name + " from " + namespace + ": " + status.getError());
+          "Failed to read events for: "
+              + resource
+              + " from "
+              + namespace
+              + ": "
+              + status.getError());
     }
 
     if (status.getError().contains("No resources found")) {
@@ -490,9 +472,10 @@ public class KubectlJobExecutor {
       command.add("-l=" + selectors.toString());
     }
 
+    String resource = kinds.stream().map(KubernetesKind::toString).collect(Collectors.joining(","));
     JobResult<ImmutableList<KubernetesManifest>> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".list." + kinds + "." + namespace,
+            new KubectlActionIdentifier(credentials, command),
             new JobRequest(command),
             parseManifestList());
 
@@ -503,7 +486,7 @@ public class KubectlJobExecutor {
         log.warn(status.getError());
       } else {
         throw new KubectlException(
-            "Failed to read " + kinds + " from " + namespace + ": " + status.getError());
+            "Failed to read " + resource + " from " + namespace + ": " + status.getError());
       }
     }
 
@@ -516,7 +499,7 @@ public class KubectlJobExecutor {
 
   public KubernetesManifest deploy(
       KubernetesCredentials credentials, KubernetesManifest manifest, Task task, String opName) {
-    log.info("Deploying manifest {}", manifest.getName());
+    log.info("Deploying manifest {}", manifest.getFullResourceName());
     List<String> command = kubectlAuthPrefix(credentials);
 
     String manifestAsJson = gson.toJson(manifest);
@@ -530,7 +513,7 @@ public class KubectlJobExecutor {
 
     JobResult<String> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".deploy." + manifest.getFullResourceName(),
+            new KubectlActionIdentifier(credentials, command, manifest),
             new JobRequest(
                 command,
                 new ByteArrayInputStream(manifestAsJson.getBytes(StandardCharsets.UTF_8))));
@@ -539,7 +522,10 @@ public class KubectlJobExecutor {
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException(
-          "Deploy failed for manifest: " + manifest.getName() + " . Error: " + status.getError());
+          "Deploy failed for manifest: "
+              + manifest.getFullResourceName()
+              + ". Error: "
+              + status.getError());
     }
 
     return getKubernetesManifestFromJobResult(status, manifest);
@@ -547,7 +533,7 @@ public class KubectlJobExecutor {
 
   public KubernetesManifest replace(
       KubernetesCredentials credentials, KubernetesManifest manifest, Task task, String opName) {
-    log.info("Replacing manifest {}", manifest.getName());
+    log.info("Replacing manifest {}", manifest.getFullResourceName());
     List<String> command = kubectlAuthPrefix(credentials);
 
     String manifestAsJson = gson.toJson(manifest);
@@ -561,7 +547,7 @@ public class KubectlJobExecutor {
 
     JobResult<String> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".replace." + manifest.getFullResourceName(),
+            new KubectlActionIdentifier(credentials, command, manifest),
             new JobRequest(
                 command,
                 new ByteArrayInputStream(manifestAsJson.getBytes(StandardCharsets.UTF_8))));
@@ -571,10 +557,16 @@ public class KubectlJobExecutor {
     if (status.getResult() != JobResult.Result.SUCCESS) {
       if (status.getError().contains(NOT_FOUND_STRING)) {
         throw new KubectlNotFoundException(
-            "Replace failed for manifest: " + manifest.getName() + ". Error: " + status.getError());
+            "Replace failed for manifest: "
+                + manifest.getFullResourceName()
+                + ". Error: "
+                + status.getError());
       }
       throw new KubectlException(
-          "Replace failed for manifest: " + manifest.getName() + ". Error: " + status.getError());
+          "Replace failed for manifest: "
+              + manifest.getFullResourceName()
+              + ". Error: "
+              + status.getError());
     }
 
     return getKubernetesManifestFromJobResult(status, manifest);
@@ -596,7 +588,7 @@ public class KubectlJobExecutor {
 
     JobResult<String> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".create." + manifest.getFullResourceName(),
+            new KubectlActionIdentifier(credentials, command, manifest),
             new JobRequest(
                 command,
                 new ByteArrayInputStream(manifestAsJson.getBytes(StandardCharsets.UTF_8))));
@@ -605,7 +597,10 @@ public class KubectlJobExecutor {
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException(
-          "Create failed for manifest: " + manifest.getName() + ". Error: " + status.getError());
+          "Create failed for manifest: "
+              + manifest.getFullResourceName()
+              + ". Error: "
+              + status.getError());
     }
 
     return getKubernetesManifestFromJobResult(status, manifest);
@@ -630,7 +625,7 @@ public class KubectlJobExecutor {
     if (!Strings.isNullOrEmpty(credentials.getKubectlExecutable())) {
       command.add(credentials.getKubectlExecutable());
     } else {
-      command.add(executable);
+      command.add(this.kubernetesConfigurationProperties.getKubectl().getExecutable());
     }
 
     if (credentials.getKubectlRequestTimeoutSeconds() != null) {
@@ -645,17 +640,17 @@ public class KubectlJobExecutor {
     if (!credentials.isServiceAccount()) {
       if (credentials.getOAuthServiceAccount() != null
           && !credentials.getOAuthServiceAccount().isEmpty()) {
-        command.add("--token=" + getOAuthToken(credentials));
+        command.add(KUBECTL_COMMAND_OPTION_TOKEN + getOAuthToken(credentials));
       }
 
       String kubeconfigFile = credentials.getKubeconfigFile();
       if (!Strings.isNullOrEmpty(kubeconfigFile)) {
-        command.add("--kubeconfig=" + kubeconfigFile);
+        command.add(KUBECTL_COMMAND_OPTION_KUBECONFIG + kubeconfigFile);
       }
 
       String context = credentials.getContext();
       if (!Strings.isNullOrEmpty(context)) {
-        command.add("--context=" + context);
+        command.add(KUBECTL_COMMAND_OPTION_CONTEXT + context);
       }
     }
 
@@ -705,14 +700,15 @@ public class KubectlJobExecutor {
 
   private String getOAuthToken(KubernetesCredentials credentials) {
     List<String> command = new ArrayList<>();
-    command.add(oAuthExecutable);
+    command.add(this.kubernetesConfigurationProperties.getOAuth().getExecutable());
     command.add("fetch");
     command.add("--json");
     command.add(credentials.getOAuthServiceAccount());
     command.addAll(credentials.getOAuthScopes());
 
     JobResult<String> status =
-        executeKubectlJob(credentials.getAccountName() + ".getOAuthToken", new JobRequest(command));
+        executeKubectlJob(
+            new KubectlActionIdentifier(credentials, command), new JobRequest(command));
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException("Could not fetch OAuth token: " + status.getError());
@@ -731,8 +727,8 @@ public class KubectlJobExecutor {
     command.add("--containers");
 
     JobResult<String> status =
-        executeKubectlJob(credentials.getAccountName() + ".topPod." + pod, new JobRequest(command));
-
+        executeKubectlJob(
+            new KubectlActionIdentifier(credentials, command), new JobRequest(command));
     if (status.getResult() != JobResult.Result.SUCCESS) {
       if (status.getError().toLowerCase().contains("not available")
           || status.getError().toLowerCase().contains("not found")) {
@@ -810,12 +806,12 @@ public class KubectlJobExecutor {
     command.add("--patch");
     command.add(patchBody);
 
+    String resource = kind + "/" + name;
     JobResult<String> status =
         executeKubectlJob(
-            credentials.getAccountName() + ".patch." + kind.toString() + "/" + name,
-            new JobRequest(command));
+            new KubectlActionIdentifier(credentials, command), new JobRequest(command));
 
-    persistKubectlJobOutput(credentials, status, kind + "/" + name, task, opName);
+    persistKubectlJobOutput(credentials, status, resource, task, opName);
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       String errMsg = status.getError();
@@ -870,12 +866,21 @@ public class KubectlJobExecutor {
     };
   }
 
-  private Optional<RetryRegistry> getRetryRegistry(
+  /**
+   * This is used to initialize a RetryRegistry. RetryRegistry acts as a global store for all retry
+   * instances. There retry instances will be shared for various kubectl actions. A retry instance
+   * can usually be identified by the account name, action, and namespace.
+   *
+   * @param retriesConfig - kubectl job retries configuration
+   * @return - If retries are enabled, it returns an Optional that contains a RetryRegistry,
+   *     otherwise it returns an empty Optional
+   */
+  private Optional<RetryRegistry> initializeRetryRegistry(
       KubernetesConfigurationProperties.KubernetesJobExecutorProperties.Retries retriesConfig) {
     if (retriesConfig.isEnabled()) {
       log.info("kubectl retries are enabled");
 
-      // the retry config configured below is set to retry on all Throwable exceptions by default.
+      // this config will be applied to all retry instances created from the registry
       RetryConfig.Builder<Object> retryConfig =
           RetryConfig.custom().maxAttempts(retriesConfig.getMaxAttempts());
       if (retriesConfig.isExponentialBackoffEnabled()) {
@@ -887,129 +892,231 @@ public class KubectlJobExecutor {
         retryConfig.waitDuration(Duration.ofMillis(retriesConfig.getBackOffInMs()));
       }
 
-      return Optional.of(RetryRegistry.of(retryConfig.build()));
+      // retry on all exceptions except NoRetryException
+      retryConfig.ignoreExceptions(NoRetryException.class);
+
+      // create the retry registry
+      RetryRegistry retryRegistry = RetryRegistry.of(retryConfig.build());
+
+      // logging whenever a new retry instance is added, removed or replaced from the registry
+      retryRegistry
+          .getEventPublisher()
+          .onEntryAdded(
+              entryAddedEvent -> {
+                Retry addedRetry = entryAddedEvent.getAddedEntry();
+                log.info("Kubectl retries configured for: {}", addedRetry.getName());
+              })
+          .onEntryRemoved(
+              entryRemovedEvent -> {
+                Retry removedRetry = entryRemovedEvent.getRemovedEntry();
+                log.info("Kubectl retries removed for: {}", removedRetry.getName());
+              })
+          .onEntryReplaced(
+              entryReplacedEvent -> {
+                Retry oldEntry = entryReplacedEvent.getOldEntry();
+                Retry newEntry = entryReplacedEvent.getNewEntry();
+                log.info(
+                    "Kubectl retry: {} updated to: {}", oldEntry.getName(), newEntry.getName());
+              });
+
+      // defining an event consumer once for the entire registry as mentioned here:
+      // https://github.com/resilience4j/resilience4j/issues/974#issuecomment-619956673
+      // If we don't do this once, but add it for each individual retry instance, and if
+      // that retry instance is invoked by multiple threads, then there is a lot of log duplication.
+      // For example, if 10 threads invoke an action to get the top pod, and it is
+      // configured to use the retry instance with the identifier "mock-account.topPod.test-pod",
+      // then we will see 10*10 log lines showing up for each retry event instead of just 10 that
+      // we expect.
+      EventConsumer<RetryEvent> eventConsumer =
+          retryEvent -> {
+            if (retryEvent instanceof RetryOnErrorEvent) {
+              log.error(
+                  "Kubectl command for {} failed after {} attempts. Exception: {}",
+                  retryEvent.getName(),
+                  retryEvent.getNumberOfRetryAttempts(),
+                  retryEvent.getLastThrowable().toString());
+            } else if (retryEvent instanceof RetryOnSuccessEvent) {
+              log.info(
+                  "Kubectl command for {} is now successful in attempt #{}. Last attempt had failed with exception: {}",
+                  retryEvent.getName(),
+                  retryEvent.getNumberOfRetryAttempts() + 1,
+                  retryEvent.getLastThrowable().toString());
+            } else if (retryEvent instanceof RetryOnRetryEvent) {
+              log.info(
+                  "Retrying Kubectl command for {}. Attempt #{} failed with exception: {}",
+                  retryEvent.getName(),
+                  retryEvent.getNumberOfRetryAttempts(),
+                  retryEvent.getLastThrowable().toString());
+            } else if (!(retryEvent instanceof RetryOnIgnoredErrorEvent)) {
+              // don't log anything for Ignored exceptions as it just leads to noise in the logs
+              log.info(retryEvent.toString());
+            }
+          };
+      retryRegistry
+          .getAllRetries()
+          .forEach(retry -> retry.getEventPublisher().onEvent(eventConsumer));
+      retryRegistry
+          .getEventPublisher()
+          .onEntryAdded(event -> event.getAddedEntry().getEventPublisher().onEvent(eventConsumer));
+
+      if (this.kubernetesConfigurationProperties
+          .getJobExecutor()
+          .getRetries()
+          .getMetrics()
+          .isEnabled()) {
+        TaggedRetryMetrics.ofRetryRegistry(retryRegistry).bindTo(meterRegistry);
+      }
+
+      return Optional.of(retryRegistry);
     } else {
       log.info("kubectl retries are disabled");
       return Optional.empty();
     }
   }
 
-  private Retry getRetry(RetryRegistry retryRegistry, String identifier) {
-    Retry retry = retryRegistry.retry(identifier);
-    Retry.EventPublisher publisher = retry.getEventPublisher();
-    publisher.onRetry(event -> log.warn(event.toString()));
-    publisher.onSuccess(event -> log.info(event.toString()));
-    publisher.onError(event -> log.error(event.toString()));
-    return retry;
-  }
-
-  private <T> boolean shouldRetry(JobResult<T> result) {
-    if (result.getResult() != JobResult.Result.SUCCESS) {
-      // the error matches the configured list of retryable errors.
-      if (this.kubernetesConfigurationProperties
-          .getJobExecutor()
-          .getRetries()
-          .getRetryableErrorMessages()
-          .stream()
-          .anyMatch(errorMessage -> result.getError().contains(errorMessage))) {
-        return true;
-      }
-
-      // even though the error is not explicitly configured to be retryable, the job was killed -
-      // hence, we should retry
-      if (result.isKilled()) {
-        log.warn("retrying since the job {} was killed", result);
-        return true;
-      }
-
-      log.warn("retries are not enabled for error: {}", result.getError());
+  /**
+   * this method is meant to be invoked only for those JobResults which are unsuccessful. It
+   * determines if the error contained in the JobResult should be retried or not. If the error needs
+   * to be retried, then KubectlException is returned. Otherwise, NoRetryException is returned.
+   *
+   * @param identifier used to log which action's job result is being processed
+   * @param result the job result which needs to be checked to see if it has an error that can be
+   *     retried
+   * @param <T> job result generic type
+   * @return - Either KubectlException or NoRetryException
+   */
+  private <T> RuntimeException convertKubectlJobResultToException(
+      String identifier, JobResult<T> result) {
+    // the error matches the configured list of retryable errors.
+    if (this.kubernetesConfigurationProperties
+        .getJobExecutor()
+        .getRetries()
+        .getRetryableErrorMessages()
+        .stream()
+        .anyMatch(errorMessage -> result.getError().contains(errorMessage))) {
+      return new KubectlException(identifier + " failed. Error: " + result.getError());
     }
-    return false;
+
+    // even though the error is not explicitly configured to be retryable, the job was killed -
+    // hence, we should retry
+    if (result.isKilled()) {
+      return new KubectlException(
+          "retrying " + identifier + " since the job " + result + " was killed");
+    }
+
+    String message =
+        "Not retrying "
+            + identifier
+            + " as retries are not enabled for error: "
+            + result.getError();
+    log.warn(message);
+    // we want to let the retry library know that such errors should not be retried.
+    // Since we have configured the global retry registry to ignore errors of type
+    // NoRetryException, we return this here
+    return new NoRetryException(message);
   }
 
-  private JobResult<String> executeKubectlJob(String identifier, JobRequest jobRequest) {
-    // retry registry will be empty if retries are not enabled. Not logging anything here as it will
-    // be very expensive to do so, since this method gets called for each and every kubectl
-    // invocation
+  /**
+   * This method ends up running the actual kubectl command and determines if it needs to run the
+   * command with retries.
+   *
+   * @param identifier only applicable if retries are enabled. This identifies which retry instance
+   *     should be used from the global retry registry
+   * @param jobRequest the actual kubectl command to be performed
+   * @return - the result of the kubectl command
+   */
+  private JobResult<String> executeKubectlJob(
+      KubectlActionIdentifier identifier, JobRequest jobRequest) {
+    // retry registry is empty if retries are not enabled.
     if (retryRegistry.isEmpty()) {
       return jobExecutor.runJob(jobRequest);
     }
 
     // capture the original result obtained from the jobExecutor.runJob(jobRequest) call.
     JobResult.JobResultBuilder<String> finalResult = JobResult.builder();
+    Retry retryContext = retryRegistry.get().retry(identifier.getRetryInstanceName());
     try {
-      return Retry.decorateSupplier(
-              getRetry(retryRegistry.get(), identifier),
-              () -> {
-                JobResult<String> result = jobExecutor.runJob(jobRequest);
-                // even though the retry handler defaults to retrying on all throwable exceptions,
-                // we have the following code because kubectl binary, when executed, does not throw
-                // an exception.
-                // This logic determines if the binary emits a result that is retryable or not.
-                if (shouldRetry(result)) {
-                  // save the result
-                  finalResult
-                      .error(result.getError())
-                      .killed(result.isKilled())
-                      .output(result.getOutput())
-                      .result(result.getResult());
-                  // throw explicit exception so that the retry library can log and handle it
-                  // correctly.
-                  throw new KubectlException(result.getError());
-                }
-                return result;
-              })
-          .get();
-    } catch (KubectlException e) {
-      // the caller functions expect Kubectl failures to be defined in a JobResult object and not in
-      // the form of an exception.
-      // Hence, we need to translate that exception back into a JobResult object - but
-      // we only need to do it for KubectlException (since that is explicitly thrown above) and not
-      // for any other ones.
+      return retryContext.executeSupplier(
+          () -> {
+            JobResult<String> result = jobExecutor.runJob(jobRequest);
+            if (result.getResult() == JobResult.Result.SUCCESS) {
+              return result;
+            }
+
+            // save the result as it'll be needed later on when we are done with retries
+            finalResult
+                .error(result.getError())
+                .killed(result.isKilled())
+                .output(result.getOutput())
+                .result(result.getResult());
+
+            // if result is not successful, that means we need to determine if we should retry
+            // or not.
+            //
+            // Since the kubectl binary doesn't throw any exceptions by default, we need to
+            // check the result to see if retries are needed. Resilience.4j needs an exception to be
+            // thrown to decide if retries are needed and also, to capture retry metrics correctly.
+            throw convertKubectlJobResultToException(identifier.getKubectlAction(), result);
+          });
+    } catch (KubectlException | NoRetryException e) {
+      // the caller functions expect any failures to be defined in a JobResult object and not in
+      // the form of an exception. Hence, we need to translate the above exceptions back into a
+      // JobResult object - but we only need to do it for KubectlException and NoRetryException (
+      // since these are the ones explicitly thrown above) and not for any other ones.
       return finalResult.build();
     }
   }
 
+  /**
+   * This method ends up running the actual kubectl command and determines if it needs to run the
+   * command with retries.
+   *
+   * @param identifier - only applicable if retries are enabled. This identifies which retry
+   *     instance should be used from the global retry registry
+   * @param jobRequest - the actual kubectl command to be performed
+   * @param readerConsumer - A function that transforms the job's standard output
+   * @param <T> - return type of the JobResult output
+   * @return - the result of the kubectl command
+   */
   private <T> JobResult<T> executeKubectlJob(
-      String identifier, JobRequest jobRequest, ReaderConsumer<T> readerConsumer) {
-    // retry registry will be empty if retries are not enabled. Not logging anything here as it will
-    // be very expensive to do so, since this method gets called for each and every kubectl
-    // invocation
+      KubectlActionIdentifier identifier, JobRequest jobRequest, ReaderConsumer<T> readerConsumer) {
+    // retry registry is empty if retries are not enabled.
     if (retryRegistry.isEmpty()) {
       return jobExecutor.runJob(jobRequest, readerConsumer);
     }
 
-    // capture the original result obtained from the jobExecutor.runJob(jobRequest) call.
+    // capture the original result obtained from the jobExecutor.runJob(jobRequest, readerConsumer)
+    // call.
     JobResult.JobResultBuilder<T> finalResult = JobResult.builder();
+    Retry retryContext = retryRegistry.get().retry(identifier.getRetryInstanceName());
     try {
-      return Retry.decorateSupplier(
-              getRetry(retryRegistry.get(), identifier),
-              () -> {
-                JobResult<T> result = jobExecutor.runJob(jobRequest, readerConsumer);
-                // even though the retry handler defaults to retrying on all throwable exceptions,
-                // we have the following code because kubectl binary, when executed, does not throw
-                // an exception.
-                // This logic determines if the binary emits a result that is retryable or not.
-                if (shouldRetry(result)) {
-                  // save the result
-                  finalResult
-                      .error(result.getError())
-                      .killed(result.isKilled())
-                      .output(result.getOutput())
-                      .result(result.getResult());
-                  // throw explicit exception so that the retry library can log and handle it
-                  // correctly.
-                  throw new KubectlException(result.getError());
-                }
-                return result;
-              })
-          .get();
-    } catch (KubectlException e) {
-      // the caller functions expect Kubectl failures to be defined in a JobResult object and not in
-      // the form of an exception.
-      // Hence, we need to translate that exception back into a JobResult object - but
-      // we only need to do it for KubectlException (since that is explicitly thrown above) and not
-      // for any other ones.
+      return retryContext.executeSupplier(
+          () -> {
+            JobResult<T> result = jobExecutor.runJob(jobRequest, readerConsumer);
+            if (result.getResult() == JobResult.Result.SUCCESS) {
+              return result;
+            }
+
+            // save the result as it'll be needed later on when we are done with retries
+            finalResult
+                .error(result.getError())
+                .killed(result.isKilled())
+                .output(result.getOutput())
+                .result(result.getResult());
+
+            // if result is not successful, that means we need to determine if we should retry
+            // or not.
+            //
+            // Since Kubectl binary doesn't throw any exceptions by default, we need to
+            // check the result to see if retries are needed. Resilience.4j needs an exception to be
+            // thrown to decide if retries are needed and also, to capture retry metrics correctly.
+            throw convertKubectlJobResultToException(identifier.getKubectlAction(), result);
+          });
+    } catch (KubectlException | NoRetryException e) {
+      // the caller functions expect any failures to be defined in a JobResult object and not in
+      // the form of an exception. Hence, we need to translate the above exceptions back into a
+      // JobResult object - but we only need to do it for KubectlException and NoRetryException
+      // (since these are the ones explicitly thrown above) and not for any other ones.
       return finalResult.build();
     }
   }
@@ -1041,6 +1148,94 @@ public class KubectlJobExecutor {
   public static class KubectlNotFoundException extends KubectlException {
     public KubectlNotFoundException(String message) {
       super(message);
+    }
+  }
+
+  /**
+   * this exception is only meant to be used in cases where we want resilience4j to not retry
+   * kubectl calls. It should not be used anywhere else.
+   */
+  static class NoRetryException extends RuntimeException {
+    NoRetryException(String message) {
+      super(message);
+    }
+  }
+
+  /** helper class to identify the kubectl command in logs and metrics when retries are enabled */
+  static class KubectlActionIdentifier {
+    KubernetesCredentials credentials;
+    List<String> command;
+    String namespace;
+    String resource;
+
+    public KubectlActionIdentifier(KubernetesCredentials credentials, List<String> command) {
+      this(credentials, command, "", "");
+    }
+
+    public KubectlActionIdentifier(
+        KubernetesCredentials credentials,
+        List<String> command,
+        KubernetesManifest kubernetesManifest) {
+      this(
+          credentials,
+          command,
+          kubernetesManifest.getNamespace(),
+          kubernetesManifest.getFullResourceName());
+    }
+
+    public KubectlActionIdentifier(
+        KubernetesCredentials credentials,
+        List<String> command,
+        String namespace,
+        String resource) {
+      this.credentials = credentials;
+      this.command = command;
+      this.namespace = namespace;
+      this.resource = resource;
+    }
+
+    /**
+     * this returns the sanitized kubectl command. This can be used to log the command during retry
+     * attempts, among other things.
+     *
+     * @return - the sanitized kubectl command
+     */
+    public String getKubectlAction() {
+      // no need to display everything in a kubectl command
+      List<String> commandToLog =
+          command.stream()
+              .filter(
+                  s ->
+                      !(s.contains(KUBECTL_COMMAND_OPTION_TOKEN)
+                          || s.contains(KUBECTL_COMMAND_OPTION_KUBECONFIG)
+                          || s.contains(KUBECTL_COMMAND_OPTION_CONTEXT)))
+              .collect(Collectors.toList());
+
+      String identifier =
+          "command: '"
+              + String.join(" ", commandToLog)
+              + "' in account: "
+              + this.credentials.getAccountName();
+
+      if (!namespace.isEmpty()) {
+        identifier += " in namespace: " + namespace;
+      }
+
+      if (!resource.isEmpty()) {
+        identifier += " for resource: " + resource;
+      }
+      return identifier;
+    }
+
+    /**
+     * this returns a name which uniquely identifies a retry instance. This name shows up in the
+     * logs when each retry event is logged. Also, when capturing the retry metrics, the 'name' tag
+     * in the metric corresponds to this.
+     *
+     * @return - the name to be used to uniquely identify a retry instance
+     */
+    public String getRetryInstanceName() {
+      return this.credentials.getAccountName();
     }
   }
 }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/ManifestFetcher.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/ManifestFetcher.java
@@ -42,7 +42,7 @@ public final class ManifestFetcher {
     return base;
   }
 
-  static KubernetesManifest getManifest(String basePath) {
+  public static KubernetesManifest getManifest(String basePath) {
     return getManifest(ManifestFetcher.class, basePath).get(0);
   }
 
@@ -56,7 +56,7 @@ public final class ManifestFetcher {
         .collect(ImmutableList.toImmutableList());
   }
 
-  private static String getResource(Class<?> referenceClass, String name) {
+  public static String getResource(Class<?> referenceClass, String name) {
     try {
       return Resources.toString(referenceClass.getResource(name), StandardCharsets.UTF_8);
     } catch (IOException e) {

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
@@ -19,17 +19,22 @@ package com.netflix.spinnaker.clouddriver.kubernetes.op.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.io.Resources;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spinnaker.clouddriver.jobs.JobExecutionException;
 import com.netflix.spinnaker.clouddriver.jobs.JobExecutor;
 import com.netflix.spinnaker.clouddriver.jobs.JobRequest;
@@ -39,24 +44,45 @@ import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurati
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPodMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPodMetric.ContainerMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+import org.slf4j.LoggerFactory;
 
 @RunWith(JUnitPlatform.class)
 final class KubectlJobExecutorTest {
   private static final String NAMESPACE = "test-namespace";
+  JobExecutor jobExecutor;
+  KubernetesConfigurationProperties kubernetesConfigurationProperties;
 
-  @ParameterizedTest
+  @BeforeEach
+  public void setup() {
+    jobExecutor = mock(JobExecutor.class);
+    kubernetesConfigurationProperties = new KubernetesConfigurationProperties();
+    kubernetesConfigurationProperties.getJobExecutor().getRetries().setBackOffInMs(500);
+  }
+
+  @ParameterizedTest(name = "{index} ==> retries enabled = {0}")
   @ValueSource(booleans = {true, false})
   void topPodEmptyOutput(boolean retriesEnabled) {
-    JobExecutor jobExecutor = mock(JobExecutor.class);
     when(jobExecutor.runJob(any(JobRequest.class)))
         .thenReturn(
             JobResult.<String>builder().result(Result.SUCCESS).output("").error("").build());
@@ -67,18 +93,33 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+            jobExecutor, kubernetesConfigurationProperties, new SimpleMeterRegistry());
     Collection<KubernetesPodMetric> podMetrics =
         kubectlJobExecutor.topPod(mockKubernetesCredentials(), "test", "");
     assertThat(podMetrics).isEmpty();
 
     // should only be called once as no retries are performed
     verify(jobExecutor).runJob(any(JobRequest.class));
+
+    if (retriesEnabled) {
+      // verify retry registry
+      assertTrue(kubectlJobExecutor.getRetryRegistry().isPresent());
+      RetryRegistry retryRegistry = kubectlJobExecutor.getRetryRegistry().get();
+      assertThat(retryRegistry.getAllRetries().size()).isEqualTo(1);
+      assertThat(retryRegistry.getAllRetries().get(0).getName()).isEqualTo("mock-account");
+
+      // verify retry metrics
+      Retry.Metrics retryMetrics = retryRegistry.getAllRetries().get(0).getMetrics();
+      assertThat(retryMetrics.getNumberOfSuccessfulCallsWithRetryAttempt()).isEqualTo(0);
+      // in this test, the action succeeded without retries. So number of unique calls == 1.
+      assertThat(retryMetrics.getNumberOfSuccessfulCallsWithoutRetryAttempt()).isEqualTo(1);
+      assertThat(retryMetrics.getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(0);
+      assertThat(retryMetrics.getNumberOfFailedCallsWithoutRetryAttempt()).isEqualTo(0);
+    }
   }
 
   @Test
   void topPodMultipleContainers() throws Exception {
-    JobExecutor jobExecutor = mock(JobExecutor.class);
     when(jobExecutor.runJob(any(JobRequest.class)))
         .thenReturn(
             JobResult.<String>builder()
@@ -92,7 +133,7 @@ final class KubectlJobExecutorTest {
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", new KubernetesConfigurationProperties());
+            jobExecutor, new KubernetesConfigurationProperties(), new SimpleMeterRegistry());
     Collection<KubernetesPodMetric> podMetrics =
         kubectlJobExecutor.topPod(mockKubernetesCredentials(), NAMESPACE, "");
     assertThat(podMetrics).hasSize(2);
@@ -135,9 +176,62 @@ final class KubectlJobExecutorTest {
     }
   }
 
+  @DisplayName("test to verify how kubectl errors are handled when retries are disabled")
   @Test
-  void kubectlRetryHandlingForConfiguredErrorsThatContinueFailingAfterMaxRetryAttempts() {
-    JobExecutor jobExecutor = mock(JobExecutor.class);
+  void kubectlJobExecutorErrorHandlingWhenRetriesAreDisabled() {
+    // when
+    when(jobExecutor.runJob(any(JobRequest.class)))
+        .thenReturn(
+            JobResult.<String>builder()
+                .result(Result.FAILURE)
+                .output("")
+                .error("some error")
+                .build());
+
+    KubectlJobExecutor kubectlJobExecutor =
+        new KubectlJobExecutor(
+            jobExecutor, kubernetesConfigurationProperties, new SimpleMeterRegistry());
+
+    // then
+    KubectlJobExecutor.KubectlException thrown =
+        assertThrows(
+            KubectlJobExecutor.KubectlException.class,
+            () -> kubectlJobExecutor.topPod(mockKubernetesCredentials(), "test", ""));
+
+    assertTrue(thrown.getMessage().contains("some error"));
+    // should only be called once as no retries are performed for this error
+    verify(jobExecutor).runJob(any(JobRequest.class));
+  }
+
+  @DisplayName(
+      "parameterized test to verify retry behavior for configured retryable errors that fail even after all "
+          + "attempts are exhausted")
+  @ParameterizedTest(
+      name = "{index} ==> number of simultaneous executions of the action under test = {0}")
+  @ValueSource(ints = {1, 10})
+  void kubectlRetryHandlingForConfiguredErrorsThatContinueFailingAfterMaxRetryAttempts(
+      int numberOfThreads) {
+    // setup
+    kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(true);
+
+    // to test log messages
+    Logger logger = (Logger) LoggerFactory.getLogger(KubectlJobExecutor.class);
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+    logger.addAppender(listAppender);
+    listAppender.start();
+
+    final ExecutorService executor =
+        Executors.newFixedThreadPool(
+            numberOfThreads,
+            new ThreadFactoryBuilder()
+                .setNameFormat(KubectlJobExecutorTest.class.getSimpleName() + "-%d")
+                .build());
+
+    final ArrayList<Future<ImmutableList<KubernetesPodMetric>>> futures =
+        new ArrayList<>(numberOfThreads);
+
+    // when
     when(jobExecutor.runJob(any(JobRequest.class)))
         .thenReturn(
             JobResult.<String>builder()
@@ -146,33 +240,187 @@ final class KubectlJobExecutorTest {
                 .error("Unable to connect to the server: net/http: TLS handshake timeout")
                 .build());
 
-    KubernetesConfigurationProperties kubernetesConfigurationProperties =
-        new KubernetesConfigurationProperties();
+    KubectlJobExecutor kubectlJobExecutor =
+        new KubectlJobExecutor(
+            jobExecutor, kubernetesConfigurationProperties, new SimpleMeterRegistry());
+
+    for (int i = 1; i <= numberOfThreads; i++) {
+      futures.add(
+          executor.submit(
+              () -> kubectlJobExecutor.topPod(mockKubernetesCredentials(), NAMESPACE, "test-pod")));
+    }
+
+    // then
+    for (Future<ImmutableList<KubernetesPodMetric>> future : futures) {
+      try {
+        future.get();
+      } catch (final ExecutionException e) {
+        assertTrue(e.getCause() instanceof KubectlJobExecutor.KubectlException);
+        assertTrue(
+            e.getMessage()
+                .contains("Unable to connect to the server: net/http: TLS handshake timeout"));
+      } catch (final InterruptedException ignored) {
+      }
+    }
+
+    executor.shutdown();
+
+    // verify that the kubectl job executor made max configured attempts per thread to execute the
+    // action
+    verify(
+            jobExecutor,
+            times(
+                kubernetesConfigurationProperties.getJobExecutor().getRetries().getMaxAttempts()
+                    * numberOfThreads))
+        .runJob(any(JobRequest.class));
+
+    // verify retry registry
+    assertTrue(kubectlJobExecutor.getRetryRegistry().isPresent());
+    RetryRegistry retryRegistry = kubectlJobExecutor.getRetryRegistry().get();
+    assertThat(retryRegistry.getAllRetries().size()).isEqualTo(1);
+    assertThat(retryRegistry.getAllRetries().get(0).getName()).isEqualTo("mock-account");
+
+    // verify retry metrics
+    Retry.Metrics retryMetrics = retryRegistry.getAllRetries().get(0).getMetrics();
+    assertThat(retryMetrics.getNumberOfSuccessfulCallsWithRetryAttempt()).isEqualTo(0);
+    assertThat(retryMetrics.getNumberOfSuccessfulCallsWithoutRetryAttempt()).isEqualTo(0);
+    // in this test, all threads failed. So number of unique failed calls == 1 per thread.
+    assertThat(retryMetrics.getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(numberOfThreads);
+    assertThat(retryMetrics.getNumberOfFailedCallsWithoutRetryAttempt()).isEqualTo(0);
+
+    // verify that no duplicate messages are shown in the logs
+    List<ILoggingEvent> logsList = listAppender.list;
+    List<ILoggingEvent> numberOfFailedRetryAttemptLogMessages =
+        logsList.stream()
+            .filter(
+                iLoggingEvent ->
+                    iLoggingEvent
+                        .getFormattedMessage()
+                        .contains(
+                            "Kubectl command for mock-account failed after "
+                                + kubernetesConfigurationProperties
+                                    .getJobExecutor()
+                                    .getRetries()
+                                    .getMaxAttempts()
+                                + " attempts. Exception: com.netflix.spinnaker.clouddriver.kubernetes.op."
+                                + "job.KubectlJobExecutor$KubectlException: command: 'kubectl "
+                                + "--request-timeout=0 --namespace=test-namespace top po test-pod "
+                                + "--containers' in account: mock-account failed. Error: Unable to "
+                                + "connect to the server: net/http: TLS handshake timeout"))
+            .collect(Collectors.toList());
+
+    // we should only see 1 failed retry attempt message per thread
+    assertThat(numberOfFailedRetryAttemptLogMessages.size()).isEqualTo(numberOfThreads);
+  }
+
+  @DisplayName(
+      "parameterized test to verify retry behavior for errors that are not configured to be retryable")
+  @ParameterizedTest(
+      name = "{index} ==> number of simultaneous executions of the action under test = {0}")
+  @ValueSource(ints = {1, 10})
+  void kubectlMultiThreadedRetryHandlingForErrorsThatAreNotConfiguredToBeRetryable(
+      int numberOfThreads) {
+    // setup
     kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(true);
-    kubernetesConfigurationProperties.getJobExecutor().getRetries().setBackOffInMs(500);
+
+    // to test log messages
+    Logger logger = (Logger) LoggerFactory.getLogger(KubectlJobExecutor.class);
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+    logger.addAppender(listAppender);
+    listAppender.start();
+
+    final ExecutorService executor =
+        Executors.newFixedThreadPool(
+            numberOfThreads,
+            new ThreadFactoryBuilder()
+                .setNameFormat(KubectlJobExecutorTest.class.getSimpleName() + "-%d")
+                .build());
+
+    final ArrayList<Future<ImmutableList<KubernetesPodMetric>>> futures =
+        new ArrayList<>(numberOfThreads);
+
+    // when
+    when(jobExecutor.runJob(any(JobRequest.class)))
+        .thenReturn(
+            JobResult.<String>builder()
+                .result(Result.FAILURE)
+                .output("")
+                .error("un-retryable error")
+                .build());
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+            jobExecutor, kubernetesConfigurationProperties, new SimpleMeterRegistry());
 
-    KubectlJobExecutor.KubectlException thrown =
-        assertThrows(
-            KubectlJobExecutor.KubectlException.class,
-            () -> kubectlJobExecutor.topPod(mockKubernetesCredentials(), "test", "test-pod"));
+    for (int i = 1; i <= numberOfThreads; i++) {
+      futures.add(
+          executor.submit(
+              () -> kubectlJobExecutor.topPod(mockKubernetesCredentials(), NAMESPACE, "test-pod")));
+    }
 
-    // should be called 3 times as there were max 3 attempts made
-    verify(jobExecutor, times(3)).runJob(any(JobRequest.class));
+    // then
+    for (Future<ImmutableList<KubernetesPodMetric>> future : futures) {
+      try {
+        future.get();
+      } catch (final ExecutionException e) {
+        assertTrue(e.getCause() instanceof KubectlJobExecutor.KubectlException);
+        assertTrue(e.getMessage().contains("un-retryable error"));
+      } catch (final InterruptedException ignored) {
+      }
+    }
 
-    // at the end of retries, the exception should still be thrown
-    assertTrue(
-        thrown
-            .getMessage()
-            .contains("Unable to connect to the server: net/http: TLS handshake timeout"));
+    executor.shutdown();
+
+    // verify that the kubectl job executor tried once to execute the action once per thread
+    verify(jobExecutor, times(numberOfThreads)).runJob(any(JobRequest.class));
+
+    // verify retry registry
+    assertTrue(kubectlJobExecutor.getRetryRegistry().isPresent());
+    RetryRegistry retryRegistry = kubectlJobExecutor.getRetryRegistry().get();
+    assertThat(retryRegistry.getAllRetries().size()).isEqualTo(1);
+    assertThat(retryRegistry.getAllRetries().get(0).getName()).isEqualTo("mock-account");
+
+    // verify retry metrics
+    Retry.Metrics retryMetrics = retryRegistry.getAllRetries().get(0).getMetrics();
+    assertThat(retryMetrics.getNumberOfSuccessfulCallsWithRetryAttempt()).isEqualTo(0);
+    assertThat(retryMetrics.getNumberOfSuccessfulCallsWithoutRetryAttempt()).isEqualTo(0);
+    assertThat(retryMetrics.getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(0);
+    // in this test, all threads failed without retrying. So number of unique failed calls == 1 per
+    // thread.
+    assertThat(retryMetrics.getNumberOfFailedCallsWithoutRetryAttempt()).isEqualTo(numberOfThreads);
+
+    // verify that no duplicate messages are shown in the logs
+    List<ILoggingEvent> logsList = listAppender.list;
+    List<ILoggingEvent> numberOfFailedRetryAttemptLogMessages =
+        logsList.stream()
+            .filter(
+                iLoggingEvent ->
+                    iLoggingEvent
+                        .getFormattedMessage()
+                        .contains(
+                            "Not retrying command: 'kubectl --request-timeout=0 --namespace=test-namespace"
+                                + " top po test-pod --containers' in account: mock-account as retries are not"
+                                + " enabled for error: un-retryable error"))
+            .collect(Collectors.toList());
+
+    // we should only see 1 failed retry attempt message per thread
+    assertThat(numberOfFailedRetryAttemptLogMessages.size()).isEqualTo(numberOfThreads);
   }
 
   @Test
-  void kubectlRetryHandlingForConfiguredErrorsThatSucceedsAfterAFewRetries() throws IOException {
-    JobExecutor jobExecutor = mock(JobExecutor.class);
+  void kubectlRetryHandlingForConfiguredErrorsThatSucceedAfterAFewRetries() throws IOException {
+    // setup
+    kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(true);
+
+    // to test log messages
+    Logger logger = (Logger) LoggerFactory.getLogger(KubectlJobExecutor.class);
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+    logger.addAppender(listAppender);
+    listAppender.start();
+
+    // when
     when(jobExecutor.runJob(any(JobRequest.class)))
         .thenReturn(
             JobResult.<String>builder()
@@ -190,22 +438,55 @@ final class KubectlJobExecutorTest {
                 .error("")
                 .build());
 
-    KubernetesConfigurationProperties kubernetesConfigurationProperties =
-        new KubernetesConfigurationProperties();
-    kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(true);
-    kubernetesConfigurationProperties.getJobExecutor().getRetries().setBackOffInMs(500);
-
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+            jobExecutor, kubernetesConfigurationProperties, new SimpleMeterRegistry());
 
     Collection<KubernetesPodMetric> podMetrics =
         kubectlJobExecutor.topPod(mockKubernetesCredentials(), NAMESPACE, "test-pod");
-    assertThat(podMetrics).hasSize(2);
 
-    // should only be called twice as it failed on the first call but succeeded in the second one
+    // then
+
+    // job executor should be called twice - as it failed on the first call but succeeded
+    // in the second one
     verify(jobExecutor, times(2)).runJob(any(JobRequest.class));
 
+    // verify retry registry
+    assertTrue(kubectlJobExecutor.getRetryRegistry().isPresent());
+    RetryRegistry retryRegistry = kubectlJobExecutor.getRetryRegistry().get();
+    assertThat(retryRegistry.getAllRetries().size()).isEqualTo(1);
+    assertThat(retryRegistry.getAllRetries().get(0).getName()).isEqualTo("mock-account");
+
+    // verify retry metrics
+    Retry.Metrics retryMetrics = retryRegistry.getAllRetries().get(0).getMetrics();
+    // in this test, the action succeeded eventually. So number of unique calls == 1.
+    assertThat(retryMetrics.getNumberOfSuccessfulCallsWithRetryAttempt()).isEqualTo(1);
+    assertThat(retryMetrics.getNumberOfSuccessfulCallsWithoutRetryAttempt()).isEqualTo(0);
+    assertThat(retryMetrics.getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(0);
+    assertThat(retryMetrics.getNumberOfFailedCallsWithoutRetryAttempt()).isEqualTo(0);
+
+    // verify that no duplicate messages are shown in the logs
+    List<ILoggingEvent> logsList = listAppender.list;
+    List<ILoggingEvent> numberOfSucceededRetryAttemptsLogMessages =
+        logsList.stream()
+            .filter(
+                iLoggingEvent ->
+                    iLoggingEvent
+                        .getFormattedMessage()
+                        .contains(
+                            "Kubectl command for mock-account is now successful in attempt #2. Last "
+                                + "attempt had failed with exception: com.netflix.spinnaker.clouddriver"
+                                + ".kubernetes.op.job.KubectlJobExecutor$KubectlException: command: "
+                                + "'kubectl --request-timeout=0 --namespace=test-namespace top po test-pod"
+                                + " --containers' in account: mock-account failed. Error: Unable to connect to"
+                                + " the server: net/http: TLS handshake timeout"))
+            .collect(Collectors.toList());
+
+    // we should only see 1 succeeded retry attempt message
+    assertThat(numberOfSucceededRetryAttemptsLogMessages.size()).isEqualTo(1);
+
+    // verify output of the command
+    assertThat(podMetrics).hasSize(2);
     ImmutableSetMultimap<String, ContainerMetric> expectedMetrics =
         ImmutableSetMultimap.<String, ContainerMetric>builder()
             .putAll(
@@ -244,55 +525,19 @@ final class KubectlJobExecutorTest {
     }
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void kubectlJobExecutorHandlingForErrorsThatAreNotConfiguredToBeRetryable(
-      boolean retriesEnabled) {
-    JobExecutor jobExecutor = mock(JobExecutor.class);
-    when(jobExecutor.runJob(any(JobRequest.class)))
-        .thenReturn(
-            JobResult.<String>builder()
-                .result(Result.FAILURE)
-                .output("")
-                .error("un-retryable error")
-                .build());
-
-    KubernetesConfigurationProperties kubernetesConfigurationProperties =
-        new KubernetesConfigurationProperties();
-    kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(retriesEnabled);
-
-    KubectlJobExecutor kubectlJobExecutor =
-        new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
-
-    KubectlJobExecutor.KubectlException thrown =
-        assertThrows(
-            KubectlJobExecutor.KubectlException.class,
-            () -> kubectlJobExecutor.topPod(mockKubernetesCredentials(), "test", ""));
-
-    assertTrue(thrown.getMessage().contains("un-retryable error"));
-    // should only be called once as no retries are performed for this error
-    verify(jobExecutor).runJob(any(JobRequest.class));
-  }
-
-  @ParameterizedTest
+  @ParameterizedTest(name = "{index} ==> retries enabled = {0}")
   @ValueSource(booleans = {true, false})
   void kubectlJobExecutorRaisesException(boolean retriesEnabled) {
-    JobExecutor jobExecutor = mock(JobExecutor.class);
     when(jobExecutor.runJob(any(JobRequest.class)))
         .thenThrow(new JobExecutionException("unknown exception", new IOException()));
 
-    KubernetesConfigurationProperties kubernetesConfigurationProperties =
-        new KubernetesConfigurationProperties();
-
     if (retriesEnabled) {
       kubernetesConfigurationProperties.getJobExecutor().getRetries().setEnabled(true);
-      kubernetesConfigurationProperties.getJobExecutor().getRetries().setBackOffInMs(500);
     }
 
     KubectlJobExecutor kubectlJobExecutor =
         new KubectlJobExecutor(
-            jobExecutor, "kubectl", "oauth2l", kubernetesConfigurationProperties);
+            jobExecutor, kubernetesConfigurationProperties, new SimpleMeterRegistry());
 
     JobExecutionException thrown =
         assertThrows(

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/job/mock-kubectl-stdin-command.sh
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/op/job/mock-kubectl-stdin-command.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Copyright 2022 Salesforce, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+# This script is meant to mock kubectl apply -f - commands in unit tests. The functionality
+# being tested is simply the fact that the retry attempts for such calls continue to read
+# data from stdin. To simulate retries, we exit the script with an error that is configured
+# to be retryable as long as $1 != "success"
+input=$(cat -)
+# simulate error case
+if [ "$1" != "success" ]
+then
+  echo "\n########################" >&2
+  echo "data received from stdin: $input" >&2
+  echo "Error: TLS handshake timeout" >&2
+  echo "########################" >&2
+  exit 1
+else
+  echo "$input"
+fi


### PR DESCRIPTION
Turns out the changes from https://github.com/spinnaker/clouddriver/pull/5401 needed some adjustment.

## Purpose

* add tests to show duplicate logs aren't being printed when multiple threads are running the same command
* add metrics support for capturing retries.
* refactor criteria that decides if an error should be retried. This is needed so that metrics are reported correctly
* refactor tests
* add short custom log messages for retries instead of the default verbose ones

Here are some log messages showing that retries help in fixing the problem in subsequent attempts:
```
{"@timestamp":"2021-11-12T16:55:15.987+00:00","@version":1,"message":"Retrying kubectl command for my-account Attempt #1 failed with exception: com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor$KubectlException: command: 'kubectl --namespace=test -o json get job my-job' in account: my-account failed. Error: Unable to connect to the server: net/http: TLS handshake timeout\n","logger_name":"com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor","thread_name":"http-nio-7002-exec-13","level":"INFO","level_value":20000}
{"@timestamp":"2021-11-12T16:55:32.037+00:00","@version":1,"message":"Kubectl command for my-account is now successful in attempt #2. Last attempt had failed with exception: com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor$KubectlException: command: 'kubectl --namespace=test -o json get job my-job' in account: my-account failed. Error: Unable to connect to the server: net/http: TLS handshake timeout\n","logger_name":"com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor","thread_name":"http-nio-7002-exec-13","level":"INFO","level_value":20000}
```
