### PR TITLE
feat(provider/kubernetes): support for kubectl server-side-apply strategy

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestStrategy.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestStrategy.java
@@ -107,7 +107,8 @@ public final class KubernetesManifestStrategy {
   public enum DeployStrategy {
     APPLY(null),
     RECREATE(STRATEGY_ANNOTATION_PREFIX + "/recreate"),
-    REPLACE(STRATEGY_ANNOTATION_PREFIX + "/replace");
+    REPLACE(STRATEGY_ANNOTATION_PREFIX + "/replace"),
+    SERVER_SIDE_APPLY(STRATEGY_ANNOTATION_PREFIX + "/server-side-apply");
 
     @Nullable private final String annotation;
 
@@ -121,6 +122,9 @@ public final class KubernetesManifestStrategy {
       }
       if (Boolean.parseBoolean(annotations.get(REPLACE.annotation))) {
         return REPLACE;
+      }
+      if (Boolean.parseBoolean(annotations.get(SERVER_SIDE_APPLY.annotation))) {
+        return SERVER_SIDE_APPLY;
       }
       return APPLY;
     }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanDeploy.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanDeploy.java
@@ -59,6 +59,9 @@ public interface CanDeploy {
       case REPLACE:
         deployedManifest = credentials.createOrReplace(manifest, task, opName);
         break;
+      case SERVER_SIDE_APPLY:
+        deployedManifest = credentials.deploy(manifest, task, opName, "--server-side");
+        break;
       case APPLY:
         deployedManifest = credentials.deploy(manifest, task, opName);
         break;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -587,10 +587,14 @@ public class KubectlJobExecutor {
   }
 
   public KubernetesManifest deploy(
-      KubernetesCredentials credentials, KubernetesManifest manifest, Task task, String opName) {
+      KubernetesCredentials credentials,
+      KubernetesManifest manifest,
+      Task task,
+      String opName,
+      String... cmdArgs) {
     log.info("Deploying manifest {}", manifest.getFullResourceName());
     List<String> command = kubectlAuthPrefix(credentials);
-
+    command.addAll(List.of(cmdArgs));
     // Read from stdin
     command.add("apply");
     command.add("-o");

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -561,12 +561,13 @@ public class KubernetesCredentials {
         () -> jobExecutor.topPod(this, coords.getNamespace(), coords.getName()));
   }
 
-  public KubernetesManifest deploy(KubernetesManifest manifest, Task task, String opName) {
+  public KubernetesManifest deploy(
+      KubernetesManifest manifest, Task task, String opName, String... cmdArgs) {
     return runAndRecordMetrics(
         "deploy",
         manifest.getKind(),
         manifest.getNamespace(),
-        () -> jobExecutor.deploy(this, manifest, task, opName));
+        () -> jobExecutor.deploy(this, manifest, task, opName, cmdArgs));
   }
 
   private KubernetesManifest replace(KubernetesManifest manifest, Task task, String opName) {

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestStrategyTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestStrategyTest.java
@@ -65,6 +65,14 @@ final class KubernetesManifestStrategyTest {
   }
 
   @Test
+  void serverSideApplyStrategy() {
+    KubernetesManifestStrategy.DeployStrategy strategy =
+        KubernetesManifestStrategy.DeployStrategy.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/server-side-apply", "true"));
+    assertThat(strategy).isEqualTo(DeployStrategy.SERVER_SIDE_APPLY);
+  }
+
+  @Test
   void nonBooleanValue() {
     KubernetesManifestStrategy.DeployStrategy strategy =
         KubernetesManifestStrategy.DeployStrategy.fromAnnotations(

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanDeployTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanDeployTest.java
@@ -62,6 +62,16 @@ final class CanDeployTest {
   }
 
   @Test
+  void applyServerSideMutations() {
+    KubernetesCredentials credentials = mock(KubernetesCredentials.class);
+    KubernetesManifest manifest = ManifestFetcher.getManifest("candeploy/deployment.yml");
+    when(credentials.deploy(manifest, task, OP_NAME, "--server-side")).thenReturn(manifest);
+    handler.deploy(credentials, manifest, DeployStrategy.SERVER_SIDE_APPLY, task, OP_NAME);
+    verify(credentials).deploy(manifest, task, OP_NAME, "--server-side");
+    verifyNoMoreInteractions(credentials);
+  }
+
+  @Test
   void replaceMutations() {
     KubernetesCredentials credentials = mock(KubernetesCredentials.class);
     KubernetesManifest manifest = ManifestFetcher.getManifest("candeploy/deployment.yml");


### PR DESCRIPTION
kubernetes server-side apply (SSA) was released back in 1.14 and became GA In 1.22. This new strategy will use the new merging algorithm, as well as tracking field ownership at the kubernetes api-server

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
