### PR TITLE
chore(dependency): add explicit dependency of groovy-templates in clouddriver-kubernetes while upgrading groovy 3.x

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -103,6 +103,7 @@ dependencies {
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
   testImplementation "org.springframework.boot:spring-boot-test"
+  testImplementation "org.codehaus.groovy:groovy-templates"
 
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, groovy-templates is not part of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/2.0-groovy-3.0) and encounter below error during test compilation:
```
> Task :clouddriver-kubernetes:compileTestGroovy FAILED
startup failed:
/clouddriver/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesManifestSpec.groovy: 25: unable to resolve class groovy.text.SimpleTemplateEngine
 @ line 25, column 1.
   import groovy.text.SimpleTemplateEngine
   ^
1 error
```
So, adding explicit dependency of groovy-templates in clouddriver-kubernetes.gradle

With groovy 2.5.15 and spockframework 1.3-groovy-2.5, groovy-templates appear as transitive dependency of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/1.3-groovy-2.5) as shown below:
```$ ./gradlew clouddriver-kubernetes:dI --dependency groovy-templates --configuration testCompileClasspath
Starting a Gradle Daemon, 34 stopped Daemons could not be reused, use --status for details

> Task :clouddriver-kubernetes:dependencyInsight
org.codehaus.groovy:groovy-templates:2.5.15
  Variant compile:
    | Attribute Name                     | Provided | Requested         |
    |------------------------------------|----------|-------------------|
    | org.gradle.status                  | release  |                   |
    | org.gradle.category                | library  | library           |
    | org.gradle.libraryelements         | jar      | classes+resources |
    | org.gradle.usage                   | java-api | java-api          |
    | org.gradle.dependency.bundling     |          | external          |
    | org.gradle.jvm.environment         |          | standard-jvm      |
    | org.gradle.jvm.version             |          | 11                |
    | org.jetbrains.kotlin.platform.type |          | jvm               |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy-templates:2.5.15
\--- io.spinnaker.kork:kork-bom:7.190.0
     \--- testCompileClasspath

org.codehaus.groovy:groovy-templates:2.5.4 -> 2.5.15
+--- org.spockframework:spock-core:1.3-groovy-2.5
|    +--- testCompileClasspath (requested org.spockframework:spock-core)
|    +--- io.spinnaker.kork:kork-bom:7.190.0
|    |    \--- testCompileClasspath
|    \--- org.spockframework:spock-spring:1.3-groovy-2.5
|         +--- testCompileClasspath (requested org.spockframework:spock-spring)
|         \--- io.spinnaker.kork:kork-bom:7.190.0 (*)
\--- org.spockframework:spock-spring:1.3-groovy-2.5 (*)
```