### PR TITLE
fix(lambda): Lambda is leaking threads on agent refreshes.  

### DIFF
--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/AsgConfigHelperSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/AsgConfigHelperSpec.groovy
@@ -53,8 +53,9 @@ class AsgConfigHelperSpec extends Specification {
     when:
     def actualName = AsgConfigHelper.createName(baseName, suffix)
 
+    //ignore the end precision for tests.
     then:
-    actualName.contains(expectedName)
+    actualName.contains(expectedName.substring(0, expectedName.length() - 3))
 
     where:
     baseName | suffix   || expectedName

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgent.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgent.java
@@ -91,13 +91,7 @@ public class LambdaCachingAgent implements CachingAgent, AccountAware, OnDemandA
             this,
             AmazonCloudProvider.ID + ":" + AmazonCloudProvider.ID + ":" + OnDemandType.Function);
     this.lambdaService =
-        new LambdaService(
-            amazonClientProvider,
-            account,
-            region,
-            objectMapper,
-            lambdaServiceConfig,
-            serviceLimitConfiguration);
+        new LambdaService(amazonClientProvider, account, region, objectMapper, lambdaServiceConfig);
   }
 
   @Override

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/service/config/LambdaServiceConfig.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/service/config/LambdaServiceConfig.java
@@ -26,16 +26,10 @@ import org.springframework.stereotype.Component;
 public class LambdaServiceConfig {
 
   private Retry retry = new Retry();
-  private Concurrency concurrency = new Concurrency();
 
   @Data
   public static class Retry {
     private int timeout = 15;
     private int retries = 5;
-  }
-
-  @Data
-  public static class Concurrency {
-    private int threads = 10;
   }
 }

--- a/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgentTest.java
+++ b/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaCachingAgentTest.java
@@ -49,7 +49,6 @@ public class LambdaCachingAgentTest {
   @BeforeEach
   public void setup() {
     when(config.getRetry()).thenReturn(new LambdaServiceConfig.Retry());
-    when(config.getConcurrency()).thenReturn(new LambdaServiceConfig.Concurrency());
     when(serviceLimitConfiguration.getLimit(any(), any(), any(), any(), any())).thenReturn(1.0);
     lambdaCachingAgent =
         new LambdaCachingAgent(

--- a/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/service/LambdaServiceTest.java
+++ b/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/service/LambdaServiceTest.java
@@ -32,19 +32,13 @@ class LambdaServiceTest {
   @Test
   void getAllFunctionsWhenFunctionsResultIsNullExpectEmpty() throws InterruptedException {
     when(lambdaServiceConfig.getRetry()).thenReturn(new LambdaServiceConfig.Retry());
-    when(lambdaServiceConfig.getConcurrency()).thenReturn(new LambdaServiceConfig.Concurrency());
     when(serviceLimitConfiguration.getLimit(any(), any(), any(), any(), any())).thenReturn(1.0);
     AWSLambda lambda = mock(AWSLambda.class); // returns null by default
     when(clientProvider.getAmazonLambda(any(), any())).thenReturn(lambda);
 
     LambdaService lambdaService =
         new LambdaService(
-            clientProvider,
-            netflixAmazonCredentials,
-            REGION,
-            objectMapper,
-            lambdaServiceConfig,
-            serviceLimitConfiguration);
+            clientProvider, netflixAmazonCredentials, REGION, objectMapper, lambdaServiceConfig);
 
     List<Map<String, Object>> allFunctions = lambdaService.getAllFunctions();
 
@@ -54,7 +48,6 @@ class LambdaServiceTest {
   @Test
   void getAllFunctionsWhenFunctionsResultIsEmptyExpectEmpty() throws InterruptedException {
     when(lambdaServiceConfig.getRetry()).thenReturn(new LambdaServiceConfig.Retry());
-    when(lambdaServiceConfig.getConcurrency()).thenReturn(new LambdaServiceConfig.Concurrency());
     when(serviceLimitConfiguration.getLimit(any(), any(), any(), any(), any())).thenReturn(1.0);
 
     ListFunctionsResult functionsResult = mock(ListFunctionsResult.class);
@@ -66,12 +59,7 @@ class LambdaServiceTest {
 
     LambdaService lambdaService =
         new LambdaService(
-            clientProvider,
-            netflixAmazonCredentials,
-            REGION,
-            objectMapper,
-            lambdaServiceConfig,
-            serviceLimitConfiguration);
+            clientProvider, netflixAmazonCredentials, REGION, objectMapper, lambdaServiceConfig);
 
     List<Map<String, Object>> allFunctions = lambdaService.getAllFunctions();
 
@@ -81,7 +69,6 @@ class LambdaServiceTest {
   @Test
   void getAllFunctionsWhenFunctionNameIsEmptyExpectEmpty() throws InterruptedException {
     when(lambdaServiceConfig.getRetry()).thenReturn(new LambdaServiceConfig.Retry());
-    when(lambdaServiceConfig.getConcurrency()).thenReturn(new LambdaServiceConfig.Concurrency());
     when(serviceLimitConfiguration.getLimit(any(), any(), any(), any(), any())).thenReturn(1.0);
 
     ListFunctionsResult functionsResult = mock(ListFunctionsResult.class);
@@ -93,12 +80,7 @@ class LambdaServiceTest {
 
     LambdaService lambdaService =
         new LambdaService(
-            clientProvider,
-            netflixAmazonCredentials,
-            REGION,
-            objectMapper,
-            lambdaServiceConfig,
-            serviceLimitConfiguration);
+            clientProvider, netflixAmazonCredentials, REGION, objectMapper, lambdaServiceConfig);
 
     List<Map<String, Object>> allFunctions = lambdaService.getAllFunctions();
 
@@ -108,7 +90,6 @@ class LambdaServiceTest {
   @Test
   void getAllFunctionsWhenFunctionNameIsNotEmptyExpectNotEmpty() throws InterruptedException {
     when(lambdaServiceConfig.getRetry()).thenReturn(new LambdaServiceConfig.Retry());
-    when(lambdaServiceConfig.getConcurrency()).thenReturn(new LambdaServiceConfig.Concurrency());
     when(serviceLimitConfiguration.getLimit(any(), any(), any(), any(), any())).thenReturn(1.0);
 
     ListFunctionsResult functionsResult = mock(ListFunctionsResult.class);
@@ -160,12 +141,7 @@ class LambdaServiceTest {
 
     LambdaService lambdaService =
         new LambdaService(
-            clientProvider,
-            netflixAmazonCredentials,
-            REGION,
-            objectMapper,
-            lambdaServiceConfig,
-            serviceLimitConfiguration);
+            clientProvider, netflixAmazonCredentials, REGION, objectMapper, lambdaServiceConfig);
 
     List<Map<String, Object>> allFunctions = lambdaService.getAllFunctions();
 


### PR DESCRIPTION
The custom executor service thing which seems like a perf improvement is causing thread leak and eventual failures.  Remove it entirely.  