### PR TITLE
perf(cache): Optimise heap usage in SqlCache

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
@@ -79,8 +79,16 @@ class SqlCache(
 
   private var createdTables = ConcurrentSkipListSet<String>()
 
+  private val hexStrings: List<String>
+
   init {
     log.info("Configured for $name")
+
+    this.hexStrings = arrayListOf()
+    for (byte in Byte.MIN_VALUE..Byte.MAX_VALUE) {
+      val str = "%02x".format(byte.toByte())
+      this.hexStrings.add(str)
+    }
   }
 
   /**
@@ -927,9 +935,11 @@ class SqlCache(
     return try {
       val digest = MessageDigest.getInstance("SHA-256")
         .digest(body.toByteArray())
-      digest.fold("") { str, it ->
-        str + "%02x".format(it)
+      val builder = StringBuilder(64)
+      for (byte in digest) {
+        builder.append(this.hexStrings[byte - Byte.MIN_VALUE])
       }
+      builder.toString()
     } catch (e: Exception) {
       log.error("error calculating hash for body: $body", e)
       null

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
@@ -84,6 +84,9 @@ class SqlCache(
   init {
     log.info("Configured for $name")
 
+    // Pre-generating string representations for all possible byte values
+    // to avoid using `String#format` in frequently invoked methods like `getHash`.
+    // Invoking `String#format` in these hot methods creates excessive garbage.
     this.hexStrings = arrayListOf()
     for (byte in Byte.MIN_VALUE..Byte.MAX_VALUE) {
       val str = "%02x".format(byte.toByte())
@@ -935,8 +938,11 @@ class SqlCache(
     return try {
       val digest = MessageDigest.getInstance("SHA-256")
         .digest(body.toByteArray())
+      // The hash length is known, so a `StringBuilder` with a predefined capacity is used
+      // to prevent unnecessary array allocations inside the StringBuilder.
       val builder = StringBuilder(64)
       for (byte in digest) {
+        // Uses pre-generated string representations for each byte to optimize performance.
         builder.append(this.hexStrings[byte - Byte.MIN_VALUE])
       }
       builder.toString()


### PR DESCRIPTION
This pull request addresses a performance issue discovered in the Clouddriver, specifically within the `SqlCache.getHash method`.

I used async-profiler to build an Allocation profile and a CPU profile. From the Allocation profile, it was found that the `SqlCache.getHash` method was responsible for 80% of the memory allocation, mostly due to the heavy use of `String.format` within this method. Furthermore, the CPU profile indicated that 34% of CPU usage was also attributed to this method.

So I'm making a conclusion that `SqlCache.getHash` is generating a significant amount of garbage, contributing to high heap and CPU usage. This could potentially be a root cause for Out Of Memory errors if the Garbage Collector is unable to clean up the generated garbage efficiently. It also may add to high CPU usage. Perhaps, relevant issues: [#6835](https://github.com/spinnaker/spinnaker/issues/6835), [#6797](https://github.com/spinnaker/spinnaker/issues/6797), and [#6810](https://github.com/spinnaker/spinnaker/issues/6810).

The proposed optimisation in this pull request aims to reduce the amount of garbage generated by this method by pre-generating string representations for all possible byte values and using `StringBuilder` with a predefined size.

This optimisation has been deployed in our production environment almost for a month and has shown promising results, reducing resource consumption by 2-5 times. I attached the screenshots of the graphs to this pull request for illustration.

![image](https://github.com/spinnaker/clouddriver/assets/6229328/fb442636-b2ca-4b67-8269-4e4eb6427a44)
![image](https://github.com/spinnaker/clouddriver/assets/6229328/7f648870-67ad-47ff-8434-f3f6a1c1f92d)
![image](https://github.com/spinnaker/clouddriver/assets/6229328/38c1f723-99cd-418f-a8c2-232bd66c071a)
![image](https://github.com/spinnaker/clouddriver/assets/6229328/4010d554-0b9e-4547-9583-876a55092bb9)


