### PR TITLE
(feat): increase kubernetes integration test coverage

### DIFF
--- a/.github/workflows/integration-tests-kubernetes.yml
+++ b/.github/workflows/integration-tests-kubernetes.yml
@@ -1,18 +1,16 @@
-name: Integration Tests
+name: Kubernetes Integration Tests
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: workflow_call
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx6g -Xms6g
 
 jobs:
   it-test-kubernetes:
-    uses: ./.github/workflows/integration-tests-kubernetes.yml
-  it-test:
+    strategy:
+      matrix:
+        kubernetes-image:
+          - "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -43,10 +41,5 @@ jobs:
           key: ${{ runner.os }}-cd-it-${{ github.event.pull_request.head.sha }}
           restore-keys: |
             ${{ runner.os }}-cd-it-${{ github.event.before }}
-      # Separating integration tests by provider allows to have separate logs
-      - name: Amazon ECS Provider Integration Tests
-        run: ./gradlew --build-cache :clouddriver-ecs:integrationTest
-      - name: Artifacts Integration Tests
-        run: ./gradlew --build-cache :clouddriver-artifacts:integrationTest
-      - name: AWS EC2 Provider Integration Tests
-        run: ./gradlew --build-cache :clouddriver-aws:integrationTest
+      - name: Kubernetes Provider Integration Tests
+        run: ./gradlew --build-cache :clouddriver-kubernetes:integrationTest -Pkubernetes-image=${{ matrix.kubernetes-image }}

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -95,7 +95,6 @@ dependencies {
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
-  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.mockito:mockito-junit-jupiter"
   testImplementation "cglib:cglib-nodep"
@@ -131,6 +130,7 @@ task integrationTest(type: Test) {
   group = 'verification'
 
   environment "IT_BUILD_HOME", "$project.buildDir/it"
+  environment "IMAGE", project.getProperties().get("kubernetes-image")
   useJUnitPlatform()
 
   testClassesDirs = sourceSets.integration.output.classesDirs

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/containers/KubernetesCluster.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/containers/KubernetesCluster.java
@@ -35,6 +35,7 @@ import org.springframework.util.FileCopyUtils;
 public class KubernetesCluster {
 
   private static KubernetesCluster INSTANCE;
+  private static final String IMAGE = System.getenv("IMAGE");
   private static final String KIND_VERSION = "0.11.1";
   private static final String KUBECTL_VERSION = "1.20.6";
   private static final Path IT_BUILD_HOME = Paths.get(System.getenv("IT_BUILD_HOME"));
@@ -171,7 +172,11 @@ public class KubernetesCluster {
       System.out.println("Deleting old test cluster");
       runKindCmd("delete cluster --name=kube-int-tests");
     }
-    runKindCmd("create cluster --name=kube-int-tests --kubeconfig=" + KUBECFG_PATH + " --wait=10m");
+    runKindCmd(
+        "create cluster --name=kube-int-tests --kubeconfig="
+            + KUBECFG_PATH
+            + " --wait=10m --image="
+            + IMAGE);
   }
 
   private String runKindCmd(String args) throws IOException, InterruptedException {


### PR DESCRIPTION
This PR addresses [this issue](https://github.com/spinnaker/spinnaker/issues/6612) by using the matrix feature of Github Actions to enable running the kubernetes integration tests for multiple versions of kubernetes in parallel. It extracts the kubernetes tests into a separate workflow called `kubernetes-integration-tests` to avoid running the other integration tests multiple times. This workflow is called by the main integration tests workflow. 

The kubernetes tests workflow passes the kubernetes images specified in the matrix to gradle as a project property: `./gradlew --build-cache :clouddriver-kubernetes:integrationTest -Pkubernetes-image=${{ matrix.kubernetes-image }}`. This value is then passed to the java code as an environment variable so that the `createCluster()` method can utilize the correct image.

Currently, the kubernetes integration tests pass only for version 1.21.1 from the list of images specified [here](https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1). I believe fixing compatibility issues with other versions should be worked on in future pull requests once the mechanism for testing multiple versions is put in place.
