### PR TITLE
fix(gce): remove the duplicate cache attribute "subnet" and update the test

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
@@ -86,7 +86,7 @@ class GoogleSubnetCachingAgent extends AbstractGoogleCachingAgent {
       def subnetKey = Keys.getSubnetKey(deriveSubnetId(subnet), region, accountName)
 
       cacheResultBuilder.namespace(SUBNETS.ns).keep(subnetKey).with {
-        attributes.subnet = [subnet: subnet,project: project]
+        attributes = [subnet: subnet,project: project]
       }
     }
 

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgentSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgentSpec.groovy
@@ -43,12 +43,13 @@ class GoogleSubnetCachingAgentSpec extends Specification {
     1 * computeMock.subnetworks() >> subnetsMock
     1 * subnetsMock.list(PROJECT_NAME,REGION) >> subnetworksListMock
     1 * subnetworksListMock.execute() >> SubnetsListReal
-    with(cache.cacheResults.get(Keys.Namespace.SUBNETS.ns)) { Collection<CacheData> cd ->
-      cd.stream().forEach( {
-        Map<String,Object> attributes= it.getAttributes()
-        attributes.get(0) == "my-project"
-      })
-      cd.id.containsAll([keyGroupA])
+    def cd = cache.cacheResults.get(Keys.Namespace.SUBNETS.ns)
+    cd.id.containsAll([keyGroupA])
+    with(cd.asList().get(0)){
+      def attributes = it.attributes
+      attributes.project == "my-project"
+      attributes.subnet.name ==  "name-a"
+      attributes.subnet.selfLink ==  "https://compute.googleapis.com/compute/v1/projects/my-project/us-east1/subnetworks/name-a"
     }
   }
 


### PR DESCRIPTION
Addresses the issue: https://github.com/spinnaker/spinnaker/issues/6813

CacheData's attributes map is so far been assigned a map of `subnet` key and it's value along with `project` key and it's value under (yet again) a `subnet` key instead of having `subnet` and `project` as separate attributes. This PR fixes the issue.

The existing test didn't catch the bug so it is now updated.

