### PR TITLE
feat(integration-tests): updated version of kind and added images for k8s v1.19 - v1.28

### DIFF
--- a/.github/workflows/integration-tests-kubernetes.yml
+++ b/.github/workflows/integration-tests-kubernetes.yml
@@ -10,7 +10,16 @@ jobs:
     strategy:
       matrix:
         kubernetes-image:
+          - "kindest/node:v1.28.0@sha256:9f3ff58f19dcf1a0611d11e8ac989fdb30a28f40f236f59f0bea31fb956ccf5c"
+          - "kindest/node:v1.27.3@sha256:9dd3392d79af1b084671b05bcf65b21de476256ad1dcc853d9f3b10b4ac52dde"
+          - "kindest/node:v1.26.6@sha256:5e5d789e90c1512c8c480844e0985bc3b4da4ba66179cc5b540fe5b785ca97b5"
+          - "kindest/node:v1.25.11@sha256:ca7371d5d1f680778e40e9bcbbea06c3c61ac6f0e1a29cba5c58ff2dae1ba7f5"
+          - "kindest/node:v1.24.15@sha256:24473777a1eef985dc405c23ab9f4daddb1352ca23db60b75de9e7c408096491"
+          - "kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac"
+          - "kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047"
           - "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
+          - "kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"
+          - "kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -42,4 +51,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cd-it-${{ github.event.before }}
       - name: Kubernetes Provider Integration Tests
-        run: ./gradlew --build-cache :clouddriver-kubernetes:integrationTest -Pkubernetes-image=${{ matrix.kubernetes-image }}
+        run: |
+          version=$(echo '${{ matrix.kubernetes-image }}' | grep -o 'v[0-9]*\.[0-9]*')
+          ./gradlew --build-cache :clouddriver-kubernetes:integrationTest -Pkubernetes-image=${{ matrix.kubernetes-image }} -Pkubernetes-version=${version}

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -131,6 +131,7 @@ task integrationTest(type: Test) {
 
   environment "IT_BUILD_HOME", "$project.buildDir/it"
   environment "IMAGE", project.getProperties().get("kubernetes-image")
+  environment "KUBERNETES_VERSION", project.getProperties().get("kubernetes-version")
   useJUnitPlatform()
 
   testClassesDirs = sourceSets.integration.output.classesDirs

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/BaseTest.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/BaseTest.java
@@ -41,6 +41,7 @@ public abstract class BaseTest {
   public static final String APP2_NAME = "testApp2";
   public static final String ACCOUNT1_NAME = "account1";
   public static final String ACCOUNT2_NAME = "account2";
+  public static final String KUBERNETES_VERSION = System.getenv("KUBERNETES_VERSION");
 
   @LocalServerPort int port;
 

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/containers/KubernetesCluster.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/containers/KubernetesCluster.java
@@ -36,7 +36,7 @@ public class KubernetesCluster {
 
   private static KubernetesCluster INSTANCE;
   private static final String IMAGE = System.getenv("IMAGE");
-  private static final String KIND_VERSION = "0.11.1";
+  private static final String KIND_VERSION = "0.20.0";
   private static final String KUBECTL_VERSION = "1.22.17";
   private static final Path IT_BUILD_HOME = Paths.get(System.getenv("IT_BUILD_HOME"));
   private static final Path KUBECFG_PATH = Paths.get(IT_BUILD_HOME.toString(), "kubecfg.yml");

--- a/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/utils/KubeTestUtils.java
+++ b/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/utils/KubeTestUtils.java
@@ -44,6 +44,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
+import org.testcontainers.utility.ComparableVersion;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
@@ -497,5 +498,12 @@ public abstract class KubeTestUtils {
     }
 
     deployAndWaitStable(baseUrl, account, namespace, kind, name, app, image);
+  }
+
+  public static int compareVersion(String sv1, String sv2) {
+    ComparableVersion v1 = new ComparableVersion(sv1.replace("v", ""));
+    ComparableVersion v2 = new ComparableVersion(sv2.replace("v", ""));
+
+    return v1.compareTo(v2);
   }
 }


### PR DESCRIPTION
This PR is a logical extension of [this merged PR](https://github.com/spinnaker/clouddriver/pull/5990) and continues to address the need for [increased k8s integration test coverage](https://github.com/spinnaker/spinnaker/issues/6612) by updating the version of [kind](https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0) used to the latest and specifying a list of compatible images for k8s versions v1.19 - v1.28 that the integration tests can run in parallel against.