### PR TITLE
fix(gce): fixed the error caused by account removal

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
@@ -229,7 +229,7 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
         moveOnDemandDataToNamespace(cacheResultBuilder, firewall)
       } else {
         cacheResultBuilder.namespace(SECURITY_GROUPS.ns).keep(securityGroupKey).with {
-          attributes = [firewall: firewall]
+          attributes = [firewall: firewall, project: project]
         }
       }
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
@@ -86,7 +86,7 @@ class GoogleSubnetCachingAgent extends AbstractGoogleCachingAgent {
       def subnetKey = Keys.getSubnetKey(deriveSubnetId(subnet), region, accountName)
 
       cacheResultBuilder.namespace(SUBNETS.ns).keep(subnetKey).with {
-        attributes.subnet = subnet
+        attributes.subnet = [subnet: subnet,project: project]
       }
     }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProvider.groovy
@@ -107,20 +107,21 @@ class GoogleSecurityGroupProvider implements SecurityGroupProvider<GoogleSecurit
   GoogleSecurityGroup fromCacheData(boolean includeRules, CacheData cacheData) {
     Map firewall = cacheData.attributes.firewall
     Map<String, String> parts = Keys.parse(cacheData.id)
+    def project = cacheData.attributes.project
 
-    return convertToGoogleSecurityGroup(includeRules, firewall, parts.account, parts.region)
+    return convertToGoogleSecurityGroup(includeRules, firewall, parts.account, parts.region, project)
   }
 
-  private GoogleSecurityGroup convertToGoogleSecurityGroup(boolean includeRules, Map firewall, String account, String region) {
+  private GoogleSecurityGroup convertToGoogleSecurityGroup(boolean includeRules, Map firewall, String account, String region, String project) {
     List<Rule> inboundRules = includeRules ? buildInboundIpRangeRules(firewall) : []
 
     new GoogleSecurityGroup(
-      id: deriveResourceId(account, firewall.selfLink),
+      id: deriveResourceId(project, firewall.selfLink),
       name: firewall.name,
       description: firewall.description,
       accountName: account,
       region: region,
-      network: deriveResourceId(account, firewall.network),
+      network: deriveResourceId(project, firewall.network),
       selfLink: firewall.selfLink,
       sourceTags: firewall.sourceTags,
       targetTags: firewall.targetTags,
@@ -233,14 +234,8 @@ class GoogleSecurityGroupProvider implements SecurityGroupProvider<GoogleSecurit
     } ?: []
   }
 
-  private String deriveResourceId(String account, String resourceLink) {
-    def accountCredentials = credentialsRepository.getOne(account)
+  private String deriveResourceId(String project, String resourceLink) {
 
-    if (!(accountCredentials instanceof GoogleNamedAccountCredentials)) {
-      throw new IllegalArgumentException("Invalid credentials: $account")
-    }
-
-    def project = accountCredentials.project
     def firewallProject = GCEUtil.deriveProjectId(resourceLink)
     def firewallId = GCEUtil.getLocalName(resourceLink)
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSubnetProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSubnetProvider.groovy
@@ -67,13 +67,14 @@ class GoogleSubnetProvider implements SubnetProvider<GoogleSubnet> {
   GoogleSubnet fromCacheData(CacheData cacheData) {
     Map subnet = cacheData.attributes.subnet
     Map<String, String> parts = Keys.parse(cacheData.id)
+    def project = cacheData.attributes.project
 
     new GoogleSubnet(
       type: this.cloudProvider,
       id: parts.id,
       name: subnet.name,
       gatewayAddress: subnet.gatewayAddress,
-      network: deriveNetworkId(parts.account, subnet),
+      network: deriveNetworkId(project, subnet),
       cidrBlock: subnet.ipCidrRange,
       account: parts.account,
       region: parts.region,
@@ -82,14 +83,8 @@ class GoogleSubnetProvider implements SubnetProvider<GoogleSubnet> {
     )
   }
 
-  private String deriveNetworkId(String account, Map subnet) {
-    def accountCredentials = accountCredentialsProvider.getCredentials(account)
+  private String deriveNetworkId(String project, Map subnet) {
 
-    if (!(accountCredentials instanceof GoogleNamedAccountCredentials)) {
-      throw new IllegalArgumentException("Invalid credentials: $account")
-    }
-
-    def project = accountCredentials.project
     def networkProject = GCEUtil.deriveProjectId(subnet.network)
     def networkId = GCEUtil.getLocalName(subnet.network)
 

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgentSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgentSpec.groovy
@@ -1,0 +1,55 @@
+package com.netflix.spinnaker.clouddriver.google.provider.agent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.api.services.compute.Compute
+import com.google.api.services.compute.model.Subnetwork
+import com.google.api.services.compute.model.SubnetworkList
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.google.cache.Keys
+import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
+import spock.lang.Specification
+import spock.lang.Subject
+
+class GoogleSubnetCachingAgentSpec extends Specification {
+  static final String PROJECT_NAME = "my-project"
+  static final String REGION = 'us-east1'
+  static final String ACCOUNT_NAME = 'some-account-name'
+
+  void "should add subnets and cache project name as an attribute to cacheData"() {
+    setup:
+    def registry = new DefaultRegistry()
+    def computeMock = Mock(Compute)
+    def credentials = new GoogleNamedAccountCredentials.Builder().project(PROJECT_NAME).name(ACCOUNT_NAME).compute(computeMock).build()
+    def subnetsMock = Mock(Compute.Subnetworks)
+    def subnetworksListMock = Mock(Compute.Subnetworks.List)
+    def subnetA = new Subnetwork(name: 'name-a',
+      selfLink: 'https://compute.googleapis.com/compute/v1/projects/my-project/us-east1/subnetworks/name-a')
+    def keyGroupA = Keys.getSubnetKey(subnetA.name as String,
+      REGION,
+      ACCOUNT_NAME)
+    def SubnetsListReal = new SubnetworkList(items: [subnetA])
+    def ProviderCache providerCache = Mock(ProviderCache)
+    @Subject GoogleSubnetCachingAgent agent = new GoogleSubnetCachingAgent("testApplicationName",
+      credentials,
+      new ObjectMapper(),
+      registry,REGION)
+
+    when:
+    def cache = agent.loadData(providerCache)
+
+    then:
+    1 * computeMock.subnetworks() >> subnetsMock
+    1 * subnetsMock.list(PROJECT_NAME,REGION) >> subnetworksListMock
+    1 * subnetworksListMock.execute() >> SubnetsListReal
+    with(cache.cacheResults.get(Keys.Namespace.SUBNETS.ns)) { Collection<CacheData> cd ->
+      cd.stream().forEach( {
+        Map<String,Object> attributes= it.getAttributes()
+        attributes.get(0) == "my-project"
+      })
+      cd.id.containsAll([keyGroupA])
+    }
+  }
+
+}

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProviderSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProviderSpec.groovy
@@ -285,6 +285,8 @@ class GoogleSecurityGroupProviderSpec extends Specification {
       cachedValue.inboundRules[1].portRanges.endPort == [65535]
   }
 
+
+
   @Shared
   Map<String, Map<String, List<Firewall>>> firewallMap = [
     prod: [
@@ -359,7 +361,7 @@ class GoogleSecurityGroupProviderSpec extends Specification {
     firewallMap.collect { String account, Map<String, List<Firewall>> regions ->
       regions.collect { String region, List<Firewall> firewalls ->
         firewalls.collect { Firewall firewall ->
-          Map<String, Object> attributes = [firewall: firewall]
+          Map<String, Object> attributes = [firewall: firewall, project: 'my-project']
           new DefaultCacheData(Keys.getSecurityGroupKey(firewall.getName(), firewall.getName(), "global", account), attributes, [:])
         }
       }.flatten()

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSubnetProviderSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSubnetProviderSpec.groovy
@@ -1,0 +1,73 @@
+package com.netflix.spinnaker.clouddriver.google.provider.view
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.api.services.compute.Compute
+import com.google.api.services.compute.model.Subnetwork
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.cats.cache.WriteableCache
+import com.netflix.spinnaker.cats.mem.InMemoryCache
+import com.netflix.spinnaker.clouddriver.google.cache.Keys
+import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+class GoogleSubnetProviderSpec extends Specification {
+  @Subject
+  GoogleSubnetProvider provider
+
+  WriteableCache cache = new InMemoryCache()
+  ObjectMapper mapper = new ObjectMapper()
+
+  def setup() {
+    def accountCredentialsProvider =  new DefaultAccountCredentialsProvider()
+    provider = new GoogleSubnetProvider(accountCredentialsProvider, cache, mapper)
+    cache.mergeAll(Keys.Namespace.SUBNETS.ns, getAllSubnets())
+  }
+
+  void "getAll lists all"() {
+    when:
+    def result = provider.getAll()
+
+    then:
+    result.size() == 2
+  }
+
+  @Shared
+  Map<String, List<Compute.Subnetworks>> subnetsMap = [
+    'us-central1': [
+      new Subnetwork(
+        name: 'a',
+        gatewayAddress: '10.0.0.1',
+        id: 6614377178691015953,
+        ipCidrRange: '10.0.0.0/24',
+        network: 'https://compute.googleapis.com/compute/v1/projects/my-project/global/networks/default',
+        regionUrl: 'https://compute.googleapis.com/compute/v1/projects/my-project/regions/us-central1',
+        selfLink: 'https://compute.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/a'
+      )
+    ],
+    'asia-south1':[
+      new Subnetwork(
+        name: 'b',
+        gatewayAddress: '10.1.0.1',
+        id: 6614377178691015954,
+        ipCidrRange: '10.1.0.0/24',
+        network: 'https://compute.googleapis.com/compute/v1/projects/my-project/global/networks/default',
+        regionUrl: 'https://compute.googleapis.com/compute/v1/projects/my-project/regions/asia-south1',
+        selfLink: 'https://compute.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/b'
+      ),
+    ]
+  ]
+
+
+  private List<CacheData> getAllSubnets() {
+    String account = 'my-account'
+    subnetsMap.collect { String regions, List<Subnetwork> region ->
+      region.collect { Subnetwork subnet ->
+        Map<String, Object> attributes = [subnet: subnet,project: "my-project"]
+        new DefaultCacheData(Keys.getSubnetKey(subnet.getName(),"global", account), attributes, [:])
+      }
+    }.flatten()
+  }
+}


### PR DESCRIPTION
As mentioned in issue [https://github.com/spinnaker/spinnaker/issues/6800](url) this PR is a fix for the error which is being caused every time the /securityGroups and subnets are queried. As part of the fix, the project name is added as an attribute by GoogleSecurityGroupCachingAgent and GoogleSubnetCachingAgent. So that when the securityGroups and subnets are queried there is no need to derive the project Id from the GoogleNamedAccountCredentials because when an account is removed the accountCredentials become null and the project id cannot be found in that case and hence the exception was being thrown.
