### PR TITLE
feat: Add the possibility to update the default handler for the Global Resource Property Registry.

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/GlobalResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/GlobalResourcePropertyRegistry.java
@@ -36,7 +36,7 @@ public class GlobalResourcePropertyRegistry implements ResourcePropertyRegistry 
   private final ImmutableMap<KubernetesKind, KubernetesResourceProperties> globalProperties;
   private ImmutableMap<KubernetesKind, KubernetesResourceProperties> crdProperties =
       ImmutableMap.of();
-  private final KubernetesResourceProperties defaultProperties;
+  private KubernetesResourceProperties defaultProperties;
 
   @Autowired
   public GlobalResourcePropertyRegistry(
@@ -48,6 +48,11 @@ public class GlobalResourcePropertyRegistry implements ResourcePropertyRegistry 
                 toImmutableMap(
                     KubernetesHandler::kind,
                     h -> new KubernetesResourceProperties(h, h.versioned())));
+    this.defaultProperties =
+        new KubernetesResourceProperties(defaultHandler, defaultHandler.versioned());
+  }
+
+  public void setDefaultHandler(KubernetesUnregisteredCustomResourceHandler defaultHandler) {
     this.defaultProperties =
         new KubernetesResourceProperties(defaultHandler, defaultHandler.versioned());
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/GlobalResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/GlobalResourcePropertyRegistry.java
@@ -52,7 +52,8 @@ public class GlobalResourcePropertyRegistry implements ResourcePropertyRegistry 
         new KubernetesResourceProperties(defaultHandler, defaultHandler.versioned());
   }
 
-  public void setDefaultHandler(KubernetesUnregisteredCustomResourceHandler defaultHandler) {
+  public void setDefaultHandler(
+      @Nonnull KubernetesUnregisteredCustomResourceHandler defaultHandler) {
     this.defaultProperties =
         new KubernetesResourceProperties(defaultHandler, defaultHandler.versioned());
   }


### PR DESCRIPTION
Unfortunately, it is not possible to override the default handler behavior from a Spinnaker plugin code. Therefore, we have decided to introduce a new setter function specifically designed to address this requirement.





