### PR TITLE
refactor(deprecation): remove deprecated gradle constructs/features from clouddriver in order to upgrade gradle 7

### DIFF
--- a/clouddriver-azure/clouddriver-azure.gradle
+++ b/clouddriver-azure/clouddriver-azure.gradle
@@ -16,9 +16,7 @@ dependencies {
   implementation "com.azure.resourcemanager:azure-resourcemanager:2.19.0"
   implementation "com.azure:azure-identity:1.6.0"
   implementation "com.azure:azure-storage-blob:12.19.1"
-  implementation("io.projectreactor:reactor-core:3.4.23") {
-    force = true
-  }
+  implementation "io.projectreactor:reactor-core"
   implementation "com.google.guava:guava:31.1-jre"
 
   testImplementation "cglib:cglib-nodep"
@@ -31,4 +29,8 @@ dependencies {
   testImplementation 'org.assertj:assertj-core:3.23.1'
 
 
+}
+
+configurations.all {
+   resolutionStrategy.force 'io.projectreactor:reactor-core:3.4.23'
 }

--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -14,9 +14,7 @@ dependencies {
   implementation "org.codehaus.groovy:groovy"
   implementation "org.codehaus.groovy:groovy-json"
   implementation "org.apache.commons:commons-lang3"
-  implementation ("com.google.apis:google-api-services-compute:beta-rev20201102-1.30.10") {
-    force = true
-  }
+  implementation "com.google.apis:google-api-services-compute"
   implementation "com.google.guava:guava"
   implementation "com.google.apis:google-api-services-iam"
   implementation 'com.google.auth:google-auth-library-oauth2-http'
@@ -51,4 +49,8 @@ dependencies {
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
   testImplementation "org.springframework.boot:spring-boot-test"
+}
+
+configurations.all {
+   resolutionStrategy.force 'com.google.apis:google-api-services-compute:beta-rev20201102-1.30.10'
 }

--- a/clouddriver-yandex/clouddriver-yandex.gradle
+++ b/clouddriver-yandex/clouddriver-yandex.gradle
@@ -14,12 +14,8 @@ dependencies {
   testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation 'com.yandex.cloud:java-sdk-services:2.1.1'
-  compile("io.opencensus:opencensus-api:0.21.0") {
-    force = true
-  }
-  compile("io.opencensus:opencensus-contrib-grpc-metrics:0.21.0") {
-    force = true
-  }
+  compileOnly "io.opencensus:opencensus-api"
+  compileOnly "io.opencensus:opencensus-contrib-grpc-metrics"
   implementation "org.codehaus.groovy:groovy-datetime"
   implementation "org.apache.commons:commons-lang3"
   implementation "com.netflix.frigga:frigga"
@@ -46,4 +42,9 @@ dependencies {
   testImplementation "org.springframework:spring-test"
   testImplementation "org.springframework.boot:spring-boot-test"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
+}
+
+configurations.all {
+   resolutionStrategy.force 'io.opencensus:opencensus-api:0.21.0'
+   resolutionStrategy.force 'io.opencensus:opencensus-contrib-grpc-metrics:0.21.0'
 }


### PR DESCRIPTION
While executing the build script with --warning-mode=fail received below error:
```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0
```
And the deprecated gradle features are:
```
> Configure project :clouddriver-azure
Using force on a dependency has been deprecated. This is scheduled to be removed in Gradle 7.0. Consider using strict version constraints instead (version { strictly ... } }). Consult the upgrading guide for further information: https://docs.gradle.org/6.8.1/userguide/upgrading_version_5.html#forced_dependencies
        at clouddriver_azure_6ftffoxb07xu7lz9bwdhnw53c$_run_closure1$_closure2.doCall(/clouddriver/clouddriver-azure/clouddriver-azure.gradle:20)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
> Configure project :clouddriver-yandex
Using force on a dependency has been deprecated. This is scheduled to be removed in Gradle 7.0. Consider using strict version constraints instead (version { strictly ... } }). Consult the upgrading guide for further information: https://docs.gradle.org/6.8.1/userguide/upgrading_version_5.html#forced_dependencies
        at clouddriver_yandex_5ufhkmiao97ey3emk48be2jrk$_run_closure1$_closure2.doCall(/clouddriver/clouddriver-yandex/clouddriver-yandex.gradle:18)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
> Configure project :clouddriver-google
Using force on a dependency has been deprecated. This is scheduled to be removed in Gradle 7.0. Consider using strict version constraints instead (version { strictly ... } }). Consult the upgrading guide for further information: https://docs.gradle.org/6.8.1/userguide/upgrading_version_5.html#forced_dependencies
        at clouddriver_google_f4jnph9t3vizredbhn83bs760$_run_closure1$_closure2.doCall(/clouddriver/clouddriver-google/clouddriver-google.gradle:18)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```
Tried `(version { strictly ... } })` as suggested by guide, but it didn't work. So refactored it with `resolutionStrategy.force`.

```
> Configure project :clouddriver-yandex
The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the implementation or api configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/6.8.1/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations
        at clouddriver_yandex_5ufhkmiao97ey3emk48be2jrk$_run_closure1.doCall(/clouddriver/clouddriver-yandex/clouddriver-yandex.gradle:17)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```
Replaced `compile` configuration to `compileOnly` configuration.