### PR TITLE
fix(gce): remove the duplicate cache attribute "subnet"

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
@@ -86,7 +86,7 @@ class GoogleSubnetCachingAgent extends AbstractGoogleCachingAgent {
       def subnetKey = Keys.getSubnetKey(deriveSubnetId(subnet), region, accountName)
 
       cacheResultBuilder.namespace(SUBNETS.ns).keep(subnetKey).with {
-        attributes.subnet = [subnet: subnet,project: project]
+        attributes = [subnet: subnet,project: project]
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/6813

The `attributes.subnet` is causing the `project` and `subnet` fields nested within `subnet` while creating the cache causing the failure to derive subnet.

```
{
  "subnet": {
      "project": "***",
      "subnet": {
        "aggregationInterval": "INTERVAL_5_SEC",
        "allowSubnetCidrRoutesOverlap": false,
        "creationTimestamp": "2017-02-07T16:17:36.327-08:00",
        "enableFlowLogs": false,
        "fingerprint": "***",
      }
}
```

Expected is 

```
{
    "project": "***",
    "subnet": {
      "aggregationInterval": "INTERVAL_5_SEC",
      "allowSubnetCidrRoutesOverlap": false,
      "creationTimestamp": "2017-02-07T16:17:36.327-08:00",
      "enableFlowLogs": false,
      "fingerprint": "***",
     }
}
```