### PR TITLE
fix(aws): don't log empty warning BasicAmazonDeployDescriptionValidator.validate

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidator.groovy
@@ -92,7 +92,9 @@ class BasicAmazonDeployDescriptionValidator extends AmazonDescriptionValidationS
 
     // log warnings
     final String warnings = getWarnings(description)
-    log.warn(warnings)
+    if (!warnings.isEmpty()) {
+      log.warn(warnings)
+    }
   }
 
   /**


### PR DESCRIPTION
It pollutes the log and isn't otherwise helpful.
