### PR TITLE
refactor(kubernetes/test): replace deprecated NioGroovyMethods.append() with ResourceGroovyMethods.append() during upgrade to groovy 3.x

### DIFF
--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
@@ -58,7 +58,7 @@ class KubernetesNamedAccountCredentialsSpec extends Specification {
   void "should equal 2 Kubernetes accounts with same kubeconfig content"() {
     setup:
       def file1 = Files.createTempFile("test", "")
-      file1.append("some content")
+      file1.toFile().append("some content")
       def account1Def = new ManagedAccount()
       account1Def.setName("test")
       account1Def.setCacheThreads(1)
@@ -67,7 +67,7 @@ class KubernetesNamedAccountCredentialsSpec extends Specification {
       account1Def.setKubeconfigFile(file1.toString())
 
       def file2 = Files.createTempFile("other", "")
-      file2.append("some content")
+      file2.toFile().append("some content")
       def account2Def = new ManagedAccount()
       account2Def.setName("test")
       account2Def.setCacheThreads(1)


### PR DESCRIPTION
While upgrading to groovy 3.0.10 and spockframework 2.0-groovy-3.0, encountered the following error due to deprecation of [NioGroovyMethods](https://javadoc.io/static/org.codehaus.groovy/groovy-all/3.0.10/org/codehaus/groovy/runtime/NioGroovyMethods.html) class:
```
No signature of method: sun.nio.fs.UnixPath.append() is applicable for argument types: (String) values: [some content]
Possible solutions: append(java.io.Writer, java.lang.String), append(java.io.Writer), append(java.lang.Object), append(java.io.Reader), append(java.io.Reader, java.lang.String), append(java.lang.Object, java.lang.String)
groovy.lang.MissingMethodException: No signature of method: sun.nio.fs.UnixPath.append() is applicable for argument types: (String) values: [some content]
Possible solutions: append(java.io.Writer, java.lang.String), append(java.io.Writer), append(java.lang.Object), append(java.io.Reader), append(java.io.Reader, java.lang.String), append(java.lang.Object, java.lang.String)
	at com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentialsSpec.should equal 2 Kubernetes accounts with same kubeconfig content(KubernetesNamedAccountCredentialsSpec.groovy:61)
	Suppressed: java.lang.NullPointerException
		at java.base/java.nio.file.Files.provider(Files.java:100)
		at java.base/java.nio.file.Files.delete(Files.java:1141)
		at java_nio_file_Files$delete.call(Unknown Source)
		at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
		at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
		at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:139)
		at com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentialsSpec.$spock_feature_0_0(KubernetesNamedAccountCredentialsSpec.groovy:88)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:566)
		at org.spockframework.util.ReflectionUtil.invokeMethod(ReflectionUtil.java:198)
....
2 tests completed, 1 failed
> Task :clouddriver-kubernetes:test FAILED
```
To fix this issue replaced deprecated method with ResourceGroovyMethods.append() [here](https://javadoc.io/static/org.codehaus.groovy/groovy-all/3.0.10/org/codehaus/groovy/runtime/ResourceGroovyMethods.html)

Test coverage of clouddriver-kubernetes module remain same before and after refactor (Tests executed 695).