### PR TITLE
chore(dependency): add explicit dependency of groovy-test in clouddriver-google while upgrading groovy 3.x

### DIFF
--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -48,6 +48,7 @@ dependencies {
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
   testImplementation "org.springframework.boot:spring-boot-test"
+  testImplementation "org.codehaus.groovy:groovy-test"
 
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }


### PR DESCRIPTION
With groovy 2.5.15 and spockframework 1.3-groovy-2.5, groovy-test appear as transitive dependency of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/1.3-groovy-2.5) as shown below:
```
$ ./gradlew clouddriver-google:dI --dependency groovy-test --configuration testCompileClasspath

> Task :clouddriver-google:dependencyInsight
org.codehaus.groovy:groovy-test:2.5.15
  Variant compile:
    | Attribute Name                     | Provided | Requested         |
    |------------------------------------|----------|-------------------|
    | org.gradle.status                  | release  |                   |
    | org.gradle.category                | library  | library           |
    | org.gradle.libraryelements         | jar      | classes+resources |
    | org.gradle.usage                   | java-api | java-api          |
    | org.gradle.dependency.bundling     |          | external          |
    | org.gradle.jvm.environment         |          | standard-jvm      |
    | org.gradle.jvm.version             |          | 11                |
    | org.jetbrains.kotlin.platform.type |          | jvm               |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy-test:2.5.15
\--- io.spinnaker.kork:kork-bom:7.190.0
     \--- testCompileClasspath

org.codehaus.groovy:groovy-test:2.5.4 -> 2.5.15
+--- org.spockframework:spock-core:1.3-groovy-2.5
|    +--- testCompileClasspath (requested org.spockframework:spock-core)
|    +--- io.spinnaker.kork:kork-bom:7.190.0
|    |    \--- testCompileClasspath
|    \--- org.spockframework:spock-spring:1.3-groovy-2.5
|         +--- testCompileClasspath (requested org.spockframework:spock-spring)
|         \--- io.spinnaker.kork:kork-bom:7.190.0 (*)
\--- org.spockframework:spock-spring:1.3-groovy-2.5 (*)
```
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, groovy-test is not part of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/2.0-groovy-3.0) and encounter below error during test compilation:
```
startup failed:
/clouddriver/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperationUnitSpec.groovy: 41: unable to resolve class groovy.mock.interceptor.MockFor
 @ line 41, column 1.
   import groovy.mock.interceptor.MockFor
   ^
/clouddriver/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleImageTagsAtomicOperationUnitSpec.groovy: 35: unable to resolve class groovy.mock.interceptor.MockFor
 @ line 35, column 1.
   import groovy.mock.interceptor.MockFor
   ^
2 errors
> Task :clouddriver-google:compileTestGroovy FAILED
```

So, adding explicit dependency of groovy-test in clouddriver-google.gradle