### PR TITLE
refactor(tests): convert junit4 based testcases to junit5 and clean up in clouddriver

### DIFF
--- a/cats/cats-core/cats-core.gradle
+++ b/cats/cats-core/cats-core.gradle
@@ -13,4 +13,8 @@ dependencies {
   testImplementation project(":cats:cats-test")
 
   testImplementation "org.spockframework:spock-core"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+}
+test{
+  useJUnitPlatform()
 }

--- a/cats/cats-redis/cats-redis.gradle
+++ b/cats/cats-redis/cats-redis.gradle
@@ -17,4 +17,5 @@ dependencies {
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.spockframework:spock-core"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
 }

--- a/cats/cats-redis/src/test/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredSortAgentSchedulerTest.java
+++ b/cats/cats-redis/src/test/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredSortAgentSchedulerTest.java
@@ -39,8 +39,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.reflect.FieldUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
@@ -56,7 +56,7 @@ public class ClusteredSortAgentSchedulerTest {
 
   private Optional<Semaphore> runningAgents;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IllegalAccessException {
     when(jedisPool.getResource()).thenReturn(jedis);
     when(jedis.scriptLoad(anyString())).thenReturn("testScriptSha");

--- a/cats/cats-sql/cats-sql.gradle
+++ b/cats/cats-sql/cats-sql.gradle
@@ -54,8 +54,6 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-engine"
-  testImplementation "org.junit.platform:junit-platform-launcher"
-  testImplementation "org.junit.vintage:junit-vintage-engine"
   testImplementation "org.objenesis:objenesis"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"

--- a/cats/cats-test/cats-test.gradle
+++ b/cats/cats-test/cats-test.gradle
@@ -13,4 +13,9 @@ dependencies {
   compileOnly "org.projectlombok:lombok"
   annotationProcessor "org.projectlombok:lombok"
   testAnnotationProcessor "org.projectlombok:lombok"
+
+  testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
+}
+test{
+  useJUnitPlatform()
 }

--- a/cats/cats-test/src/main/groovy/com/netflix/spinnaker/cats/cache/CacheSpec.groovy
+++ b/cats/cats-test/src/main/groovy/com/netflix/spinnaker/cats/cache/CacheSpec.groovy
@@ -16,8 +16,7 @@
 
 package com.netflix.spinnaker.cats.cache
 
-import org.junit.Rule
-import org.junit.rules.TestName
+import org.junit.jupiter.api.BeforeEach
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -27,10 +26,9 @@ abstract class CacheSpec extends Specification {
     @Subject
     Cache cache
 
-    @Rule TestName testName = new TestName()
-
+    @BeforeEach
     def setup() {
-        println "--------------- Test " + testName.getMethodName()
+      println "--------------- Test " + specificationContext.currentIteration.name
         cache = getSubject()
     }
 

--- a/clouddriver-api/clouddriver-api.gradle
+++ b/clouddriver-api/clouddriver-api.gradle
@@ -29,13 +29,4 @@ dependencies {
 
   compileOnly("org.projectlombok:lombok")
   annotationProcessor("org.projectlombok:lombok")
-
-  testRuntimeOnly("org.junit.jupiter:junit-jupiter-api")
-  testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
-}
-
-test {
-  useJUnitPlatform {
-    includeEngines "junit-vintage", "junit-jupiter"
-  }
 }

--- a/clouddriver-appengine/src/test/java/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/DeployAppengineConfigAtomicOperationConverterTest.java
+++ b/clouddriver-appengine/src/test/java/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/DeployAppengineConfigAtomicOperationConverterTest.java
@@ -17,7 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.appengine.deploy.converters;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -28,8 +28,8 @@ import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccoun
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DeployAppengineConfigAtomicOperationConverterTest {
 
@@ -37,7 +37,7 @@ public class DeployAppengineConfigAtomicOperationConverterTest {
   CredentialsRepository<AppengineNamedAccountCredentials> credentialsRepository;
   AppengineNamedAccountCredentials mockCredentials;
 
-  @Before
+  @BeforeEach
   public void init() {
     converter = new DeployAppengineConfigAtomicOperationConverter();
     credentialsRepository = mock(CredentialsRepository.class);

--- a/clouddriver-appengine/src/test/java/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineConfigAtomicOperationTest.java
+++ b/clouddriver-appengine/src/test/java/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineConfigAtomicOperationTest.java
@@ -17,7 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.appengine.deploy.ops;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -36,8 +36,8 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class DeployAppengineConfigAtomicOperationTest {
@@ -47,7 +47,7 @@ public class DeployAppengineConfigAtomicOperationTest {
   ObjectMapper mapper;
   ArtifactDownloader artifactDownloader = mock(ArtifactDownloader.class);
 
-  @Before
+  @BeforeEach
   public void init() {
     deployAppengineConfigAtomicOperation = new DeployAppengineConfigAtomicOperation(description);
     mapper = new ObjectMapper();

--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -61,7 +61,6 @@ dependencies {
   testImplementation "org.junit-pioneer:junit-pioneer:0.3.0"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "org.testcontainers:testcontainers"

--- a/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver-aws/clouddriver-aws.gradle
@@ -65,7 +65,6 @@ dependencies {
   testImplementation "com.natpryce:hamkrest"
   testImplementation "com.google.guava:guava"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.objenesis:objenesis"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"

--- a/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerInstanceStateCachingAgentTest.java
+++ b/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerInstanceStateCachingAgentTest.java
@@ -44,13 +44,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
 
-@RunWith(JUnitPlatform.class)
 @ExtendWith(MockitoExtension.class)
 class AmazonLoadBalancerInstanceStateCachingAgentTest {
   private static final String region = "region";

--- a/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/DeleteCloudrunLoadBalancerAtomicOperationConverterTest.java
+++ b/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/DeleteCloudrunLoadBalancerAtomicOperationConverterTest.java
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.clouddriver.cloudrun.deploy.converters;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -10,8 +10,8 @@ import com.netflix.spinnaker.clouddriver.cloudrun.security.CloudrunNamedAccountC
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DeleteCloudrunLoadBalancerAtomicOperationConverterTest {
 
@@ -26,7 +26,7 @@ public class DeleteCloudrunLoadBalancerAtomicOperationConverterTest {
         }
       };
 
-  @Before
+  @BeforeEach
   public void init() {
     deleteCloudrunLoadBalancerAtomicOperationConverter =
         new DeleteCloudrunLoadBalancerAtomicOperationConverter();

--- a/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/DeployCloudrunAtomicOperationConverterTest.java
+++ b/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/DeployCloudrunAtomicOperationConverterTest.java
@@ -9,8 +9,8 @@ import com.netflix.spinnaker.clouddriver.cloudrun.security.CloudrunNamedAccountC
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DeployCloudrunAtomicOperationConverterTest {
   DeployCloudrunAtomicOperationConverter deployCloudrunAtomicOperationConverter;
@@ -23,7 +23,7 @@ public class DeployCloudrunAtomicOperationConverterTest {
         }
       };
 
-  @Before
+  @BeforeEach
   public void init() {
     deployCloudrunAtomicOperationConverter = new DeployCloudrunAtomicOperationConverter();
     credentialsRepository = mock(CredentialsRepository.class);

--- a/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/DestroyCloudrunAtomicOperationConverterTest.java
+++ b/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/DestroyCloudrunAtomicOperationConverterTest.java
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.clouddriver.cloudrun.deploy.converters;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -10,8 +10,8 @@ import com.netflix.spinnaker.clouddriver.cloudrun.security.CloudrunNamedAccountC
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DestroyCloudrunAtomicOperationConverterTest {
   DestroyCloudrunAtomicOperationConverter destroyCloudrunAtomicOperationConverter;
@@ -24,7 +24,7 @@ public class DestroyCloudrunAtomicOperationConverterTest {
         }
       };
 
-  @Before
+  @BeforeEach
   public void init() {
     destroyCloudrunAtomicOperationConverter = new DestroyCloudrunAtomicOperationConverter();
     credentialsRepository = mock(CredentialsRepository.class);

--- a/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/DisableCloudrunAtomicOperationConverterTest.java
+++ b/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/DisableCloudrunAtomicOperationConverterTest.java
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.clouddriver.cloudrun.deploy.converters;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -10,8 +10,8 @@ import com.netflix.spinnaker.clouddriver.cloudrun.security.CloudrunNamedAccountC
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DisableCloudrunAtomicOperationConverterTest {
   DisableCloudrunAtomicOperationConverter disableCloudrunAtomicOperationConverter;
@@ -24,7 +24,7 @@ public class DisableCloudrunAtomicOperationConverterTest {
         }
       };
 
-  @Before
+  @BeforeEach
   public void init() {
     disableCloudrunAtomicOperationConverter = new DisableCloudrunAtomicOperationConverter();
     credentialsRepository = mock(CredentialsRepository.class);

--- a/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/EnableCloudrunAtomicOperationConverterTest.java
+++ b/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/EnableCloudrunAtomicOperationConverterTest.java
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.clouddriver.cloudrun.deploy.converters;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -10,8 +10,8 @@ import com.netflix.spinnaker.clouddriver.cloudrun.security.CloudrunNamedAccountC
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EnableCloudrunAtomicOperationConverterTest {
   EnableCloudrunAtomicOperationConverter enableCloudrunAtomicOperationConverter;
@@ -24,7 +24,7 @@ public class EnableCloudrunAtomicOperationConverterTest {
         }
       };
 
-  @Before
+  @BeforeEach
   public void init() {
     enableCloudrunAtomicOperationConverter = new EnableCloudrunAtomicOperationConverter();
     credentialsRepository = mock(CredentialsRepository.class);

--- a/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/UpsertCloudrunLoadBalancerAtomicOperationConverterTest.java
+++ b/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/UpsertCloudrunLoadBalancerAtomicOperationConverterTest.java
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.clouddriver.cloudrun.deploy.converters;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -10,8 +10,8 @@ import com.netflix.spinnaker.clouddriver.cloudrun.security.CloudrunNamedAccountC
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class UpsertCloudrunLoadBalancerAtomicOperationConverterTest {
   UpsertCloudrunLoadBalancerAtomicOperationConverter
@@ -25,7 +25,7 @@ public class UpsertCloudrunLoadBalancerAtomicOperationConverterTest {
         }
       };
 
-  @Before
+  @BeforeEach
   public void init() {
     upsertCloudrunLoadBalancerAtomicOperationConverter =
         new UpsertCloudrunLoadBalancerAtomicOperationConverter();

--- a/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/ops/DeleteCloudrunLoadBalancerAtomicOperationTest.java
+++ b/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/ops/DeleteCloudrunLoadBalancerAtomicOperationTest.java
@@ -14,8 +14,8 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.jobs.JobExecutor;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DeleteCloudrunLoadBalancerAtomicOperationTest {
   DeleteCloudrunLoadBalancerAtomicOperation deleteCloudrunLoadBalancerAtomicOperation;
@@ -28,7 +28,7 @@ public class DeleteCloudrunLoadBalancerAtomicOperationTest {
   CloudrunLoadBalancer loadBalancer;
   JobExecutor executor;
 
-  @Before
+  @BeforeEach
   public void init() {
     mockcredentials =
         new CloudrunNamedAccountCredentials.Builder()

--- a/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/ops/DestroyCloudrunAtomicOperationTest.java
+++ b/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/ops/DestroyCloudrunAtomicOperationTest.java
@@ -14,8 +14,8 @@ import com.netflix.spinnaker.clouddriver.cloudrun.security.CloudrunNamedAccountC
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import java.util.ArrayList;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DestroyCloudrunAtomicOperationTest {
 
@@ -29,7 +29,7 @@ public class DestroyCloudrunAtomicOperationTest {
 
   CloudrunServerGroup serverGroup;
 
-  @Before
+  @BeforeEach
   public void init() {
     mockcredentials =
         new CloudrunNamedAccountCredentials.Builder()

--- a/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/ops/UpsertCloudrunLoadBalancerAtomicOperationTest.java
+++ b/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/ops/UpsertCloudrunLoadBalancerAtomicOperationTest.java
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.clouddriver.cloudrun.deploy.ops;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -16,8 +16,8 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class UpsertCloudrunLoadBalancerAtomicOperationTest {
 
@@ -31,7 +31,7 @@ public class UpsertCloudrunLoadBalancerAtomicOperationTest {
 
   CloudrunAllocationDescription allocationDescription;
 
-  @Before
+  @BeforeEach
   public void init() {
 
     mockcredentials =

--- a/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/validators/DeployCloudrunConfigDescriptionValidatorTest.java
+++ b/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/validators/DeployCloudrunConfigDescriptionValidatorTest.java
@@ -13,8 +13,8 @@ import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository;
 import com.netflix.spinnaker.credentials.NoopCredentialsLifecycleHandler;
 import java.lang.reflect.Field;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DeployCloudrunConfigDescriptionValidatorTest {
   DeployCloudrunConfigDescriptionValidator deployCloudrunConfigDescriptionValidator;
@@ -23,7 +23,7 @@ public class DeployCloudrunConfigDescriptionValidatorTest {
   DeployCloudrunConfigDescription description;
   ValidationErrors errors;
 
-  @Before
+  @BeforeEach
   public void init() {
     deployCloudrunConfigDescriptionValidator = new DeployCloudrunConfigDescriptionValidator();
     mockCredentials = mock(CloudrunNamedAccountCredentials.class);

--- a/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/validators/DeployCloudrunDescriptionValidatorTest.java
+++ b/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/validators/DeployCloudrunDescriptionValidatorTest.java
@@ -13,8 +13,8 @@ import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository;
 import com.netflix.spinnaker.credentials.NoopCredentialsLifecycleHandler;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DeployCloudrunDescriptionValidatorTest {
   DeployCloudrunDescriptionValidator deployCloudrunDescriptionValidator;
@@ -23,7 +23,7 @@ public class DeployCloudrunDescriptionValidatorTest {
   DeployCloudrunDescription description;
   ValidationErrors validationErrors;
 
-  @Before
+  @BeforeEach
   public void init() {
     deployCloudrunDescriptionValidator = new DeployCloudrunDescriptionValidator();
     validationErrors = mock(ValidationErrors.class);

--- a/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/validators/StandardCloudrunAttributeValidatorTest.java
+++ b/clouddriver-cloudrun/src/test/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/validators/StandardCloudrunAttributeValidatorTest.java
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.clouddriver.cloudrun.deploy.validators;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.google.api.services.run.v1.CloudRun;
@@ -11,8 +12,8 @@ import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository;
 import com.netflix.spinnaker.credentials.NoopCredentialsLifecycleHandler;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class StandardCloudrunAttributeValidatorTest {
   StandardCloudrunAttributeValidator standardCloudrunAttributeValidator;
@@ -20,7 +21,7 @@ public class StandardCloudrunAttributeValidatorTest {
   CloudrunNamedAccountCredentials mockcredentials;
   ValidationErrors errors;
 
-  @Before
+  @BeforeEach
   public void init() {
     errors = mock(ValidationErrors.class);
     standardCloudrunAttributeValidator =

--- a/clouddriver-core-tck/clouddriver-core-tck.gradle
+++ b/clouddriver-core-tck/clouddriver-core-tck.gradle
@@ -2,7 +2,7 @@ dependencies {
   implementation project(":clouddriver-core")
 
   implementation "com.fasterxml.jackson.core:jackson-annotations"
-  implementation "junit:junit"
+  implementation "org.junit.jupiter:junit-jupiter-api"
   implementation "org.apache.commons:commons-lang3"
   implementation "org.assertj:assertj-core"
   implementation "org.codehaus.groovy:groovy"

--- a/clouddriver-core-tck/src/main/java/com/netflix/spinnaker/clouddriver/core/test/TaskRepositoryTck.java
+++ b/clouddriver-core-tck/src/main/java/com/netflix/spinnaker/clouddriver/core/test/TaskRepositoryTck.java
@@ -28,8 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.text.WordUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class TaskRepositoryTck<T extends TaskRepository> {
 
@@ -37,7 +37,7 @@ public abstract class TaskRepositoryTck<T extends TaskRepository> {
 
   protected abstract T createTaskRepository();
 
-  @Before
+  @BeforeEach
   public void setupTest() {
     subject = createTaskRepository();
   }

--- a/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/data/task/jedis/RedisTaskRepositoryTest.java
+++ b/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/data/task/jedis/RedisTaskRepositoryTest.java
@@ -19,7 +19,7 @@ import com.netflix.spinnaker.clouddriver.core.test.TaskRepositoryTck;
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis;
 import com.netflix.spinnaker.kork.jedis.JedisClientDelegate;
 import java.util.Optional;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import redis.clients.jedis.JedisPool;
 
 public class RedisTaskRepositoryTest extends TaskRepositoryTck<RedisTaskRepository> {
@@ -36,7 +36,7 @@ public class RedisTaskRepositoryTest extends TaskRepositoryTck<RedisTaskReposito
     return new RedisTaskRepository(new JedisClientDelegate(jedisPool), Optional.empty());
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     Optional.ofNullable(embeddedRedis).ifPresent(EmbeddedRedis::destroy);
   }

--- a/clouddriver-docker/clouddriver-docker.gradle
+++ b/clouddriver-docker/clouddriver-docker.gradle
@@ -26,10 +26,10 @@ dependencies {
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.mockito:mockito-junit-jupiter"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/health/DockerRegistryHealthIndicatorTest.java
+++ b/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/health/DockerRegistryHealthIndicatorTest.java
@@ -32,14 +32,11 @@ import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 
-@RunWith(JUnitPlatform.class)
 @ExtendWith(MockitoExtension.class)
 class DockerRegistryHealthIndicatorTest {
 

--- a/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsLifecycleHandlerTest.java
+++ b/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsLifecycleHandlerTest.java
@@ -26,10 +26,7 @@ import com.netflix.spinnaker.clouddriver.docker.registry.provider.DockerRegistry
 import com.netflix.spinnaker.clouddriver.docker.registry.provider.agent.DockerRegistryImageCachingAgent;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 class DockerRegistryCredentialsLifecycleHandlerTest {
 
   @Test

--- a/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentialsTest.java
+++ b/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentialsTest.java
@@ -39,8 +39,6 @@ import java.util.regex.Pattern;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import retrofit.client.OkClient;
@@ -48,7 +46,6 @@ import retrofit.client.Request;
 import retrofit.client.Response;
 import retrofit.mime.TypedString;
 
-@RunWith(JUnitPlatform.class)
 final class DockerRegistryNamedAccountCredentialsTest {
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private static final String ACCOUNT_NAME = "test-account";

--- a/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/security/KeyBasedSorterTest.java
+++ b/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/security/KeyBasedSorterTest.java
@@ -29,10 +29,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KeyBasedSorterTest {
   @Test
   void naturalOrderSort() {

--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/EcsControllersSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/EcsControllersSpec.java
@@ -16,9 +16,9 @@
 package com.netflix.spinnaker.clouddriver.ecs.test;
 
 import static io.restassured.RestAssured.get;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/LoadBalancersSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/LoadBalancersSpec.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.ecs.test;
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.TARGET_GROUPS;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
 import static io.restassured.RestAssured.get;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import com.amazonaws.services.ecs.model.LoadBalancer;

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/view/EcrImageProviderSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/view/EcrImageProviderSpec.groovy
@@ -1,7 +1,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.view
 
 import com.netflix.spinnaker.clouddriver.ecs.provider.view.EcrImageProvider
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import spock.lang.Specification
 
 class EcrImageProviderSpec extends Specification {

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/view/UnvalidatedDockerImageProviderSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/view/UnvalidatedDockerImageProviderSpec.groovy
@@ -1,7 +1,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.view
 
 import com.netflix.spinnaker.clouddriver.ecs.provider.view.UnvalidatedDockerImageProvider
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import spock.lang.Specification
 
 class UnvalidatedDockerImageProviderSpec extends Specification {

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/cache/ContainerInstanceCacheClientTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/cache/ContainerInstanceCacheClientTest.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.cache;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.CONTAINER_INSTANCES;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.ecs.model.ContainerInstance;
@@ -26,7 +26,7 @@ import com.netflix.spinnaker.clouddriver.ecs.cache.client.ContainerInstanceCache
 import com.netflix.spinnaker.clouddriver.ecs.provider.agent.ContainerInstanceCachingAgent;
 import java.util.Collections;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class ContainerInstanceCacheClientTest extends CommonCacheClient {
@@ -57,17 +57,17 @@ public class ContainerInstanceCacheClientTest extends CommonCacheClient {
 
     // Then
     assertTrue(
+        containerInstance.getEc2InstanceId().equals(ecsContainerInstance.getEc2InstanceId()),
         "Expected the EC2 instance ID to be "
             + containerInstance.getEc2InstanceId()
             + " but got "
-            + ecsContainerInstance.getEc2InstanceId(),
-        containerInstance.getEc2InstanceId().equals(ecsContainerInstance.getEc2InstanceId()));
+            + ecsContainerInstance.getEc2InstanceId());
 
     assertTrue(
+        containerInstance.getContainerInstanceArn().equals(ecsContainerInstance.getArn()),
         "Expected the container instance ARN to be "
             + containerInstance.getContainerInstanceArn()
             + " but got "
-            + ecsContainerInstance.getArn(),
-        containerInstance.getContainerInstanceArn().equals(ecsContainerInstance.getArn()));
+            + ecsContainerInstance.getArn());
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/cache/EcsClusterCacheClientTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/cache/EcsClusterCacheClientTest.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.cache;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
@@ -26,7 +26,7 @@ import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsCluster;
 import com.netflix.spinnaker.clouddriver.ecs.provider.agent.EcsClusterCachingAgent;
 import java.util.Collections;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class EcsClusterCacheClientTest extends CommonCacheClient {
@@ -50,16 +50,16 @@ public class EcsClusterCacheClientTest extends CommonCacheClient {
 
     // Then
     assertTrue(
-        "Expected cluster name to be " + clusterName + " but got " + ecsCluster.getName(),
-        clusterName.equals(ecsCluster.getName()));
+        clusterName.equals(ecsCluster.getName()),
+        "Expected cluster name to be " + clusterName + " but got " + ecsCluster.getName());
     assertTrue(
-        "Expected cluster ARN to be " + clusterArn + " but got " + ecsCluster.getArn(),
-        clusterArn.equals(ecsCluster.getArn()));
+        clusterArn.equals(ecsCluster.getArn()),
+        "Expected cluster ARN to be " + clusterArn + " but got " + ecsCluster.getArn());
     assertTrue(
-        "Expected cluster account to be " + ACCOUNT + " but got " + ecsCluster.getAccount(),
-        ACCOUNT.equals(ecsCluster.getAccount()));
+        ACCOUNT.equals(ecsCluster.getAccount()),
+        "Expected cluster account to be " + ACCOUNT + " but got " + ecsCluster.getAccount());
     assertTrue(
-        "Expected cluster region to be " + REGION + " but got " + ecsCluster.getRegion(),
-        REGION.equals(ecsCluster.getRegion()));
+        REGION.equals(ecsCluster.getRegion()),
+        "Expected cluster region to be " + REGION + " but got " + ecsCluster.getRegion());
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/cache/IamRoleCacheClientTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/cache/IamRoleCacheClientTest.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.cache;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.IAM_ROLE;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,7 +28,7 @@ import com.netflix.spinnaker.clouddriver.ecs.provider.agent.IamRoleCachingAgent;
 import com.netflix.spinnaker.clouddriver.ecs.provider.agent.IamTrustRelationship;
 import java.util.Collections;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class IamRoleCacheClientTest extends CommonCacheClient {
@@ -63,7 +63,7 @@ public class IamRoleCacheClientTest extends CommonCacheClient {
 
     // Then
     assertTrue(
-        "Expected the IAM Role to be " + iamRole + " but got " + returnedIamRole,
-        iamRole.equals(returnedIamRole));
+        iamRole.equals(returnedIamRole),
+        "Expected the IAM Role to be " + iamRole + " but got " + returnedIamRole);
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/cache/ServiceCacheClientTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/cache/ServiceCacheClientTest.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.cache;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.ecs.model.*;
@@ -31,7 +31,7 @@ import com.netflix.spinnaker.clouddriver.ecs.provider.agent.TestServiceCachingAg
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class ServiceCacheClientTest extends CommonCacheClient {
@@ -87,122 +87,125 @@ public class ServiceCacheClientTest extends CommonCacheClient {
 
     // Then
     assertTrue(
+        clusterName.equals(ecsService.getClusterName()),
         "Expected the cluster name to be "
             + clusterName
             + " but got "
-            + ecsService.getClusterName(),
-        clusterName.equals(ecsService.getClusterName()));
+            + ecsService.getClusterName());
 
     assertTrue(
+        service.getClusterArn().equals(ecsService.getClusterArn()),
         "Expected the cluster ARN to be "
             + service.getClusterArn()
             + " but got "
-            + ecsService.getClusterArn(),
-        service.getClusterArn().equals(ecsService.getClusterArn()));
+            + ecsService.getClusterArn());
 
     assertTrue(
+        ACCOUNT.equals(ecsService.getAccount()),
         "Expected the account of the service to be "
             + ACCOUNT
             + " but got "
-            + ecsService.getAccount(),
-        ACCOUNT.equals(ecsService.getAccount()));
+            + ecsService.getAccount());
 
     assertTrue(
-        "Expected the region of the service to be " + REGION + " but got " + ecsService.getRegion(),
-        REGION.equals(ecsService.getRegion()));
+        REGION.equals(ecsService.getRegion()),
+        "Expected the region of the service to be "
+            + REGION
+            + " but got "
+            + ecsService.getRegion());
 
     assertTrue(
+        applicationName.equals(ecsService.getApplicationName()),
         "Expected the service application name to be "
             + applicationName
             + " but got "
-            + ecsService.getApplicationName(),
-        applicationName.equals(ecsService.getApplicationName()));
+            + ecsService.getApplicationName());
 
     assertTrue(
+        serviceName.equals(ecsService.getServiceName()),
         "Expected the service name to be "
             + serviceName
             + " but got "
-            + ecsService.getServiceName(),
-        serviceName.equals(ecsService.getServiceName()));
+            + ecsService.getServiceName());
 
     assertTrue(
+        service.getServiceArn().equals(ecsService.getServiceArn()),
         "Expected the service ARN to be "
             + service.getServiceArn()
             + " but got "
-            + ecsService.getServiceArn(),
-        service.getServiceArn().equals(ecsService.getServiceArn()));
+            + ecsService.getServiceArn());
 
     assertTrue(
+        service.getRoleArn().equals(ecsService.getRoleArn()),
         "Expected the role ARN of the service to be "
             + service.getRoleArn()
             + " but got "
-            + ecsService.getRoleArn(),
-        service.getRoleArn().equals(ecsService.getRoleArn()));
+            + ecsService.getRoleArn());
 
     assertTrue(
+        service.getTaskDefinition().equals(ecsService.getTaskDefinition()),
         "Expected the task definition of the service to be "
             + service.getTaskDefinition()
             + " but got "
-            + ecsService.getTaskDefinition(),
-        service.getTaskDefinition().equals(ecsService.getTaskDefinition()));
+            + ecsService.getTaskDefinition());
 
     assertTrue(
+        service.getDesiredCount() == ecsService.getDesiredCount(),
         "Expected the desired count of the service to be "
             + service.getDesiredCount()
             + " but got "
-            + ecsService.getDesiredCount(),
-        service.getDesiredCount() == ecsService.getDesiredCount());
+            + ecsService.getDesiredCount());
 
     assertTrue(
+        service.getDeploymentConfiguration().getMaximumPercent() == ecsService.getMaximumPercent(),
         "Expected the maximum percent of the service to be "
             + service.getDeploymentConfiguration().getMaximumPercent()
             + " but got "
-            + ecsService.getMaximumPercent(),
-        service.getDeploymentConfiguration().getMaximumPercent() == ecsService.getMaximumPercent());
+            + ecsService.getMaximumPercent());
 
     assertTrue(
+        service.getDeploymentConfiguration().getMinimumHealthyPercent()
+            == ecsService.getMinimumHealthyPercent(),
         "Expected the minimum healthy percent of the service to be "
             + service.getDeploymentConfiguration().getMinimumHealthyPercent()
             + " but got "
-            + ecsService.getMinimumHealthyPercent(),
-        service.getDeploymentConfiguration().getMinimumHealthyPercent()
-            == ecsService.getMinimumHealthyPercent());
+            + ecsService.getMinimumHealthyPercent());
 
     assertTrue(
+        service.getCreatedAt().getTime() == ecsService.getCreatedAt(),
         "Expected the created at of the service to be "
             + service.getCreatedAt().getTime()
             + " but got "
-            + ecsService.getCreatedAt(),
-        service.getCreatedAt().getTime() == ecsService.getCreatedAt());
+            + ecsService.getCreatedAt());
 
     assertTrue(
-        "Expected the service to have 1 subnet but got " + ecsService.getSubnets().size(),
-        ecsService.getSubnets().size() == 1);
+        ecsService.getSubnets().size() == 1,
+        "Expected the service to have 1 subnet but got " + ecsService.getSubnets().size());
 
     assertTrue(
-        "Expected the service to have subnet subnet-id but got " + ecsService.getSubnets().get(0),
-        ecsService.getSubnets().get(0).equals("subnet-id"));
+        ecsService.getSubnets().get(0).equals("subnet-id"),
+        "Expected the service to have subnet subnet-id but got " + ecsService.getSubnets().get(0));
 
     assertTrue(
+        ecsService.getSecurityGroups().size() == 1,
         "Expected the service to have 1 security group but got "
-            + ecsService.getSecurityGroups().size(),
-        ecsService.getSecurityGroups().size() == 1);
+            + ecsService.getSecurityGroups().size());
 
     assertTrue(
+        ecsService.getSecurityGroups().get(0).equals("security-group-id"),
         "Expected the service to have security group security-group-id but got "
-            + ecsService.getSecurityGroups().get(0),
-        ecsService.getSecurityGroups().get(0).equals("security-group-id"));
+            + ecsService.getSecurityGroups().get(0));
 
     assertTrue(
+        ecsService.getLoadBalancers().size() == 1,
         "Expected the service to have 1 load balancer but got "
-            + ecsService.getLoadBalancers().size(),
-        ecsService.getLoadBalancers().size() == 1);
+            + ecsService.getLoadBalancers().size());
 
     assertTrue(
+        ecsService.getLoadBalancers().get(0).equals(loadBalancer),
         "Expected the service to have load balancer "
             + loadBalancer
             + " but got "
-            + ecsService.getLoadBalancers().get(0),
-        ecsService.getLoadBalancers().get(0).equals(loadBalancer));
+            + ecsService.getLoadBalancers().get(0));
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/cache/TaskCacheClientTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/cache/TaskCacheClientTest.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.cache;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.ecs.model.Task;
@@ -28,7 +28,7 @@ import com.netflix.spinnaker.clouddriver.ecs.provider.agent.TaskCachingAgent;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class TaskCacheClientTest extends CommonCacheClient {
@@ -66,61 +66,61 @@ public class TaskCacheClientTest extends CommonCacheClient {
 
     // Then
     assertTrue(
-        "Expected the cluster ARN to be " + clusterArn + " but got " + ecsTask.getClusterArn(),
-        clusterArn.equals(ecsTask.getClusterArn()));
+        clusterArn.equals(ecsTask.getClusterArn()),
+        "Expected the cluster ARN to be " + clusterArn + " but got " + ecsTask.getClusterArn());
 
     assertTrue(
-        "Expected the task ARN to be " + taskArn + " but got " + ecsTask.getTaskArn(),
-        taskArn.equals(ecsTask.getTaskArn()));
+        taskArn.equals(ecsTask.getTaskArn()),
+        "Expected the task ARN to be " + taskArn + " but got " + ecsTask.getTaskArn());
 
     assertTrue(
+        task.getContainerInstanceArn().equals(ecsTask.getContainerInstanceArn()),
         "Expected the container instance ARN name to be "
             + task.getContainerInstanceArn()
             + " but got "
-            + ecsTask.getContainerInstanceArn(),
-        task.getContainerInstanceArn().equals(ecsTask.getContainerInstanceArn()));
+            + ecsTask.getContainerInstanceArn());
 
     assertTrue(
-        "Expected the group to be " + task.getGroup() + " but got " + ecsTask.getGroup(),
-        task.getGroup().equals(ecsTask.getGroup()));
+        task.getGroup().equals(ecsTask.getGroup()),
+        "Expected the group to be " + task.getGroup() + " but got " + ecsTask.getGroup());
 
     assertTrue(
+        task.getLastStatus().equals(ecsTask.getLastStatus()),
         "Expected the last status to be "
             + task.getLastStatus()
             + " but got "
-            + ecsTask.getLastStatus(),
-        task.getLastStatus().equals(ecsTask.getLastStatus()));
+            + ecsTask.getLastStatus());
 
     assertTrue(
+        task.getHealthStatus().equals(ecsTask.getHealthStatus()),
         "Expected the health status to be "
             + task.getHealthStatus()
             + " but got "
-            + ecsTask.getHealthStatus(),
-        task.getHealthStatus().equals(ecsTask.getHealthStatus()));
+            + ecsTask.getHealthStatus());
 
     assertTrue(
+        task.getDesiredStatus().equals(ecsTask.getDesiredStatus()),
         "Expected the desired status to be "
             + task.getDesiredStatus()
             + " but got "
-            + ecsTask.getDesiredStatus(),
-        task.getDesiredStatus().equals(ecsTask.getDesiredStatus()));
+            + ecsTask.getDesiredStatus());
 
     assertTrue(
+        task.getStartedAt().getTime() == ecsTask.getStartedAt(),
         "Expected the started at to be "
             + task.getStartedAt().getTime()
             + " but got "
-            + ecsTask.getStartedAt(),
-        task.getStartedAt().getTime() == ecsTask.getStartedAt());
+            + ecsTask.getStartedAt());
 
     assertTrue(
-        "Expected the task to have 0 containers but got " + task.getContainers().size(),
-        task.getContainers().size() == 0);
+        task.getContainers().size() == 0,
+        "Expected the task to have 0 containers but got " + task.getContainers().size());
 
     assertTrue(
+        task.getAvailabilityZone().equals(ecsTask.getAvailabilityZone()),
         "Expected the availability zone to be "
             + task.getAvailabilityZone()
             + " but got "
-            + ecsTask.getAvailabilityZone(),
-        task.getAvailabilityZone().equals(ecsTask.getAvailabilityZone()));
+            + ecsTask.getAvailabilityZone());
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/cache/TaskDefinitionCacheClientTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/cache/TaskDefinitionCacheClientTest.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.cache;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASK_DEFINITIONS;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.ecs.model.ContainerDefinition;
@@ -28,7 +28,7 @@ import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskDefinitionCacheCli
 import com.netflix.spinnaker.clouddriver.ecs.provider.agent.TaskDefinitionCachingAgent;
 import java.util.Collections;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class TaskDefinitionCacheClientTest extends CommonCacheClient {
@@ -69,10 +69,10 @@ public class TaskDefinitionCacheClientTest extends CommonCacheClient {
 
     // Then
     assertTrue(
+        taskDefinition.equals(retrievedTaskDefinition),
         "Expected the task definition to be "
             + taskDefinition
             + " but got "
-            + retrievedTaskDefinition,
-        taskDefinition.equals(retrievedTaskDefinition));
+            + retrievedTaskDefinition);
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/CommonCachingAgent.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/CommonCachingAgent.java
@@ -28,7 +28,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 public class CommonCachingAgent {
   static final String REGION = "us-west-2";
@@ -81,7 +81,7 @@ public class CommonCachingAgent {
     when(netflixAmazonCredentials.getAccountId()).thenReturn(ACCOUNT_ID);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     when(clientProvider.getAmazonEcs(eq(netflixAmazonCredentials), anyString(), anyBoolean()))
         .thenReturn(ecs);

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCacheTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCacheTest.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.CONTAINER_INSTANCES;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -33,7 +33,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.ContainerInstanceCacheClient;
 import java.util.Collection;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class ContainerInstanceCacheTest extends CommonCachingAgent {
@@ -76,24 +76,24 @@ public class ContainerInstanceCacheTest extends CommonCachingAgent {
     com.netflix.spinnaker.clouddriver.ecs.cache.model.ContainerInstance ecsContainerInstance =
         client.get(key);
 
-    assertTrue("Expected CacheData to be returned but null is returned", cacheData != null);
-    assertTrue("Expected 1 CacheData but returned " + cacheData.size(), cacheData.size() == 1);
+    assertTrue(cacheData != null, "Expected CacheData to be returned but null is returned");
+    assertTrue(cacheData.size() == 1, "Expected 1 CacheData but returned " + cacheData.size());
     String retrievedKey = cacheData.iterator().next().getId();
     assertTrue(
-        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey,
-        retrievedKey.equals(key));
+        retrievedKey.equals(key),
+        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey);
 
     assertTrue(
+        containerInstance.getEc2InstanceId().equals(ecsContainerInstance.getEc2InstanceId()),
         "Expected the container instance to have EC2 instance ID of "
             + containerInstance.getEc2InstanceId()
             + " but got "
-            + ecsContainerInstance.getEc2InstanceId(),
-        containerInstance.getEc2InstanceId().equals(ecsContainerInstance.getEc2InstanceId()));
+            + ecsContainerInstance.getEc2InstanceId());
     assertTrue(
+        containerInstance.getContainerInstanceArn().equals(ecsContainerInstance.getArn()),
         "Expected the container instance to have the ARN "
             + containerInstance.getContainerInstanceArn()
             + " but got "
-            + ecsContainerInstance.getArn(),
-        containerInstance.getContainerInstanceArn().equals(ecsContainerInstance.getArn()));
+            + ecsContainerInstance.getArn());
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgentTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgentTest.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.CONTAINER_INSTANCES;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -35,7 +35,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class ContainerInstanceCachingAgentTest extends CommonCachingAgent {
@@ -76,24 +76,24 @@ public class ContainerInstanceCachingAgentTest extends CommonCachingAgent {
 
     // Then
     assertTrue(
+        returnedContainerInstances.size() == containerInstances.size(),
         "Expected the list to contain "
             + containerInstances.size()
             + " ECS container instances, but got "
-            + returnedContainerInstances.size(),
-        returnedContainerInstances.size() == containerInstances.size());
+            + returnedContainerInstances.size());
     for (ContainerInstance containerInstance : returnedContainerInstances) {
       assertTrue(
+          containerInstances.contains(containerInstance),
           "Expected the container instance to be in  "
               + containerInstances
               + " list but it was not. The container instance is: "
-              + containerInstance,
-          containerInstances.contains(containerInstance));
+              + containerInstance);
       assertTrue(
+          containerInstanceArns.contains(containerInstance.getContainerInstanceArn()),
           "Expected the container instance arn to be in  "
               + containerInstanceArns
               + " list but it was not. The container instance ARN is: "
-              + containerInstance.getContainerInstanceArn(),
-          containerInstanceArns.contains(containerInstance.getContainerInstanceArn()));
+              + containerInstance.getContainerInstanceArn());
     }
   }
 
@@ -123,36 +123,36 @@ public class ContainerInstanceCachingAgentTest extends CommonCachingAgent {
 
     // Then
     assertTrue(
+        dataMap.keySet().size() == 1,
         "Expected the data map to contain 1 namespace, but it contains "
             + dataMap.keySet().size()
-            + " namespaces.",
-        dataMap.keySet().size() == 1);
+            + " namespaces.");
     assertTrue(
+        dataMap.containsKey(CONTAINER_INSTANCES.toString()),
         "Expected the data map to contain "
             + CONTAINER_INSTANCES.toString()
             + " namespace, but it contains "
             + dataMap.keySet()
-            + " namespaces.",
-        dataMap.containsKey(CONTAINER_INSTANCES.toString()));
+            + " namespaces.");
     assertTrue(
+        dataMap.get(CONTAINER_INSTANCES.toString()).size() == 2,
         "Expected there to be 2 CacheData, instead there is  "
-            + dataMap.get(CONTAINER_INSTANCES.toString()).size(),
-        dataMap.get(CONTAINER_INSTANCES.toString()).size() == 2);
+            + dataMap.get(CONTAINER_INSTANCES.toString()).size());
 
     for (CacheData cacheData : dataMap.get(CONTAINER_INSTANCES.toString())) {
       Map<String, Object> attributes = cacheData.getAttributes();
       assertTrue(
+          arns.contains(attributes.get("containerInstanceArn")),
           "Expected the container instance ARN to be in the "
               + arns
               + " list, but was not. The given arn is "
-              + attributes.get("containerInstanceArn"),
-          arns.contains(attributes.get("containerInstanceArn")));
+              + attributes.get("containerInstanceArn"));
       assertTrue(
+          ec2Ids.contains(attributes.get("ec2InstanceId")),
           "Expected the EC2 instance ID to be in the "
               + ec2Ids
               + " list, but was not. The given arn is "
-              + attributes.get("ec2InstanceId"),
-          ec2Ids.contains(attributes.get("ec2InstanceId")));
+              + attributes.get("ec2InstanceId"));
     }
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsClusterCacheTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsClusterCacheTest.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -29,8 +29,7 @@ import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.EcsClusterCacheClient;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsCluster;
 import java.util.Collection;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class EcsClusterCacheTest extends CommonCachingAgent {
@@ -57,24 +56,24 @@ public class EcsClusterCacheTest extends CommonCachingAgent {
     Collection<CacheData> cacheData = cacheResult.getCacheResults().get(ECS_CLUSTERS.toString());
     EcsCluster ecsCluster = client.get(key);
 
-    assertTrue("Expected CacheData to be returned but null is returned", cacheData != null);
-    assertTrue("Expected 1 CacheData but returned " + cacheData.size(), cacheData.size() == 1);
+    assertTrue(cacheData != null, "Expected CacheData to be returned but null is returned");
+    assertTrue(cacheData.size() == 1, "Expected 1 CacheData but returned " + cacheData.size());
     String retrievedKey = cacheData.iterator().next().getId();
     assertTrue(
-        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey,
-        retrievedKey.equals(key));
+        retrievedKey.equals(key),
+        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey);
 
-    Assert.assertTrue(
-        "Expected cluster name to be " + CLUSTER_NAME_1 + " but got " + ecsCluster.getName(),
-        CLUSTER_NAME_1.equals(ecsCluster.getName()));
-    Assert.assertTrue(
-        "Expected cluster ARN to be " + CLUSTER_ARN_1 + " but got " + ecsCluster.getArn(),
-        CLUSTER_ARN_1.equals(ecsCluster.getArn()));
-    Assert.assertTrue(
-        "Expected cluster account to be " + ACCOUNT + " but got " + ecsCluster.getAccount(),
-        ACCOUNT.equals(ecsCluster.getAccount()));
-    Assert.assertTrue(
-        "Expected cluster region to be " + REGION + " but got " + ecsCluster.getRegion(),
-        REGION.equals(ecsCluster.getRegion()));
+    assertTrue(
+        CLUSTER_NAME_1.equals(ecsCluster.getName()),
+        "Expected cluster name to be " + CLUSTER_NAME_1 + " but got " + ecsCluster.getName());
+    assertTrue(
+        CLUSTER_ARN_1.equals(ecsCluster.getArn()),
+        "Expected cluster ARN to be " + CLUSTER_ARN_1 + " but got " + ecsCluster.getArn());
+    assertTrue(
+        ACCOUNT.equals(ecsCluster.getAccount()),
+        "Expected cluster account to be " + ACCOUNT + " but got " + ecsCluster.getAccount());
+    assertTrue(
+        REGION.equals(ecsCluster.getRegion()),
+        "Expected cluster region to be " + REGION + " but got " + ecsCluster.getRegion());
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsClusterCachingAgentTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsClusterCachingAgentTest.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -31,7 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class EcsClusterCachingAgentTest extends CommonCachingAgent {
@@ -52,20 +52,20 @@ public class EcsClusterCachingAgentTest extends CommonCachingAgent {
 
     // Then
     assertTrue(
-        "Expected the list to contain 2 ECS cluster ARNs " + clusterArns.size(),
-        clusterArns.size() == 2);
+        clusterArns.size() == 2,
+        "Expected the list to contain 2 ECS cluster ARNs " + clusterArns.size());
     assertTrue(
+        clusterArns.contains(CLUSTER_ARN_1),
         "Expected the list to contain "
             + CLUSTER_ARN_1
             + ", but it does not. It contains: "
-            + clusterArns,
-        clusterArns.contains(CLUSTER_ARN_1));
+            + clusterArns);
     assertTrue(
+        clusterArns.contains(CLUSTER_ARN_2),
         "Expected the list to contain "
             + CLUSTER_ARN_2
             + ", but it does not. It contains: "
-            + clusterArns,
-        clusterArns.contains(CLUSTER_ARN_2));
+            + clusterArns);
   }
 
   @Test
@@ -84,37 +84,37 @@ public class EcsClusterCachingAgentTest extends CommonCachingAgent {
 
     // Then
     assertTrue(
+        dataMap.keySet().size() == 1,
         "Expected the data map to contain 1 namespace, but it contains "
             + dataMap.keySet().size()
-            + " namespaces.",
-        dataMap.keySet().size() == 1);
+            + " namespaces.");
     assertTrue(
+        dataMap.containsKey(ECS_CLUSTERS.toString()),
         "Expected the data map to contain "
             + ECS_CLUSTERS.toString()
             + " namespace, but it contains "
             + dataMap.keySet()
-            + " namespaces.",
-        dataMap.containsKey(ECS_CLUSTERS.toString()));
+            + " namespaces.");
     assertTrue(
+        dataMap.get(ECS_CLUSTERS.toString()).size() == 2,
         "Expected there to be 2 CacheData, instead there is  "
-            + dataMap.get(ECS_CLUSTERS.toString()).size(),
-        dataMap.get(ECS_CLUSTERS.toString()).size() == 2);
+            + dataMap.get(ECS_CLUSTERS.toString()).size());
 
     for (CacheData cacheData : dataMap.get(ECS_CLUSTERS.toString())) {
       assertTrue(
+          keys.contains(cacheData.getId()),
           "Expected the key to be one of the following keys: "
               + keys.toString()
               + ". The key is: "
               + cacheData.getId()
-              + ".",
-          keys.contains(cacheData.getId()));
+              + ".");
       assertTrue(
+          clusterArns.contains(cacheData.getAttributes().get("clusterArn")),
           "Expected the cluster ARN to be one of the following ARNs: "
               + clusterArns.toString()
               + ". The cluster ARN is: "
               + cacheData.getAttributes().get("clusterArn")
-              + ".",
-          clusterArns.contains(cacheData.getAttributes().get("clusterArn")));
+              + ".");
     }
   }
 
@@ -130,11 +130,11 @@ public class EcsClusterCachingAgentTest extends CommonCachingAgent {
 
     // Then
     Collection<CacheData> cacheData = cacheResult.getCacheResults().get(ECS_CLUSTERS.toString());
-    assertTrue("Expected CacheData to be returned but null is returned", cacheData != null);
-    assertTrue("Expected 1 CacheData but returned " + cacheData.size(), cacheData.size() == 1);
+    assertTrue(cacheData != null, "Expected CacheData to be returned but null is returned");
+    assertTrue(cacheData.size() == 1, "Expected 1 CacheData but returned " + cacheData.size());
     String retrievedKey = cacheData.iterator().next().getId();
     assertTrue(
-        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey,
-        retrievedKey.equals(key));
+        retrievedKey.equals(key),
+        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey);
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCacheTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCacheTest.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.IAM_ROLE;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
@@ -38,7 +38,7 @@ import com.netflix.spinnaker.clouddriver.ecs.cache.model.IamRole;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class IamRoleCacheTest extends CommonCachingAgent {
@@ -96,15 +96,15 @@ public class IamRoleCacheTest extends CommonCachingAgent {
         cacheResult.getCacheResults().get(Keys.Namespace.IAM_ROLE.toString());
     IamRole returnedIamRole = client.get(key);
 
-    assertTrue("Expected CacheData to be returned but null is returned", cacheData != null);
-    assertTrue("Expected 1 CacheData but returned " + cacheData.size(), cacheData.size() == 1);
+    assertTrue(cacheData != null, "Expected CacheData to be returned but null is returned");
+    assertTrue(cacheData.size() == 1, "Expected 1 CacheData but returned " + cacheData.size());
     String retrievedKey = cacheData.iterator().next().getId();
     assertTrue(
-        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey,
-        retrievedKey.equals(key));
+        retrievedKey.equals(key),
+        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey);
 
     assertTrue(
-        "Expected the IAM Role to be " + iamRole + " but got " + returnedIamRole,
-        iamRole.equals(returnedIamRole));
+        iamRole.equals(returnedIamRole),
+        "Expected the IAM Role to be " + iamRole + " but got " + returnedIamRole);
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCachingAgentTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCachingAgentTest.java
@@ -17,8 +17,8 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.IAM_ROLE;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -34,7 +34,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.IamRole;
 import java.util.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class IamRoleCachingAgentTest extends CommonCachingAgent {
@@ -81,19 +81,19 @@ public class IamRoleCachingAgentTest extends CommonCachingAgent {
 
     // Then
     assertEquals(
+        returnedRoles.size(),
+        numberOfRoles,
         "Expected the list to contain "
             + numberOfRoles
             + " ECS IAM roles, but got "
-            + returnedRoles.size(),
-        returnedRoles.size(),
-        numberOfRoles);
+            + returnedRoles.size());
     for (IamRole iamRole : returnedRoles) {
       assertTrue(
+          iamRoles.contains(iamRole),
           "Expected the IAM role to be in  "
               + iamRoles
               + " list but it was not. The IAM role is: "
-              + iamRole,
-          iamRoles.contains(iamRole));
+              + iamRole);
     }
   }
 
@@ -125,32 +125,32 @@ public class IamRoleCachingAgentTest extends CommonCachingAgent {
 
     // Then
     assertTrue(
+        dataMap.keySet().size() == 1,
         "Expected the data map to contain 1 namespace, but it contains "
             + dataMap.keySet().size()
-            + " namespaces.",
-        dataMap.keySet().size() == 1);
+            + " namespaces.");
     assertTrue(
+        dataMap.containsKey(IAM_ROLE.toString()),
         "Expected the data map to contain "
             + IAM_ROLE.toString()
             + " namespace, but it contains "
             + dataMap.keySet()
-            + " namespaces.",
-        dataMap.containsKey(IAM_ROLE.toString()));
+            + " namespaces.");
     assertTrue(
+        dataMap.get(IAM_ROLE.toString()).size() == numberOfRoles,
         "Expected there to be "
             + numberOfRoles
             + " CacheData, instead there is  "
-            + dataMap.get(IAM_ROLE.toString()).size(),
-        dataMap.get(IAM_ROLE.toString()).size() == numberOfRoles);
+            + dataMap.get(IAM_ROLE.toString()).size());
 
     for (CacheData cacheData : dataMap.get(IAM_ROLE.toString())) {
       assertTrue(
+          keys.contains(cacheData.getId()),
           "Expected the key to be one of the following keys: "
               + keys.toString()
               + ". The key is: "
               + cacheData.getId()
-              + ".",
-          keys.contains(cacheData.getId()));
+              + ".");
     }
   }
 
@@ -166,9 +166,9 @@ public class IamRoleCachingAgentTest extends CommonCachingAgent {
 
     // then
     assertEquals(
-        "Expected region to equal " + defaultRegionName + ", but got " + actualRegionName,
         defaultRegionName,
-        actualRegionName);
+        actualRegionName,
+        "Expected region to equal " + defaultRegionName + ", but got " + actualRegionName);
   }
 
   @Test
@@ -184,8 +184,8 @@ public class IamRoleCachingAgentTest extends CommonCachingAgent {
 
     // then
     assertEquals(
-        "Expected region to equal " + expectedRegionName + ", but got " + actualRegionName,
         expectedRegionName,
-        actualRegionName);
+        actualRegionName,
+        "Expected region to equal " + expectedRegionName + ", but got " + actualRegionName);
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCacheTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCacheTest.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -30,8 +30,7 @@ import com.netflix.spinnaker.clouddriver.ecs.cache.client.ServiceCacheClient;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class ServiceCacheTest extends CommonCachingAgent {
@@ -81,96 +80,96 @@ public class ServiceCacheTest extends CommonCachingAgent {
     Collection<CacheData> cacheData = cacheResult.getCacheResults().get(SERVICES.toString());
     com.netflix.spinnaker.clouddriver.ecs.cache.model.Service ecsService = client.get(key);
 
-    assertTrue("Expected CacheData to be returned but null is returned", cacheData != null);
-    assertTrue("Expected 1 CacheData but returned " + cacheData.size(), cacheData.size() == 1);
+    assertTrue(cacheData != null, "Expected CacheData to be returned but null is returned");
+    assertTrue(cacheData.size() == 1, "Expected 1 CacheData but returned " + cacheData.size());
     String retrievedKey = cacheData.iterator().next().getId();
     assertTrue(
-        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey,
-        retrievedKey.equals(key));
+        retrievedKey.equals(key),
+        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey);
 
     assertTrue(
+        APP_NAME.equals(ecsService.getApplicationName()),
         "Expected the service application name to be "
             + APP_NAME
             + " but got "
-            + ecsService.getApplicationName(),
-        APP_NAME.equals(ecsService.getApplicationName()));
+            + ecsService.getApplicationName());
     assertTrue(
+        SERVICE_NAME_1.equals(ecsService.getServiceName()),
         "Expected the service name to be "
             + SERVICE_NAME_1
             + " but got "
-            + ecsService.getServiceName(),
-        SERVICE_NAME_1.equals(ecsService.getServiceName()));
+            + ecsService.getServiceName());
     assertTrue(
+        SERVICE_ARN_1.equals(ecsService.getServiceArn()),
         "Expected the service ARN to be "
             + SERVICE_ARN_1
             + " but got "
-            + ecsService.getServiceArn(),
-        SERVICE_ARN_1.equals(ecsService.getServiceArn()));
+            + ecsService.getServiceArn());
     assertTrue(
+        CLUSTER_ARN_1.equals(ecsService.getClusterArn()),
         "Expected the service's cluster ARN to be "
             + CLUSTER_ARN_1
             + " but got "
-            + ecsService.getClusterArn(),
-        CLUSTER_ARN_1.equals(ecsService.getClusterArn()));
-    Assert.assertTrue(
+            + ecsService.getClusterArn());
+    assertTrue(
+        service.getRoleArn().equals(ecsService.getRoleArn()),
         "Expected the role ARN of the service to be "
             + service.getRoleArn()
             + " but got "
-            + ecsService.getRoleArn(),
-        service.getRoleArn().equals(ecsService.getRoleArn()));
-    Assert.assertTrue(
+            + ecsService.getRoleArn());
+    assertTrue(
+        service.getTaskDefinition().equals(ecsService.getTaskDefinition()),
         "Expected the task definition of the service to be "
             + service.getTaskDefinition()
             + " but got "
-            + ecsService.getTaskDefinition(),
-        service.getTaskDefinition().equals(ecsService.getTaskDefinition()));
-    Assert.assertTrue(
+            + ecsService.getTaskDefinition());
+    assertTrue(
+        service.getDesiredCount() == ecsService.getDesiredCount(),
         "Expected the desired count of the service to be "
             + service.getDesiredCount()
             + " but got "
-            + ecsService.getDesiredCount(),
-        service.getDesiredCount() == ecsService.getDesiredCount());
-    Assert.assertTrue(
+            + ecsService.getDesiredCount());
+    assertTrue(
+        service.getDeploymentConfiguration().getMaximumPercent() == ecsService.getMaximumPercent(),
         "Expected the maximum percent of the service to be "
             + service.getDeploymentConfiguration().getMaximumPercent()
             + " but got "
-            + ecsService.getMaximumPercent(),
-        service.getDeploymentConfiguration().getMaximumPercent() == ecsService.getMaximumPercent());
-    Assert.assertTrue(
+            + ecsService.getMaximumPercent());
+    assertTrue(
+        service.getDeploymentConfiguration().getMinimumHealthyPercent()
+            == ecsService.getMinimumHealthyPercent(),
         "Expected the minimum healthy percent of the service to be "
             + service.getDeploymentConfiguration().getMinimumHealthyPercent()
             + " but got "
-            + ecsService.getMinimumHealthyPercent(),
-        service.getDeploymentConfiguration().getMinimumHealthyPercent()
-            == ecsService.getMinimumHealthyPercent());
-    Assert.assertTrue(
+            + ecsService.getMinimumHealthyPercent());
+    assertTrue(
+        service.getCreatedAt().getTime() == ecsService.getCreatedAt(),
         "Expected the created at of the service to be "
             + service.getCreatedAt().getTime()
             + " but got "
-            + ecsService.getCreatedAt(),
-        service.getCreatedAt().getTime() == ecsService.getCreatedAt());
-    Assert.assertTrue(
-        "Expected the service to have 0 load balancer but got "
-            + ecsService.getLoadBalancers().size(),
-        ecsService.getLoadBalancers().size() == 0);
-    Assert.assertTrue(
-        "Expected the service to have 1 subnet but got " + ecsService.getSubnets().size(),
-        ecsService.getSubnets().size() == 1);
+            + ecsService.getCreatedAt());
     assertTrue(
+        ecsService.getLoadBalancers().size() == 0,
+        "Expected the service to have 0 load balancer but got "
+            + ecsService.getLoadBalancers().size());
+    assertTrue(
+        ecsService.getSubnets().size() == 1,
+        "Expected the service to have 1 subnet but got " + ecsService.getSubnets().size());
+    assertTrue(
+        SUBNET_ID_1.equals(ecsService.getSubnets().get(0)),
         "Expected the service's subnet to be "
             + SUBNET_ID_1
             + " but got "
-            + ecsService.getSubnets().get(0),
-        SUBNET_ID_1.equals(ecsService.getSubnets().get(0)));
-    Assert.assertTrue(
-        "Expected the service to have 1 security group but got "
-            + ecsService.getSecurityGroups().size(),
-        ecsService.getSecurityGroups().size() == 1);
+            + ecsService.getSubnets().get(0));
     assertTrue(
+        ecsService.getSecurityGroups().size() == 1,
+        "Expected the service to have 1 security group but got "
+            + ecsService.getSecurityGroups().size());
+    assertTrue(
+        SECURITY_GROUP_1.equals(ecsService.getSecurityGroups().get(0)),
         "Expected the service's security group to be "
             + SECURITY_GROUP_1
             + " but got "
-            + ecsService.getSecurityGroups().get(0),
-        SECURITY_GROUP_1.equals(ecsService.getSecurityGroups().get(0)));
+            + ecsService.getSecurityGroups().get(0));
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgentTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgentTest.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -40,7 +40,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class ServiceCachingAgentTest extends CommonCachingAgent {
@@ -73,15 +73,15 @@ public class ServiceCachingAgentTest extends CommonCachingAgent {
 
     // Then
     assertTrue(
-        "Expected the list to contain 2 ECS services, but got " + returnedServices.size(),
-        returnedServices.size() == 2);
+        returnedServices.size() == 2,
+        "Expected the list to contain 2 ECS services, but got " + returnedServices.size());
     for (Service service : returnedServices) {
       assertTrue(
+          services.contains(service),
           "Expected the service to be in  "
               + services
               + " list but it was not. The service is: "
-              + service,
-          services.contains(service));
+              + service);
     }
   }
 
@@ -122,44 +122,44 @@ public class ServiceCachingAgentTest extends CommonCachingAgent {
 
     // Then
     assertTrue(
+        dataMap.keySet().size() == 2,
         "Expected the data map to contain 2 namespaces, but it contains "
             + dataMap.keySet().size()
-            + " namespaces.",
-        dataMap.keySet().size() == 2);
+            + " namespaces.");
     assertTrue(
+        dataMap.containsKey(SERVICES.toString()),
         "Expected the data map to contain "
             + SERVICES.toString()
             + " namespace, but it contains "
             + dataMap.keySet()
-            + " namespaces.",
-        dataMap.containsKey(SERVICES.toString()));
+            + " namespaces.");
     assertTrue(
+        dataMap.containsKey(ECS_CLUSTERS.toString()),
         "Expected the data map to contain "
             + ECS_CLUSTERS.toString()
             + " namespace, but it contains "
             + dataMap.keySet()
-            + " namespaces.",
-        dataMap.containsKey(ECS_CLUSTERS.toString()));
+            + " namespaces.");
     assertTrue(
+        dataMap.get(SERVICES.toString()).size() == 2,
         "Expected there to be 2 CacheData, instead there is  "
-            + dataMap.get(SERVICES.toString()).size(),
-        dataMap.get(SERVICES.toString()).size() == 2);
+            + dataMap.get(SERVICES.toString()).size());
 
     for (CacheData cacheData : dataMap.get(SERVICES.toString())) {
       assertTrue(
+          keys.contains(cacheData.getId()),
           "Expected the key to be one of the following keys: "
               + keys.toString()
               + ". The key is: "
               + cacheData.getId()
-              + ".",
-          keys.contains(cacheData.getId()));
+              + ".");
       assertTrue(
+          serviceArns.contains(cacheData.getAttributes().get("serviceArn")),
           "Expected the service ARN to be one of the following ARNs: "
               + serviceArns.toString()
               + ". The service ARN is: "
               + cacheData.getAttributes().get("serviceArn")
-              + ".",
-          serviceArns.contains(cacheData.getAttributes().get("serviceArn")));
+              + ".");
     }
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCacheTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCacheTest.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -36,7 +36,7 @@ import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskCacheClient;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class TaskCacheTest extends CommonCachingAgent {
@@ -82,62 +82,62 @@ public class TaskCacheTest extends CommonCachingAgent {
         cacheResult.getCacheResults().get(Keys.Namespace.TASKS.toString());
     com.netflix.spinnaker.clouddriver.ecs.cache.model.Task ecsTask = client.get(key);
 
-    assertTrue("Expected CacheData to be returned but null is returned", cacheData != null);
-    assertTrue("Expected 1 CacheData but returned " + cacheData.size(), cacheData.size() == 1);
+    assertTrue(cacheData != null, "Expected CacheData to be returned but null is returned");
+    assertTrue(cacheData.size() == 1, "Expected 1 CacheData but returned " + cacheData.size());
     String retrievedKey = cacheData.iterator().next().getId();
     assertTrue(
-        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey,
-        retrievedKey.equals(key));
+        cacheData.size() == 1,
+        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey);
 
     assertTrue(
-        "Expected the cluster ARN to be " + CLUSTER_ARN_1 + " but got " + ecsTask.getClusterArn(),
-        CLUSTER_ARN_1.equals(ecsTask.getClusterArn()));
+        CLUSTER_ARN_1.equals(ecsTask.getClusterArn()),
+        "Expected the cluster ARN to be " + CLUSTER_ARN_1 + " but got " + ecsTask.getClusterArn());
 
     assertTrue(
-        "Expected the task ARN to be " + TASK_ARN_1 + " but got " + ecsTask.getTaskArn(),
-        TASK_ARN_1.equals(ecsTask.getTaskArn()));
+        TASK_ARN_1.equals(ecsTask.getTaskArn()),
+        "Expected the task ARN to be " + TASK_ARN_1 + " but got " + ecsTask.getTaskArn());
 
     assertTrue(
+        task.getContainerInstanceArn().equals(ecsTask.getContainerInstanceArn()),
         "Expected the container instance ARN name to be "
             + task.getContainerInstanceArn()
             + " but got "
-            + ecsTask.getContainerInstanceArn(),
-        task.getContainerInstanceArn().equals(ecsTask.getContainerInstanceArn()));
+            + ecsTask.getContainerInstanceArn());
 
     assertTrue(
-        "Expected the group to be " + task.getGroup() + " but got " + ecsTask.getGroup(),
-        task.getGroup().equals(ecsTask.getGroup()));
+        task.getGroup().equals(ecsTask.getGroup()),
+        "Expected the group to be " + task.getGroup() + " but got " + ecsTask.getGroup());
 
     assertTrue(
+        task.getLastStatus().equals(ecsTask.getLastStatus()),
         "Expected the last status to be "
             + task.getLastStatus()
             + " but got "
-            + ecsTask.getLastStatus(),
-        task.getLastStatus().equals(ecsTask.getLastStatus()));
+            + ecsTask.getLastStatus());
 
     assertTrue(
+        task.getDesiredStatus().equals(ecsTask.getDesiredStatus()),
         "Expected the desired status to be "
             + task.getDesiredStatus()
             + " but got "
-            + ecsTask.getDesiredStatus(),
-        task.getDesiredStatus().equals(ecsTask.getDesiredStatus()));
+            + ecsTask.getDesiredStatus());
 
     assertTrue(
+        task.getStartedAt().getTime() == ecsTask.getStartedAt(),
         "Expected the started at to be "
             + task.getStartedAt().getTime()
             + " but got "
-            + ecsTask.getStartedAt(),
-        task.getStartedAt().getTime() == ecsTask.getStartedAt());
+            + ecsTask.getStartedAt());
 
     assertTrue(
+        task.getAvailabilityZone() == ecsTask.getAvailabilityZone(),
         "Expected the availability zone to be "
             + task.getAvailabilityZone()
             + " but got "
-            + ecsTask.getAvailabilityZone(),
-        task.getAvailabilityZone() == ecsTask.getAvailabilityZone());
+            + ecsTask.getAvailabilityZone());
 
     assertTrue(
-        "Expected the task to have 0 containers but got " + task.getContainers().size(),
-        task.getContainers().size() == 0);
+        task.getContainers().size() == 0,
+        "Expected the task to have 0 containers but got " + task.getContainers().size());
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgentTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgentTest.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -39,7 +39,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class TaskCachingAgentTest extends CommonCachingAgent {
@@ -69,15 +69,15 @@ public class TaskCachingAgentTest extends CommonCachingAgent {
 
     // Then
     assertTrue(
+        returnedTasks.size() == tasks.size(),
         "Expected the list to contain "
             + tasks.size()
             + " ECS tasks, but got "
-            + returnedTasks.size(),
-        returnedTasks.size() == tasks.size());
+            + returnedTasks.size());
     for (Task task : returnedTasks) {
       assertTrue(
-          "Expected the task to be in  " + tasks + " list but it was not. The task is: " + task,
-          tasks.contains(task));
+          tasks.contains(task),
+          "Expected the task to be in  " + tasks + " list but it was not. The task is: " + task);
     }
   }
 
@@ -114,44 +114,44 @@ public class TaskCachingAgentTest extends CommonCachingAgent {
 
     // Then
     assertTrue(
+        dataMap.keySet().size() == 2,
         "Expected the data map to contain 2 namespaces, but it contains "
             + dataMap.keySet().size()
-            + " namespaces.",
-        dataMap.keySet().size() == 2);
+            + " namespaces.");
     assertTrue(
+        dataMap.containsKey(TASKS.toString()),
         "Expected the data map to contain "
             + TASKS.toString()
             + " namespace, but it contains "
             + dataMap.keySet()
-            + " namespaces.",
-        dataMap.containsKey(TASKS.toString()));
+            + " namespaces.");
     assertTrue(
+        dataMap.containsKey(ECS_CLUSTERS.toString()),
         "Expected the data map to contain "
             + ECS_CLUSTERS.toString()
             + " namespace, but it contains "
             + dataMap.keySet()
-            + " namespaces.",
-        dataMap.containsKey(ECS_CLUSTERS.toString()));
+            + " namespaces.");
     assertTrue(
+        dataMap.get(TASKS.toString()).size() == 2,
         "Expected there to be 2 CacheData, instead there is  "
-            + dataMap.get(TASKS.toString()).size(),
-        dataMap.get(TASKS.toString()).size() == 2);
+            + dataMap.get(TASKS.toString()).size());
 
     for (CacheData cacheData : dataMap.get(TASKS.toString())) {
       assertTrue(
+          keys.contains(cacheData.getId()),
           "Expected the key to be one of the following keys: "
               + keys.toString()
               + ". The key is: "
               + cacheData.getId()
-              + ".",
-          keys.contains(cacheData.getId()));
+              + ".");
       assertTrue(
+          taskArns.contains(cacheData.getAttributes().get("taskArn")),
           "Expected the task ARN to be one of the following ARNs: "
               + taskArns.toString()
               + ". The task ARN is: "
               + cacheData.getAttributes().get("taskArn")
-              + ".",
-          taskArns.contains(cacheData.getAttributes().get("taskArn")));
+              + ".");
     }
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCacheTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCacheTest.java
@@ -18,7 +18,8 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASK_DEFINITIONS;
-import static junit.framework.TestCase.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
@@ -31,8 +32,7 @@ import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskDefinitionCacheClient;
 import java.util.*;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class TaskDefinitionCacheTest extends CommonCachingAgent {
@@ -85,20 +85,20 @@ public class TaskDefinitionCacheTest extends CommonCachingAgent {
     // Then
     Collection<CacheData> cacheData =
         cacheResult.getCacheResults().get(TASK_DEFINITIONS.toString());
-    assertNotNull("Expected CacheData to be returned but null is returned", cacheData);
-    assertEquals("Expected 1 CacheData but returned " + cacheData.size(), 1, cacheData.size());
+    assertNotNull(cacheData, "Expected CacheData to be returned but null is returned");
+    assertEquals(1, cacheData.size(), "Expected 1 CacheData but returned " + cacheData.size());
     String retrievedKey = cacheData.iterator().next().getId();
     assertEquals(
-        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey,
         retrievedKey,
-        key);
+        key,
+        "Expected CacheData with ID " + key + " but retrieved ID " + retrievedKey);
 
-    Assert.assertEquals(
+    assertEquals(
+        taskDefinition,
+        retrievedTaskDefinition,
         "Expected the task definition to be "
             + taskDefinition
             + " but got "
-            + retrievedTaskDefinition,
-        taskDefinition,
-        retrievedTaskDefinition);
+            + retrievedTaskDefinition);
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgentTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgentTest.java
@@ -18,8 +18,8 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASK_DEFINITIONS;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
@@ -32,7 +32,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import java.util.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
 
 public class TaskDefinitionCachingAgentTest extends CommonCachingAgent {
@@ -73,17 +73,17 @@ public class TaskDefinitionCachingAgentTest extends CommonCachingAgent {
 
     // Then
     assertEquals(
-        "Expected the list to contain 1 ECS task definition, but got " + returnedTaskDefs.size(),
         1,
-        returnedTaskDefs.size());
+        returnedTaskDefs.size(),
+        "Expected the list to contain 1 ECS task definition, but got " + returnedTaskDefs.size());
     for (TaskDefinition taskDef : returnedTaskDefs) {
       assertEquals(
+          taskDef.getTaskDefinitionArn(),
+          TASK_DEFINITION_ARN_1,
           "Expected the task definition ARN to be  "
               + TASK_DEFINITION_ARN_1
               + " but it was: "
-              + taskDef.getTaskDefinitionArn(),
-          taskDef.getTaskDefinitionArn(),
-          TASK_DEFINITION_ARN_1);
+              + taskDef.getTaskDefinitionArn());
     }
   }
 
@@ -121,17 +121,17 @@ public class TaskDefinitionCachingAgentTest extends CommonCachingAgent {
 
     // Then
     assertEquals(
-        "Expected the list to contain 1 ECS task definition, but got " + returnedTaskDefs.size(),
         1,
-        returnedTaskDefs.size());
+        returnedTaskDefs.size(),
+        "Expected the list to contain 1 ECS task definition, but got " + returnedTaskDefs.size());
     for (TaskDefinition taskDef : returnedTaskDefs) {
       assertEquals(
+          taskDef.getTaskDefinitionArn(),
+          TASK_DEFINITION_ARN_1,
           "Expected the task definition ARN to be  "
               + TASK_DEFINITION_ARN_1
               + " but it was: "
-              + taskDef.getTaskDefinitionArn(),
-          taskDef.getTaskDefinitionArn(),
-          TASK_DEFINITION_ARN_1);
+              + taskDef.getTaskDefinitionArn());
     }
   }
 
@@ -158,37 +158,37 @@ public class TaskDefinitionCachingAgentTest extends CommonCachingAgent {
 
     // Then
     assertTrue(
+        dataMap.keySet().size() == 1,
         "Expected the data map to contain 1 namespaces, but it contains "
             + dataMap.keySet().size()
-            + " namespaces.",
-        dataMap.keySet().size() == 1);
+            + " namespaces.");
     assertTrue(
+        dataMap.containsKey(TASK_DEFINITIONS.toString()),
         "Expected the data map to contain "
             + TASK_DEFINITIONS.toString()
             + " namespace, but it contains "
             + dataMap.keySet()
-            + " namespaces.",
-        dataMap.containsKey(TASK_DEFINITIONS.toString()));
+            + " namespaces.");
     assertTrue(
+        dataMap.get(TASK_DEFINITIONS.toString()).size() == 2,
         "Expected there to be 2 CacheData, instead there is  "
-            + dataMap.get(TASK_DEFINITIONS.toString()).size(),
-        dataMap.get(TASK_DEFINITIONS.toString()).size() == 2);
+            + dataMap.get(TASK_DEFINITIONS.toString()).size());
 
     for (CacheData cacheData : dataMap.get(TASK_DEFINITIONS.toString())) {
       assertTrue(
+          keys.contains(cacheData.getId()),
           "Expected the key to be one of the following keys: "
               + keys.toString()
               + ". The key is: "
               + cacheData.getId()
-              + ".",
-          keys.contains(cacheData.getId()));
+              + ".");
       assertTrue(
+          taskDefinitionArns.contains(cacheData.getAttributes().get("taskDefinitionArn")),
           "Expected the task definition ARN to be one of the following ARNs: "
               + taskDefinitionArns.toString()
               + ". The task definition  ARN is: "
               + cacheData.getAttributes().get("taskDefinitionArn")
-              + ".",
-          taskDefinitionArns.contains(cacheData.getAttributes().get("taskDefinitionArn")));
+              + ".");
     }
   }
 }

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsAccountBuilderTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsAccountBuilderTest.java
@@ -16,14 +16,14 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.security;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration.Account;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EcsAccountBuilderTest {
 
@@ -42,23 +42,23 @@ public class EcsAccountBuilderTest {
 
     // Then
     assertTrue(
+        !account.getAccountType().equals(netflixAmazonCredentials.getAccountType()),
         "The new account should not be of the same type as the old account ("
             + netflixAmazonCredentials.getAccountType()
-            + ").",
-        !account.getAccountType().equals(netflixAmazonCredentials.getAccountType()));
+            + ").");
 
     assertTrue(
+        !account.getName().equals(netflixAmazonCredentials.getName()),
         "The new account should not have the same name as the old account ("
             + netflixAmazonCredentials.getName()
-            + ").",
-        !account.getName().equals(netflixAmazonCredentials.getName()));
+            + ").");
 
     assertTrue(
+        account.getAccountId().equals(netflixAmazonCredentials.getAccountId()),
         "The new account should have the same account ID as the old one ("
             + netflixAmazonCredentials.getAccountId()
             + ") but has "
             + account.getAccountId()
-            + " as the ID.",
-        account.getAccountId().equals(netflixAmazonCredentials.getAccountId()));
+            + " as the ID.");
   }
 }

--- a/clouddriver-event/clouddriver-event.gradle
+++ b/clouddriver-event/clouddriver-event.gradle
@@ -31,7 +31,6 @@ dependencies {
 
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.springframework:spring-test"
   testImplementation "org.springframework.boot:spring-boot-test"
@@ -40,6 +39,5 @@ dependencies {
   testImplementation "dev.minutest:minutest"
   testImplementation "io.mockk:mockk"
 
-  testRuntimeOnly "org.junit.platform:junit-platform-launcher"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -41,7 +41,6 @@ dependencies {
   testImplementation "org.apache.httpcomponents:httpmime"
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.mockito:mockito-junit-jupiter"
   testImplementation "org.objenesis:objenesis"
@@ -49,6 +48,8 @@ dependencies {
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
   testImplementation "org.springframework.boot:spring-boot-test"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
 
 configurations.all {

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/cache/CacheResultBuilderTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/cache/CacheResultBuilderTest.java
@@ -32,10 +32,7 @@ import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder.CacheDa
 import java.util.Collection;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class CacheResultBuilderTest {
 
   @Test

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/BatchComputeRequestImplTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/BatchComputeRequestImplTest.java
@@ -42,12 +42,9 @@ import com.netflix.spectator.api.Timer;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.http.client.HttpResponseException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class BatchComputeRequestImplTest {
 
   private static final String USER_AGENT = "spinnaker-test";
@@ -58,7 +55,7 @@ public class BatchComputeRequestImplTest {
 
   private Registry registry;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     registry = new DefaultRegistry();
   }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/BatchPaginatedComputeRequestImplTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/BatchPaginatedComputeRequestImplTest.java
@@ -30,10 +30,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class BatchPaginatedComputeRequestImplTest {
 
   @Test

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/GetFirstBatchComputeRequestTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/GetFirstBatchComputeRequestTest.java
@@ -27,10 +27,7 @@ import com.google.api.services.compute.model.Image;
 import java.io.IOException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class GetFirstBatchComputeRequestTest {
 
   @Test

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/ImagesTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/ImagesTest.java
@@ -35,10 +35,7 @@ import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials;
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class ImagesTest {
 
   private static final int CLOCK_STEP_TIME_MS = 1234;

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplatesTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplatesTest.java
@@ -38,11 +38,8 @@ import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry;
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials;
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials;
 import java.io.IOException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class InstanceTemplatesTest {
 
   private static final int CLOCK_STEP_TIME_MS = 1234;

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/PaginatedComputeRequestImplTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/PaginatedComputeRequestImplTest.java
@@ -28,10 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class PaginatedComputeRequestImplTest {
 
   @Test

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/RegionGoogleServerGroupManagersTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/RegionGoogleServerGroupManagersTest.java
@@ -39,11 +39,8 @@ import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry;
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials;
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials;
 import java.io.IOException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class RegionGoogleServerGroupManagersTest {
 
   private static final String REGION = "us-central1";

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/ZoneGoogleServerGroupManagersTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/ZoneGoogleServerGroupManagersTest.java
@@ -39,11 +39,8 @@ import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry;
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials;
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials;
 import java.io.IOException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class ZoneGoogleServerGroupManagersTest {
 
   private static final String ZONE = "us-central1-f";

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/SetStatefulDiskAtomicOperationConverterTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/SetStatefulDiskAtomicOperationConverterTest.java
@@ -30,12 +30,9 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCrede
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class SetStatefulDiskAtomicOperationConverterTest {
 
   private static final String ACCOUNT_NAME = "spinnaker-account";
@@ -45,7 +42,7 @@ public class SetStatefulDiskAtomicOperationConverterTest {
 
   SetStatefulDiskAtomicOperationConverter converter;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     GoogleClusterProvider clusterProvider = mock(GoogleClusterProvider.class);
     GoogleComputeApiFactory serverGroupManagersFactory = mock(GoogleComputeApiFactory.class);

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/StatefullyUpdateBootImageAtomicOperationTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/StatefullyUpdateBootImageAtomicOperationTest.java
@@ -59,13 +59,10 @@ import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(JUnitPlatform.class)
 @ExtendWith(MockitoExtension.class)
 final class StatefullyUpdateBootImageAtomicOperationTest {
 

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/SetStatefulDiskDescriptionValidatorTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/SetStatefulDiskDescriptionValidatorTest.java
@@ -25,14 +25,11 @@ import com.netflix.spinnaker.clouddriver.google.deploy.description.SetStatefulDi
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials;
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials;
 import org.assertj.core.api.Condition;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 
-@RunWith(JUnit4.class)
 public class SetStatefulDiskDescriptionValidatorTest {
 
   private static final String ACCOUNT_NAME = "spintest";
@@ -46,7 +43,7 @@ public class SetStatefulDiskDescriptionValidatorTest {
 
   private SetStatefulDiskDescriptionValidator validator;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     validator = new SetStatefulDiskDescriptionValidator();
   }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgentTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgentTest.java
@@ -83,10 +83,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 class AbstractGoogleServerGroupCachingAgentTest {
 
   private static final String ACCOUNT_NAME = "partypups";

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHealthCheckCachingAgentTest.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHealthCheckCachingAgentTest.groovy
@@ -29,10 +29,7 @@ import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.platform.runner.JUnitPlatform
-import org.junit.runner.RunWith
 
-@RunWith(JUnitPlatform.class)
 class GoogleHealthCheckCachingAgentTest {
 
   private static final String ACCOUNT_NAME = "partypups"

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgentTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgentTest.java
@@ -67,10 +67,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class GoogleRegionalServerGroupCachingAgentTest {
 
   private static final NamingStrategy<GoogleLabeledResource> NAMER =

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgentTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgentTest.java
@@ -62,10 +62,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class GoogleZonalServerGroupCachingAgentTest {
 
   private static final NamingStrategy<GoogleLabeledResource> NAMER =

--- a/clouddriver-huaweicloud/clouddriver-huaweicloud.gradle
+++ b/clouddriver-huaweicloud/clouddriver-huaweicloud.gradle
@@ -31,7 +31,6 @@ dependencies {
   testImplementation "org.apache.httpcomponents:httpmime"
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.mockito:mockito-junit-jupiter"
   testImplementation "org.objenesis:objenesis"

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -95,7 +95,6 @@ dependencies {
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.mockito:mockito-junit-jupiter"
   testImplementation "cglib:cglib-nodep"

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/ArtifactKeyTest.java
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/ArtifactKeyTest.java
@@ -25,10 +25,7 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact.ArtifactBuilder;
 import java.util.Collection;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class ArtifactKeyTest {
   private static String TYPE = "docker/image";
   private static String NAME = "gcr.io/test/test-image";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactConverterTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactConverterTest.java
@@ -25,10 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class ArtifactConverterTest {
   private static final String ACCOUNT = "my-account";
   private static final String NAMESPACE = "my-namespace";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacerTest.java
@@ -50,10 +50,7 @@ import lombok.Value;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class ArtifactReplacerTest {
   // We serialized generated Kubernetes metadata objects with JSON io.kubernetes.client.openapi.JSON
   // so that they match what we get back from kubectl.  We'll just gson from converting to a

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ReplacerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ReplacerTest.java
@@ -35,8 +35,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * The goal of this class is to do a test on each of the statically-defined replacers in {@link
@@ -49,7 +47,6 @@ import org.junit.runner.RunWith;
  * (ex: do we properly filter artifacts by namespace/account) this class focuses on ensuring that
  * each static replacer works as expected.
  */
-@RunWith(JUnitPlatform.class)
 final class ReplacerTest {
   // We serialized generated Kubernetes metadata objects with JSON io.kubernetes.client.openapi.JSON
   // so that they match what we get back from kubectl.  We'll just gson from converting to a

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ResourceVersionerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ResourceVersionerTest.java
@@ -38,12 +38,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(JUnitPlatform.class)
 @ExtendWith(MockitoExtension.class)
 final class ResourceVersionerTest {
   private static final ObjectMapper mapper = new ObjectMapper();

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KeysTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KeysTest.java
@@ -23,10 +23,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.CacheKey;
 import java.util.Optional;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KeysTest {
   @ParameterizedTest
   @ValueSource(

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverterTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverterTest.java
@@ -25,10 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesCacheDataConverterTest {
 
   @Test

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcherTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcherTest.java
@@ -33,10 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesCachingAgentDispatcherTest {
 
   @Test

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
@@ -66,11 +66,8 @@ import lombok.Value;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.stubbing.Answer;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesCoreCachingAgentTest {
   private static final String ACCOUNT = "my-account";
   private static final String NAMESPACE1 = "test-namespace";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgentTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgentTest.java
@@ -33,11 +33,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.springframework.lang.Nullable;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesUnregisteredCustomResourceCachingAgentTest {
 
   private static final String ACCOUNT = "my-account";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -89,12 +89,9 @@ import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsSmartNulls;
 
 @ExtendWith(SoftAssertionsExtension.class)
-@RunWith(JUnitPlatform.class)
 final class KubernetesDataProviderIntegrationTest {
   private static final String ACCOUNT_NAME = "my-account";
   private static final Registry registry = new NoopRegistry();

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesInstanceProviderTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesInstanceProviderTest.java
@@ -44,10 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesInstanceProviderTest {
 
   private KubernetesInstanceProvider provider;

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesRawResourceProviderTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesRawResourceProviderTest.java
@@ -38,10 +38,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesRawResourceProviderTest {
 
   private KubernetesRawResourceProvider provider;

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesCoordinatesTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesCoordinatesTest.java
@@ -24,10 +24,7 @@ import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesCoordinatesTest {
   @ParameterizedTest
   @MethodSource("parseNameCases")

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesPodMetricTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesPodMetricTest.java
@@ -28,10 +28,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesPodMetricTest {
   private static final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesEnableDisableManifestDescriptionTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesEnableDisableManifestDescriptionTest.java
@@ -22,10 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesEnableDisableManifestDescriptionTest {
   private static final JsonNodeFactory jsonFactory = JsonNodeFactory.instance;
   private static final ObjectMapper objectMapper = new ObjectMapper();

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestOwnerRefTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestOwnerRefTest.java
@@ -22,10 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesManifestOwnerRefTest {
 
   @ParameterizedTest

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestReplicasTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestReplicasTest.java
@@ -23,10 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesManifestReplicasTest {
   private static final JsonNodeFactory jsonFactory = JsonNodeFactory.instance;
   private static final ObjectMapper objectMapper = new ObjectMapper();

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestStrategyTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestStrategyTest.java
@@ -29,10 +29,7 @@ import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesManifestStrategyTest {
   @Test
   void deployStrategyDefaultsToApply() {

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTest.java
@@ -22,10 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashMap;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesManifestTest {
 
   private static final String GENERATE_NAME = "my-generate-name";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTrafficTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTrafficTest.java
@@ -22,10 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesManifestTrafficTest {
   @Test
   final void createNullTraffic() {

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicatorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicatorTest.java
@@ -39,14 +39,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 
-@RunWith(JUnitPlatform.class)
 @ExtendWith(MockitoExtension.class)
 final class KubernetesHealthIndicatorTest {
   private static final String ERROR_MESSAGE = "Failed to get namespaces";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/manifest/KubernetesDeployManifestConverterTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/manifest/KubernetesDeployManifestConverterTest.java
@@ -35,11 +35,8 @@ import java.nio.charset.Charset;
 import java.util.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesDeployManifestConverterTest {
   private static KubernetesDeployManifestConverter converter;
   private static ObjectMapper mapper;

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/names/KubernetesNamerRegistryTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/names/KubernetesNamerRegistryTest.java
@@ -25,10 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.names.NamingStrategy;
 import com.netflix.spinnaker.moniker.Moniker;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesNamerRegistryTest {
   private static final NamingStrategy<KubernetesManifest> DEFAULT_NAMER =
       new KubernetesManifestNamer();

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeleteManifestOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeleteManifestOperationTest.java
@@ -17,8 +17,8 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.op;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -56,13 +56,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 /** Test the deleteManifest stage. */
-@RunWith(JUnitPlatform.class)
 public class KubernetesDeleteManifestOperationTest {
   private static final GlobalResourcePropertyRegistry resourcePropertyRegistry =
       new GlobalResourcePropertyRegistry(

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
@@ -58,10 +58,7 @@ import com.netflix.spinnaker.moniker.Namer;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesDeployManifestOperationTest {
   private static final String DEFAULT_NAMESPACE = "default-namespace";
   private static final ResourcePropertyRegistry resourcePropertyRegistry =

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanDeployTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanDeployTest.java
@@ -35,10 +35,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentia
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesSelectorList;
 import io.kubernetes.client.openapi.models.V1DeleteOptions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class CanDeployTest {
   private final CanDeploy handler = new CanDeploy() {};
   private final String OP_NAME = "Can Deploy Test";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesDaemonSetHandlerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesDaemonSetHandlerTest.java
@@ -22,10 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest.Status;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesDaemonSetHandlerTest {
   private KubernetesDaemonSetHandler handler = new KubernetesDaemonSetHandler();
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHorizontalPodAutoscalerHandlerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHorizontalPodAutoscalerHandlerTest.java
@@ -22,10 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest.Status;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesHorizontalPodAutoscalerHandlerTest {
   private KubernetesHorizontalPodAutoscalerHandler handler =
       new KubernetesHorizontalPodAutoscalerHandler();

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesStatefulSetHandlerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesStatefulSetHandlerTest.java
@@ -22,10 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest.Status;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesStatefulSetHandlerTest {
   private KubernetesStatefulSetHandler handler = new KubernetesStatefulSetHandler();
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
@@ -73,11 +73,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.slf4j.LoggerFactory;
 
-@RunWith(JUnitPlatform.class)
 final class KubectlJobExecutorTest {
   private static final String NAMESPACE = "test-namespace";
   JobExecutor jobExecutor;

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
@@ -52,10 +52,7 @@ import com.netflix.spinnaker.moniker.Namer;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesRunJobOperationTest {
   private static final String NAMESPACE = "my-namespace";
   private static final String GENERATE_SUFFIX = "-abcd";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProviderTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProviderTest.java
@@ -18,8 +18,8 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.provider.view;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsLifecycleHandlerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsLifecycleHandlerTest.java
@@ -36,11 +36,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesCredentialsLifecycleHandlerTest {
   KubernetesProvider provider;
   KubernetesCachingAgentDispatcher cachingAgentDispatcher;

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsTest.java
@@ -51,10 +51,7 @@ import com.netflix.spinnaker.kork.configserver.CloudConfigResourceService;
 import com.netflix.spinnaker.kork.configserver.ConfigFileService;
 import java.util.HashMap;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesCredentialsTest {
   private static final String ACCOUNT_NAME = "my-account";
   private static final String DEPLOYMENT_NAME = "my-deployment";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesKindRegistryTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesKindRegistryTest.java
@@ -26,10 +26,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import java.util.Collection;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesKindRegistryTest {
   private static final KubernetesApiGroup CUSTOM_API_GROUP = KubernetesApiGroup.fromString("test");
   private static final KubernetesKind CUSTOM_KIND =

--- a/clouddriver-lambda/clouddriver-lambda.gradle
+++ b/clouddriver-lambda/clouddriver-lambda.gradle
@@ -37,9 +37,10 @@ dependencies {
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
+
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgentTest.java
+++ b/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgentTest.java
@@ -32,8 +32,8 @@ import com.netflix.spinnaker.clouddriver.lambda.cache.Keys;
 import com.netflix.spinnaker.clouddriver.lambda.service.config.LambdaServiceConfig;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LambdaCachingAgentTest {
   private ObjectMapper objectMapper = new ObjectMapper();
@@ -46,7 +46,7 @@ public class LambdaCachingAgentTest {
   private LambdaCachingAgent lambdaCachingAgent;
   private final ProviderCache cache = mock(ProviderCache.class);
 
-  @Before
+  @BeforeEach
   public void setup() {
     when(config.getRetry()).thenReturn(new LambdaServiceConfig.Retry());
     when(config.getConcurrency()).thenReturn(new LambdaServiceConfig.Concurrency());

--- a/clouddriver-saga-test/clouddriver-saga-test.gradle
+++ b/clouddriver-saga-test/clouddriver-saga-test.gradle
@@ -23,7 +23,6 @@ dependencies {
 
   implementation "cglib:cglib-nodep"
   implementation "org.objenesis:objenesis"
-  implementation "org.junit.platform:junit-platform-runner"
   implementation "org.junit.jupiter:junit-jupiter-api"
   implementation "org.springframework:spring-test"
   implementation "org.springframework.boot:spring-boot-test"

--- a/clouddriver-saga/clouddriver-saga.gradle
+++ b/clouddriver-saga/clouddriver-saga.gradle
@@ -19,7 +19,6 @@ dependencies {
   testImplementation project(":clouddriver-saga-test")
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.springframework:spring-test"
   testImplementation "org.springframework.boot:spring-boot-test"
@@ -28,6 +27,5 @@ dependencies {
   testImplementation "dev.minutest:minutest"
   testImplementation "io.mockk:mockk"
 
-  testRuntimeOnly "org.junit.platform:junit-platform-launcher"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/clouddriver-security/clouddriver-security.gradle
+++ b/clouddriver-security/clouddriver-security.gradle
@@ -19,7 +19,6 @@ dependencies {
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.mockito:mockito-junit-jupiter"
   testImplementation "org.mockito:mockito-core"

--- a/clouddriver-security/src/test/java/com/netflix/spinnaker/clouddriver/security/DefaultAccountCredentialsProviderTest.java
+++ b/clouddriver-security/src/test/java/com/netflix/spinnaker/clouddriver/security/DefaultAccountCredentialsProviderTest.java
@@ -26,11 +26,8 @@ import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.credentials.CompositeCredentialsRepository;
 import java.util.HashSet;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.AdditionalMatchers;
 
-@RunWith(JUnitPlatform.class)
 public class DefaultAccountCredentialsProviderTest {
 
   @Test

--- a/clouddriver-sql/clouddriver-sql.gradle
+++ b/clouddriver-sql/clouddriver-sql.gradle
@@ -42,7 +42,6 @@ dependencies {
 
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.springframework:spring-test"
   testImplementation "org.springframework.boot:spring-boot-test"
@@ -53,6 +52,5 @@ dependencies {
   testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin"
   testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 
-  testRuntimeOnly "org.junit.platform:junit-platform-launcher"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/clouddriver-sql/src/test/java/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepositoryTest.java
+++ b/clouddriver-sql/src/test/java/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepositoryTest.java
@@ -23,7 +23,7 @@ import com.netflix.spinnaker.kork.sql.config.RetryProperties;
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties;
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil;
 import java.time.Clock;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
 public class SqlTaskRepositoryTest extends TaskRepositoryTck {
 
@@ -46,7 +46,7 @@ public class SqlTaskRepositoryTest extends TaskRepositoryTck {
         ConnectionPools.TASKS.getValue());
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     if (database != null) {
       SqlTestUtil.cleanupDb(database.context);

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/MainSpec.java
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/MainSpec.java
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {Main.class})
 @TestPropertySource(
     properties = {

--- a/clouddriver-yandex/clouddriver-yandex.gradle
+++ b/clouddriver-yandex/clouddriver-yandex.gradle
@@ -33,7 +33,6 @@ dependencies {
   testImplementation "org.apache.httpcomponents:httpmime"
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.mockito:mockito-junit-jupiter"
   testImplementation "org.objenesis:objenesis"

--- a/clouddriver-yandex/src/test/java/com/netflix/spinnaker/clouddriver/yandex/controller/YandexControllersTest.java
+++ b/clouddriver-yandex/src/test/java/com/netflix/spinnaker/clouddriver/yandex/controller/YandexControllersTest.java
@@ -24,16 +24,16 @@ import com.netflix.spinnaker.clouddriver.Main;
 import com.netflix.spinnaker.clouddriver.yandex.YandexCloudProvider;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureMockMvc
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {Main.class, TestConfig.class})
 @TestPropertySource(
     properties = {

--- a/clouddriver-yandex/src/test/java/com/netflix/spinnaker/clouddriver/yandex/provider/agent/YandexNetworkLoadBalancerCachingAgentTest.java
+++ b/clouddriver-yandex/src/test/java/com/netflix/spinnaker/clouddriver/yandex/provider/agent/YandexNetworkLoadBalancerCachingAgentTest.java
@@ -16,10 +16,10 @@
 
 package com.netflix.spinnaker.clouddriver.yandex.provider.agent;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
Before refactor, total test cases executed were 3976, 7 ignored. 
After refactor, total test cases executed are 4071, 7 ignored.