### PR TITLE
feat(artifacts): Adds ArtifactStore logic to clouddriver

### DIFF
--- a/clouddriver-appengine/src/test/java/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineConfigAtomicOperationTest.java
+++ b/clouddriver-appengine/src/test/java/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineConfigAtomicOperationTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.clouddriver.appengine.deploy.description.DeployAppengineConfigDescription;
 import com.netflix.spinnaker.clouddriver.artifacts.ArtifactDownloader;
+import com.netflix.spinnaker.kork.artifacts.ArtifactTypes;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -73,7 +74,7 @@ public class DeployAppengineConfigAtomicOperationTest {
     artifactMap.put("artifactAccount", "embedded-artifact");
     artifactMap.put("id", "123abc");
     artifactMap.put("reference", "ZG9zb21ldGhpbmc=");
-    artifactMap.put("type", "embedded/base64");
+    artifactMap.put("type", ArtifactTypes.EMBEDDED_BASE64.getMimeType());
     Artifact artifact = mapper.convertValue(artifactMap, Artifact.class);
 
     Path path = null;

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.java
@@ -99,6 +99,9 @@ import com.netflix.spinnaker.credentials.definition.AbstractCredentialsLoader;
 import com.netflix.spinnaker.credentials.poller.PollerConfiguration;
 import com.netflix.spinnaker.credentials.poller.PollerConfigurationProperties;
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactDeserializer;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStore;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreConfiguration;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.kork.jackson.ObjectMapperSubtypeConfigurer;
@@ -108,6 +111,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.inject.Provider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -128,7 +132,8 @@ import org.springframework.web.client.RestTemplate;
   RedisConfig.class,
   CacheConfig.class,
   SearchExecutorConfig.class,
-  PluginsAutoConfiguration.class
+  PluginsAutoConfiguration.class,
+  ArtifactStoreConfiguration.class,
 })
 @PropertySource(
     value = "classpath:META-INF/clouddriver-core.properties",
@@ -417,5 +422,12 @@ class CloudDriverConfig {
     threadPoolTaskScheduler.setPoolSize(threadPoolSize);
     threadPoolTaskScheduler.setThreadNamePrefix("ThreadPoolTaskScheduler");
     return threadPoolTaskScheduler;
+  }
+
+  @Bean
+  @ConditionalOnExpression("${artifact-store.enabled:false}")
+  ArtifactDeserializer artifactDeserializer(
+      ArtifactStore storage, @Qualifier("artifactObjectMapper") ObjectMapper objectMapper) {
+    return new ArtifactDeserializer(objectMapper, storage);
   }
 }


### PR DESCRIPTION
This commit adds artifact storage to clouddriver. The idea in this
commit is artifact will automatically be expanded when the server
receives a request since clouddriver is more than likely interested in
the artifact.
