### PR TITLE
refactor(aws/test): fix conflict of variable scope by renaming local variables during upgrade of groovy 3.x

### DIFF
--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperationSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperationSpec.groovy
@@ -104,9 +104,9 @@ class ModifyAsgLaunchConfigurationOperationSpec extends Specification {
 
     then:
     1 * asgService.getAutoScalingGroup(asgName) >> new AutoScalingGroup().withLaunchConfigurationName(existingLc)
-    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region, name ->
+    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region_local, name ->
       assert act == credential
-      assert region == region
+      assert region_local == region
       assert name == existingLc
 
       existing
@@ -154,9 +154,9 @@ class ModifyAsgLaunchConfigurationOperationSpec extends Specification {
 
     then:
     1 * asgService.getAutoScalingGroup(asgName) >> new AutoScalingGroup().withLaunchConfigurationName(existingLc)
-    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region, name ->
+    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region_local, name ->
       assert act == credential
-      assert region == region
+      assert region_local == region
       assert name == existingLc
 
       existing
@@ -220,9 +220,9 @@ class ModifyAsgLaunchConfigurationOperationSpec extends Specification {
 
     then:
     1 * asgService.getAutoScalingGroup(asgName) >> new AutoScalingGroup().withLaunchConfigurationName(existingLc)
-    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region, name ->
+    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region_local, name ->
       assert act == credential
-      assert region == region
+      assert region_local == region
       assert name == existingLc
 
       existing
@@ -280,9 +280,9 @@ class ModifyAsgLaunchConfigurationOperationSpec extends Specification {
 
     then:
     1 * asgService.getAutoScalingGroup(asgName) >> new AutoScalingGroup().withLaunchConfigurationName(existingLc)
-    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region, name ->
+    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region_local, name ->
       assert act == credential
-      assert region == region
+      assert region_local == region
       assert name == existingLc
 
       existing
@@ -334,9 +334,9 @@ class ModifyAsgLaunchConfigurationOperationSpec extends Specification {
 
     then:
     1 * asgService.getAutoScalingGroup(asgName) >> new AutoScalingGroup().withLaunchConfigurationName(existingLc)
-    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region, name ->
+    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region_local, name ->
       assert act == credential
-      assert region == region
+      assert region_local == region
       assert name == existingLc
 
       existing
@@ -383,9 +383,9 @@ class ModifyAsgLaunchConfigurationOperationSpec extends Specification {
 
     then:
     1 * asgService.getAutoScalingGroup(asgName) >> new AutoScalingGroup().withLaunchConfigurationName(existingLc)
-    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region, name ->
+    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region_local, name ->
       assert act == credential
-      assert region == region
+      assert region_local == region
       assert name == existingLc
 
       existing
@@ -450,9 +450,9 @@ class ModifyAsgLaunchConfigurationOperationSpec extends Specification {
 
     then:
     1 * asgService.getAutoScalingGroup(asgName) >> new AutoScalingGroup().withLaunchConfigurationName(existingLc)
-    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region, name ->
+    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region_local, name ->
       assert act == credential
-      assert region == region
+      assert region_local == region
       assert name == existingLc
 
       existing
@@ -519,9 +519,9 @@ class ModifyAsgLaunchConfigurationOperationSpec extends Specification {
 
     then:
     1 * asgService.getAutoScalingGroup(asgName) >> new AutoScalingGroup().withLaunchConfigurationName(existingLc)
-    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region, name ->
+    1 * lcBuilder.buildSettingsFromLaunchConfiguration(_, _, _) >> { act, region_local, name ->
       assert act == credential
-      assert region == region
+      assert region_local == region
       assert name == existingLc
 
       existing


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encountered the following errors in groovy test compilation of clouddriver-aws module:

```
> Task :clouddriver-aws:compileTestGroovy FAILED
startup failed:
/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperationSpec.groovy: 107: The current scope already contains a variable of the name region
 @ line 107, column 68.
   unchConfiguration(_, _, _) >> { act, reg
                                 ^
1 error

startup failed:
/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperationSpec.groovy: 157: The current scope already contains a variable of the name region
 @ line 157, column 68.
   unchConfiguration(_, _, _) >> { act, reg
                                 ^
1 error
> Task :clouddriver-aws:compileTestGroovy FAILED

> Task :clouddriver-aws:compileTestGroovy FAILED
startup failed:
/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperationSpec.groovy: 223: The current scope already contains a variable of the name region
 @ line 223, column 68.
   unchConfiguration(_, _, _) >> { act, reg
                                 ^
1 error

startup failed:
/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperationSpec.groovy: 283: The current scope already contains a variable of the name region
 @ line 283, column 68.
   unchConfiguration(_, _, _) >> { act, reg
                                 ^
1 error
> Task :clouddriver-aws:compileTestGroovy FAILED

> Task :clouddriver-aws:compileTestGroovy FAILED
startup failed:
/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperationSpec.groovy: 337: The current scope already contains a variable of the name region
 @ line 337, column 68.
   unchConfiguration(_, _, _) >> { act, reg
                                 ^
1 error

startup failed:
/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperationSpec.groovy: 386: The current scope already contains a variable of the name region
 @ line 386, column 68.
   unchConfiguration(_, _, _) >> { act, reg
                                 ^
1 error
> Task :clouddriver-aws:compileTestGroovy FAILED

startup failed:
/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperationSpec.groovy: 453: The current scope already contains a variable of the name region
 @ line 453, column 68.
   unchConfiguration(_, _, _) >> { act, reg
                                 ^
1 error
> Task :clouddriver-aws:compileTestGroovy FAILED

> Task :clouddriver-aws:compileTestGroovy FAILED
startup failed:
/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperationSpec.groovy: 522: The current scope already contains a variable of the name region
 @ line 522, column 68.
   unchConfiguration(_, _, _) >> { act, reg
                                 ^
1 error
```
To fix this issue renamed the local variables to avoid the scope confilct with global variables.