### PR TITLE
fix(kubernetes): Revert to using the dockerImage Artifact Replacer for cronjobs

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/Replacer.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/Replacer.java
@@ -165,6 +165,12 @@ public final class Replacer {
 
   private static final Replacer DOCKER_IMAGE =
       builder()
+          // This matches not only resources where the path is
+          // e.g. .spec.template.spec.containers.[0].image (e.g. deployments and
+          // jobs), but also where the path is
+          // .spec.jobTemplate.spec.containers[0].image (e.g. cronjobs).  The
+          // double dot at the beginning is a "descendant selector".  See
+          // https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-01.html#section-3.5.7.
           .path("$..spec.template.spec['containers', 'initContainers'].[?].image")
           .legacyReplaceFilter(a -> filter(where("image").is(a.getName())))
           .replacePathFromPlaceholder("image")
@@ -278,14 +284,6 @@ public final class Replacer {
           .type(KubernetesArtifactType.ReplicaSet)
           .build();
 
-  private static final Replacer CRON_JOB_DOCKER_IMAGE =
-      builder()
-          .path("$.spec.jobTemplate.spec.template.spec.containers.[?].image")
-          .legacyReplaceFilter(a -> filter(where("image").is(a.getName())))
-          .replacePathFromPlaceholder("image")
-          .type(KubernetesArtifactType.DockerImage)
-          .build();
-
   public static Replacer dockerImage() {
     return DOCKER_IMAGE;
   }
@@ -332,9 +330,5 @@ public final class Replacer {
 
   public static Replacer hpaReplicaSet() {
     return HPA_REPLICA_SET;
-  }
-
-  public static Replacer cronJobDockerImage() {
-    return CRON_JOB_DOCKER_IMAGE;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesCronJobHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesCronJobHandler.java
@@ -41,7 +41,7 @@ public class KubernetesCronJobHandler extends KubernetesHandler
   @Override
   protected ImmutableList<Replacer> artifactReplacers() {
     return ImmutableList.of(
-        Replacer.cronJobDockerImage(),
+        Replacer.dockerImage(),
         Replacer.configMapVolume(),
         Replacer.secretVolume(),
         Replacer.configMapProjectedVolume(),


### PR DESCRIPTION
PR #5554 updated the docker image artifact replacer for K8s Cronjobs. While it works if there is no tag defined in the manifest, it fails if there is a tag defined in the manifest and the artifact binding strategy is set to `match-name-and-tag`. 
Commit: https://github.com/spinnaker/clouddriver/pull/5876/commits/e55cbcb1769cbb6ec70bf0087697fcac9e9a0f37 adds a test that demonstrates that failure. With the artifact replacer set to `dockerImage()`, we don't see that failure. 