### PR TITLE
 refactor(google): add constructor-based DI to mock private members in test and resolved the scope of variables during upgrade to groovy 3.x

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/DeleteGoogleAutoscalingPolicyAtomicOperationConverter.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/DeleteGoogleAutoscalingPolicyAtomicOperationConverter.groovy
@@ -17,20 +17,33 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.converters
 
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
+import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleAutoscalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation
+import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationsRegistry
+import com.netflix.spinnaker.clouddriver.orchestration.OrchestrationProcessor
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsConverter
 import org.springframework.stereotype.Component
 
 @GoogleOperation(AtomicOperations.DELETE_SCALING_POLICY)
 @Component("deleteGoogleScalingPolicyDescription")
 class DeleteGoogleAutoscalingPolicyAtomicOperationConverter extends AbstractAtomicOperationsCredentialsConverter<GoogleNamedAccountCredentials> {
+
+  GoogleClusterProvider googleClusterProvider
+
+  GoogleOperationPoller googleOperationPoller
+
+  AtomicOperationsRegistry atomicOperationsRegistry
+
+  OrchestrationProcessor orchestrationProcessor
+
   @Override
   AtomicOperation convertOperation(Map input) {
-    new DeleteGoogleAutoscalingPolicyAtomicOperation(convertDescription(input))
+    new DeleteGoogleAutoscalingPolicyAtomicOperation(convertDescription(input), googleClusterProvider, googleOperationPoller, atomicOperationsRegistry, orchestrationProcessor)
   }
 
   @Override

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy
@@ -29,6 +29,10 @@ import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleA
 import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationsRegistry
+import com.netflix.spinnaker.clouddriver.orchestration.DefaultOrchestrationProcessor
+import com.netflix.spinnaker.clouddriver.orchestration.OrchestrationProcessor
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -40,9 +44,11 @@ class DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec extends Specification
   private static final PROJECT_NAME = "my-project"
   private static final ZONE = "us-central1-f"
 
-  def googleClusterProviderMock = Mock(GoogleClusterProvider)
-  def computeMock = Mock(Compute)
-  def operationPollerMock = Mock(GoogleOperationPoller)
+  GoogleClusterProvider googleClusterProviderMock = Mock(GoogleClusterProvider)
+  Compute computeMock = Mock(Compute)
+  GoogleOperationPoller operationPollerMock = Mock(GoogleOperationPoller)
+  AtomicOperationsRegistry atomicOperationsRegistry = Mock(AtomicOperationsRegistry)
+  DefaultOrchestrationProcessor orchestrationProcessorMock = Mock(DefaultOrchestrationProcessor)
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -73,10 +79,8 @@ class DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec extends Specification
       region: REGION,
       accountName: ACCOUNT_NAME,
       credentials: credentials)
-    @Subject def operation = Spy(DeleteGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description])
+    @Subject def operation = Spy(DeleteGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description, googleClusterProviderMock, operationPollerMock, atomicOperationsRegistry, orchestrationProcessorMock])
     operation.registry = registry
-    operation.googleClusterProvider = googleClusterProviderMock
-    operation.googleOperationPoller = operationPollerMock
 
     when:
     operation.operate([])
@@ -134,10 +138,8 @@ class DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec extends Specification
           "compute.regionInstanceGroupManagers.setAutoHealingPolicies",
           [scope: "regional", region: REGION])
 
-    @Subject def operation = Spy(DeleteGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description])
+    @Subject def operation = Spy(DeleteGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description, googleClusterProviderMock, operationPollerMock, atomicOperationsRegistry, orchestrationProcessorMock])    
     operation.registry = registry
-    operation.googleClusterProvider = googleClusterProviderMock
-    operation.googleOperationPoller = operationPollerMock
 
     when:
     operation.operate([])
@@ -190,10 +192,8 @@ class DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec extends Specification
       serviceAccounts: [[email: 'serviceAccount@google.com']]
     ])
 
-    @Subject def operation = Spy(DeleteGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description])
+    @Subject def operation = Spy(DeleteGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description, googleClusterProviderMock, operationPollerMock, atomicOperationsRegistry, orchestrationProcessorMock])
     operation.registry = registry
-    operation.googleClusterProvider = googleClusterProviderMock
-    operation.googleOperationPoller = operationPollerMock
 
     when:
     operation.deletePolicyMetadata(computeMock, credentials, PROJECT_NAME, groupUrl)


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encountered the following errors in `DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec` tests, due to inaccessible private variable to mock the object :
```
DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec > should delete zonal and regional autoscaling policy > com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoscaling policy [isRegional: true, #0] FAILED
    groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.setGoogleClusterProvider() is applicable for argument types: (com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider$SpockMock$1654598657) values: [Mock for type 'GoogleClusterProvider' named 'googleClusterProviderMock']
        at com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoscaling policy(DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy:78)
DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec > should delete zonal and regional autoscaling policy > com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoscaling policy [isRegional: false, #1] FAILED
    groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.setGoogleClusterProvider() is applicable for argument types: (com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider$SpockMock$1654598657) values: [Mock for type 'GoogleClusterProvider' named 'googleClusterProviderMock']
        at com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoscaling policy(DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy:78)
DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec > should delete zonal and regional autoHealing policy > com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoHealing policy [isRegional: true, #0] FAILED
    groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.setGoogleClusterProvider() is applicable for argument types: (com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider$SpockMock$1654598657) values: [Mock for type 'GoogleClusterProvider' named 'googleClusterProviderMock']
        at com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoHealing policy(DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy:139)
DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec > should delete zonal and regional autoHealing policy > com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoHealing policy [isRegional: false, #1] FAILED
    groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.setGoogleClusterProvider() is applicable for argument types: (com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider$SpockMock$1654598657) values: [Mock for type 'GoogleClusterProvider' named 'googleClusterProviderMock']
        at com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoHealing policy(DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy:139)
DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec > delete the instance template when deletePolicyMetadata is called > com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.delete the instance template when deletePolicyMetadata is called [isRegional: false, location: us-central1-f, groupUrl: https://compute.googleapis.com/compute/v1/projects/spinnaker-jtk54/zones/us-central1-f/autoscalers/okra-auto-v005, #0] FAILED
    groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.setGoogleClusterProvider() is applicable for argument types: (com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider$SpockMock$1654598657) values: [Mock for type 'GoogleClusterProvider' named 'googleClusterProviderMock']
        at com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.delete the instance template when deletePolicyMetadata is called(DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy:195)
DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec > delete the instance template when deletePolicyMetadata is called > com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.delete the instance template when deletePolicyMetadata is called [isRegional: true, location: us-central1, groupUrl: https://compute.googleapis.com/compute/v1/projects/spinnaker-jtk54/regions/us-central1/autoscalers/okra-auto-v005, #1] FAILED
    groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.setGoogleClusterProvider() is applicable for argument types: (com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider$SpockMock$1654598657) values: [Mock for type 'GoogleClusterProvider' named 'googleClusterProviderMock']
        at com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.delete the instance template when deletePolicyMetadata is called(DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy:195)
6 tests completed, 6 failed
> Task :clouddriver-google:test FAILED
```
To fix this issue introduced @VisibleForTesting annotation to variables in `DeleteGoogleAutoscalingPolicyAtomicOperation.groovy`.

Encountered the following errors in `DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec` tests, due to improper scope of static variables:
```
DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec > should delete zonal and regional autoscaling policy > com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoscaling policy [isRegional: true, #0] FAILED
    groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.getTAG_SCOPE() is applicable for argument types: () values: []
        at app//com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.operate(DeleteGoogleAutoscalingPolicyAtomicOperation.groovy:116)
        at app//org.spockframework.mock.runtime.ByteBuddyMethodInvoker.respond(ByteBuddyMethodInvoker.java:20)
        at app//org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:59)
        at app//org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:30)
        at app//org.spockframework.mock.runtime.MockController.handle(MockController.java:50)
        at app//org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:84)
        at app//org.spockframework.mock.runtime.ByteBuddyInterceptorAdapter.interceptNonAbstract(ByteBuddyInterceptorAdapter.java:35)
        at com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoscaling policy(DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy:82)
DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec > should delete zonal and regional autoscaling policy > com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoscaling policy [isRegional: false, #1] FAILED
    groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.getTAG_SCOPE() is applicable for argument types: () values: []
        at app//com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.operate(DeleteGoogleAutoscalingPolicyAtomicOperation.groovy:125)
        at app//org.spockframework.mock.runtime.ByteBuddyMethodInvoker.respond(ByteBuddyMethodInvoker.java:20)
        at app//org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:59)
        at app//org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:30)
        at app//org.spockframework.mock.runtime.MockController.handle(MockController.java:50)
        at app//org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:84)
        at app//org.spockframework.mock.runtime.ByteBuddyInterceptorAdapter.interceptNonAbstract(ByteBuddyInterceptorAdapter.java:35)
        at com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoscaling policy(DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy:82)
DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec > should delete zonal and regional autoHealing policy > com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoHealing policy [isRegional: true, #0] FAILED
    groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.getTAG_SCOPE() is applicable for argument types: () values: []
        at app//com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.operate(DeleteGoogleAutoscalingPolicyAtomicOperation.groovy:93)
        at app//org.spockframework.mock.runtime.ByteBuddyMethodInvoker.respond(ByteBuddyMethodInvoker.java:20)
        at app//org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:59)
        at app//org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:30)
        at app//org.spockframework.mock.runtime.MockController.handle(MockController.java:50)
        at app//org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:84)
        at app//org.spockframework.mock.runtime.ByteBuddyInterceptorAdapter.interceptNonAbstract(ByteBuddyInterceptorAdapter.java:35)
        at com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoHealing policy(DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy:143)
DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec > should delete zonal and regional autoHealing policy > com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoHealing policy [isRegional: false, #1] FAILED
    groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.getTAG_SCOPE() is applicable for argument types: () values: []
        at app//com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.operate(DeleteGoogleAutoscalingPolicyAtomicOperation.groovy:103)
        at app//org.spockframework.mock.runtime.ByteBuddyMethodInvoker.respond(ByteBuddyMethodInvoker.java:20)
        at app//org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:59)
        at app//org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:30)
        at app//org.spockframework.mock.runtime.MockController.handle(MockController.java:50)
        at app//org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:84)
        at app//org.spockframework.mock.runtime.ByteBuddyInterceptorAdapter.interceptNonAbstract(ByteBuddyInterceptorAdapter.java:35)
        at com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.should delete zonal and regional autoHealing policy(DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy:143)
DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec > delete the instance template when deletePolicyMetadata is called > com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.delete the instance template when deletePolicyMetadata is called [isRegional: false, location: us-central1-f, groupUrl: https://compute.googleapis.com/compute/v1/projects/spinnaker-jtk54/zones/us-central1-f/autoscalers/okra-auto-v005, #0] FAILED
    groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.getTAG_SCOPE() is applicable for argument types: () values: []
        at app//com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.deletePolicyMetadata(DeleteGoogleAutoscalingPolicyAtomicOperation.groovy:159)
        at app//org.spockframework.mock.runtime.ByteBuddyMethodInvoker.respond(ByteBuddyMethodInvoker.java:20)
        at app//org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:59)
        at app//org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:30)
        at app//org.spockframework.mock.runtime.MockController.handle(MockController.java:50)
        at app//org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:84)
        at app//org.spockframework.mock.runtime.ByteBuddyInterceptorAdapter.interceptNonAbstract(ByteBuddyInterceptorAdapter.java:35)
        at com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.delete the instance template when deletePolicyMetadata is called(DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy:199)
DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec > delete the instance template when deletePolicyMetadata is called > com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.delete the instance template when deletePolicyMetadata is called [isRegional: true, location: us-central1, groupUrl: https://compute.googleapis.com/compute/v1/projects/spinnaker-jtk54/regions/us-central1/autoscalers/okra-auto-v005, #1] FAILED
    groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.getTAG_SCOPE() is applicable for argument types: () values: []
        at app//com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperation.deletePolicyMetadata(DeleteGoogleAutoscalingPolicyAtomicOperation.groovy:150)
        at app//org.spockframework.mock.runtime.ByteBuddyMethodInvoker.respond(ByteBuddyMethodInvoker.java:20)
        at app//org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:59)
        at app//org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:30)
        at app//org.spockframework.mock.runtime.MockController.handle(MockController.java:50)
        at app//org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:84)
        at app//org.spockframework.mock.runtime.ByteBuddyInterceptorAdapter.interceptNonAbstract(ByteBuddyInterceptorAdapter.java:35)
        at com.netflix.spinnaker.clouddriver.google.deploy.ops.DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.delete the instance template when deletePolicyMetadata is called(DeleteGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy:199)
6 tests completed, 6 failed
> Task :clouddriver-google:test FAILED
```
To fix this issue added qualified class name with static variables in `DeleteGoogleAutoscalingPolicyAtomicOperation.groovy`.