### PR TITLE
fix(permissions): Added evaluator case when fiat is enabled

### DIFF
--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizerService.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizerService.java
@@ -114,9 +114,7 @@ public class DescriptionAuthorizerService {
       && (
       (resourceTypes.contains(ResourceType.ACCOUNT)
         && !secretManager.canAccessAccountWithSecrets(account))
-        || (
-        auth != null
-          && !fiatPermissionEvaluator.hasPermission(auth, account, "ACCOUNT", "WRITE")))) {
+        && (auth != null && !fiatPermissionEvaluator.hasPermission(auth, account, "ACCOUNT", "WRITE")))) {
       hasPermission = false;
       errors.reject("authorization.account", format("Access denied to account %s", account));
     }

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizerService.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizerService.java
@@ -111,10 +111,10 @@ public class DescriptionAuthorizerService {
 
     boolean hasPermission = true;
     if (account != null
-      && (
-      (resourceTypes.contains(ResourceType.ACCOUNT)
-        && !secretManager.canAccessAccountWithSecrets(account))
-        && (auth != null && !fiatPermissionEvaluator.hasPermission(auth, account, "ACCOUNT", "WRITE")))) {
+        && ((resourceTypes.contains(ResourceType.ACCOUNT)
+                && !secretManager.canAccessAccountWithSecrets(account))
+            && (auth != null
+                && !fiatPermissionEvaluator.hasPermission(auth, account, "ACCOUNT", "WRITE")))) {
       hasPermission = false;
       errors.reject("authorization.account", format("Access denied to account %s", account));
     }

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizerService.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizerService.java
@@ -110,9 +110,13 @@ public class DescriptionAuthorizerService {
     }
 
     boolean hasPermission = true;
-    if (resourceTypes.contains(ResourceType.ACCOUNT)
-        && account != null
-        && !secretManager.canAccessAccountWithSecrets(account)) {
+    if (account != null
+      && (
+      (resourceTypes.contains(ResourceType.ACCOUNT)
+        && !secretManager.canAccessAccountWithSecrets(account))
+        || (
+        auth != null
+          && !fiatPermissionEvaluator.hasPermission(auth, account, "ACCOUNT", "WRITE")))) {
       hasPermission = false;
       errors.reject("authorization.account", format("Access denied to account %s", account));
     }

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizerServiceSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizerServiceSpec.groovy
@@ -118,7 +118,7 @@ class DescriptionAuthorizerServiceSpec extends Specification {
 
     where:
     resourceType              || expectedNumberOfAuthChecks | expectedNumberOfErrors
-    ResourceType.APPLICATION  || 3                          | 3
+    ResourceType.APPLICATION  || 4                          | 4
     ResourceType.ACCOUNT      || 0                          | 1
   }
 

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizerServiceSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizerServiceSpec.groovy
@@ -65,7 +65,7 @@ class DescriptionAuthorizerServiceSpec extends Specification {
     service.authorize(description, errors)
 
     then:
-    3 * evaluator.hasPermission(*_) >> false
+    4 * evaluator.hasPermission(*_) >> false
     1 * evaluator.storeWholePermission()
     errors.allErrors.size() == 4
   }
@@ -83,15 +83,15 @@ class DescriptionAuthorizerServiceSpec extends Specification {
     service.authorize(description, errors)
 
     then:
-    0 * evaluator.hasPermission(*_) >> false
+    expectedNumberOfInvocations * evaluator.hasPermission(*_) >> false
     0 * evaluator.storeWholePermission()
     errors.allErrors.size() == expectedNumberOfErrors
 
     where:
-    allowUnauthenticatedImageTaggingInAccounts || expectedNumberOfErrors
-    ["testAccount"]                            || 0
-    ["anotherAccount"]                         || 1
-    []                                         || 1
+    allowUnauthenticatedImageTaggingInAccounts || expectedNumberOfErrors || expectedNumberOfInvocations
+    ["testAccount"]                            || 0                      || 0
+    ["anotherAccount"]                         || 1                      || 1
+    []                                         || 1                      || 1
   }
 
   @Unroll
@@ -118,8 +118,8 @@ class DescriptionAuthorizerServiceSpec extends Specification {
 
     where:
     resourceType              || expectedNumberOfAuthChecks | expectedNumberOfErrors
-    ResourceType.APPLICATION  || 4                          | 4
-    ResourceType.ACCOUNT      || 0                          | 1
+    ResourceType.APPLICATION  || 3                          | 3
+    ResourceType.ACCOUNT      || 1                          | 1
   }
 
   class TestDescription implements AccountNameable, ApplicationNameable, ResourcesNameable {


### PR DESCRIPTION
When fiat is enabled and validation for accounts without roles is requested, the access is denied by emptyRoles condition, so when a dummy role is set this condition is skipped. Adding extra old fiat validator we preserved a consistent behaviour on accounts with roles vs without roles


Steps to reproduce issue:
With fiat enabled create 2 serviceAccounts, one with role, and other without role
<img width="573" alt="image" src="https://user-images.githubusercontent.com/21283264/213018648-ca3775f6-4b3c-4438-994e-046492eeac79.png">

Try apply ops operations like scale manifest deployment with different accounts, so we gonna have the inconsistent scenario where dummy roled account is succeeded  and empty role account received a denied access error

Account without roles:
<img width="623" alt="image" src="https://user-images.githubusercontent.com/21283264/213020273-b84fd872-7b62-43af-a12e-e50c51c35fc3.png">
<img width="1301" alt="image" src="https://user-images.githubusercontent.com/21283264/213020365-ef61fd56-3f71-4142-848e-c5e8dc37f813.png">

Account with dummy roles:
<img width="622" alt="image" src="https://user-images.githubusercontent.com/21283264/213020478-17400a89-d29b-4ebd-bfd8-26bedeb7b640.png">
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/21283264/213020559-297bdcff-728e-4075-8e5c-967e96093442.png">


Use case for empty role accounts was introduced in https://github.com/spinnaker/clouddriver/commit/da657157d6f8c7050ee577e147db99c9936b0b72
previously accounts without roles were working
