### PR TITLE
Two credentials with same accountId confuses EcrImageProvider

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProvider.java
@@ -89,7 +89,7 @@ public class EcrImageProvider implements ImageRepositoryProvider {
         !(identifier.startsWith("sha256:") && identifier.length() == ("sha256:".length() + 64));
     String region = extractAwsRegion(url);
 
-    NetflixAmazonCredentials credentials = getCredentials(accountId);
+    NetflixAmazonCredentials credentials = getCredentials(accountId, region);
 
     if (!isValidRegion(credentials, region)) {
       throw new IllegalArgumentException(
@@ -144,15 +144,18 @@ public class EcrImageProvider implements ImageRepositoryProvider {
         : imageIdentifier.getImageDigest().equals(identifier);
   }
 
-  private NetflixAmazonCredentials getCredentials(String accountId) {
+  private NetflixAmazonCredentials getCredentials(String accountId, String region) {
+
     for (NetflixECSCredentials credentials : credentialsRepository.getAll()) {
-      if (credentials.getAccountId().equals(accountId)) {
+      if (credentials.getAccountId().equals(accountId) &&
+        (credentials.getRegions().isEmpty() || credentials.getRegions().stream().anyMatch(
+          oneRegion -> oneRegion.getName().equals(region)))) {
         return credentials;
       }
     }
     throw new NotFoundException(
         String.format(
-            "AWS account %s was not found.  Please specify a valid account name", accountId));
+            "AWS account %s with region %s was not found.  Please specify a valid account name and region", accountId, region));
   }
 
   private List<ImageIdentifier> getImageIdentifiers(

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProviderSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProviderSpec.groovy
@@ -136,6 +136,65 @@ class EcrImageProviderSpec extends Specification {
     retrievedListOfImages == expectedListOfImages
   }
 
+  def 'should find second credential when two share account ids'() {
+    given:
+    def region = 'us-east-1'
+    def repoName = 'repositoryname'
+    def accountId = '123456789012'
+    def tag = 'arbitrary-tag'
+    def digest = 'sha256:deadbeef785192c146085da66a4261e25e79a6210103433464eb7f79deadbeef'
+    def creationDate = new Date()
+    def url = accountId + '.dkr.ecr.' + region + '.amazonaws.com/' + repoName + ':' + tag// + '@' + digest
+    def imageDetail = new ImageDetail(
+      repositoryName: repoName,
+      registryId: accountId,
+      imageDigest: digest,
+      imageTags: List.of(tag),
+      imagePushedAt: creationDate
+    )
+
+    Map<String, Object> region1 = Map.of(
+      'name', 'eu-west-1',
+      'availabilityZones', Arrays.asList('us-west-1a', 'us-west-1b', 'us-west-1c')
+    )
+    Map<String, Object> overrides1 = Map.of(
+      'accountId', accountId,
+      'regions', Arrays.asList(region1)
+    )
+
+    Map<String, Object> region2 = Map.of(
+      'name', region,
+      'availabilityZones', Arrays.asList('us-west-1a', 'us-west-1b', 'us-west-1c')
+    )
+    Map<String, Object> overrides2 = Map.of(
+      'accountId', accountId,
+      'regions', Arrays.asList(region2)
+    )
+
+    credentialsRepository.getAll() >> [
+      new NetflixECSCredentials(TestCredential.named('incorrect-region', overrides1)),
+      new NetflixECSCredentials(TestCredential.named('correct-region', overrides2))]
+
+    def amazonECR = Mock(AmazonECR)
+
+    amazonClientProvider.getAmazonEcr(_, _, _) >> amazonECR
+    amazonECR.listImages(_) >> new ListImagesResult().withImageIds(Collections.emptyList())
+    amazonECR.describeImages(_) >> new DescribeImagesResult().withImageDetails(imageDetail)
+
+    def expectedListOfImages = [new EcsDockerImage(
+      region: region,
+      imageName: accountId + '.dkr.ecr.' + region + '.amazonaws.com/' + repoName + '@' + digest,
+      amis: ['us-east-1': Collections.singletonList(digest)],
+      attributes: [creationDate: creationDate]
+    )]
+
+    when:
+    def retrievedListOfImages = provider.findImage(url)
+
+    then:
+    retrievedListOfImages == expectedListOfImages
+  }
+
   def 'should throw exception due to malformed account'() {
     given:
     def region = 'us-west-1'
@@ -198,8 +257,8 @@ class EcrImageProviderSpec extends Specification {
     provider.findImage(url)
 
     then:
-    final IllegalArgumentException error = thrown()
-    error.message == "The repository URI provided does not belong to a region that the credentials have access to or the region is not valid."
+    final com.netflix.spinnaker.kork.web.exceptions.NotFoundException error = thrown()
+    error.message == String.format("AWS account %s with region %s was not found.  Please specify a valid account name and region", accountId, region)
   }
 
   def 'should find the image in a repository with a large number of images'() {


### PR DESCRIPTION
When Autodesk set up our Spinnaker instances, we created separate Credentials for each (accountId, region) duple.

So for example, ('123456789012', 'us-west-1') is one credential, and later on, ('123456789012', 'us-east-1') is a second one.

We discovered that if we attempt to validate a container present in the account's second region (ordering determined by the getCredentials API), then it would fail to validate, because only the account id is matched by the credential search, not the regions within it.

This PR contributes a test that fails on the existing code, and a proposed change to address it.

I'm not 100% happy about including the test for no-regions-specified in the code change I'm offering, but it reduced the number of tests that needed to change; I wasn't sure if the semantics require the regions or not.


We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
