### PR TITLE
fix(google): make AbstractAtomicOperationsCredentialsConverter generic type

### DIFF
--- a/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/deploy/converters/SetStatefulDiskAtomicOperationConverter.java
+++ b/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/deploy/converters/SetStatefulDiskAtomicOperationConverter.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.google.compute.GoogleComputeApiFactory;
 import com.netflix.spinnaker.clouddriver.google.deploy.description.SetStatefulDiskDescription;
 import com.netflix.spinnaker.clouddriver.google.deploy.ops.SetStatefulDiskAtomicOperation;
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider;
+import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsConverter;
 import java.util.Map;
@@ -30,7 +31,7 @@ import org.springframework.stereotype.Component;
 @GoogleOperation(AtomicOperations.SET_STATEFUL_DISK)
 @Component
 public class SetStatefulDiskAtomicOperationConverter
-    extends AbstractAtomicOperationsCredentialsConverter {
+    extends AbstractAtomicOperationsCredentialsConverter<GoogleNamedAccountCredentials> {
 
   private final GoogleClusterProvider clusterProvider;
   private final GoogleComputeApiFactory computeApiFactory;

--- a/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/deploy/converters/StatefullyUpdateBootImageOperationConverter.java
+++ b/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/deploy/converters/StatefullyUpdateBootImageOperationConverter.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProper
 import com.netflix.spinnaker.clouddriver.google.deploy.description.StatefullyUpdateBootImageDescription;
 import com.netflix.spinnaker.clouddriver.google.deploy.ops.StatefullyUpdateBootImageAtomicOperation;
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider;
+import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsConverter;
 import java.util.Map;
@@ -31,7 +32,7 @@ import org.springframework.stereotype.Component;
 @GoogleOperation(AtomicOperations.STATEFULLY_UPDATE_BOOT_IMAGE)
 @Component
 public class StatefullyUpdateBootImageOperationConverter
-    extends AbstractAtomicOperationsCredentialsConverter {
+    extends AbstractAtomicOperationsCredentialsConverter<GoogleNamedAccountCredentials> {
 
   private final GoogleClusterProvider clusterProvider;
   private final GoogleComputeApiFactory computeApiFactory;


### PR DESCRIPTION
There are a couple of classes which extended AbstractAtomicOperationsCredentialsConverter but without being a generic type causing it to work fine with google accounts alone but fails when kubernetes accounts get added. 
This PR will fix the issue ([#6796](https://github.com/spinnaker/spinnaker/issues/6796))