### PR TITLE
fix(core): Renamed a query parameter for template tags

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
@@ -69,7 +69,7 @@ interface Front50Service {
   // v2 MPT APIs
   @GET('/v2/pipelineTemplates/{pipelineTemplateId}')
   Map getV2PipelineTemplate(@Path("pipelineTemplateId") String pipelineTemplateId,
-                            @Query("version") String version,
+                            @Query("tag") String version,
                             @Query("digest") String digest)
 
   @GET('/v2/pipelineTemplates')


### PR DESCRIPTION
The parameter in the Front50 API is called `tag`, but in the Retrofit client it's called `version`. Because of this, Clouddriver ignores the tags during template lookup. 
The parameter in the API: https://github.com/spinnaker/front50/blob/a2f188767a1f9584452e6ab61c555dd1a630c468/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateController.java#L151

This PR fixes the issue: https://github.com/spinnaker/spinnaker/issues/6583
