### PR TITLE
fix(aws): ignore deserialziation of getServerGroupNames

### DIFF
--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/description/ModifyServerGroupLaunchTemplateDescription.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/description/ModifyServerGroupLaunchTemplateDescription.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.description;
 
 import com.amazonaws.util.CollectionUtils;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice;
 import com.netflix.spinnaker.clouddriver.aws.userdata.UserDataOverride;
@@ -101,6 +102,7 @@ public class ModifyServerGroupLaunchTemplateDescription extends AbstractAmazonCr
       launchTemplateOverridesForInstanceType;
 
   @Override
+  @JsonIgnore
   public Collection<String> getServerGroupNames() {
     return Collections.singletonList(asgName);
   }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/ModifyServerGroupLaunchTemplateSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/actions/ModifyServerGroupLaunchTemplateSpec.groovy
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops.actions
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup
 import com.amazonaws.services.autoscaling.model.LaunchTemplateSpecification
 import com.amazonaws.services.ec2.model.*
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyServerGroupLaunchTemplateDescription
 import com.netflix.spinnaker.clouddriver.aws.services.LaunchTemplateService
@@ -10,6 +11,7 @@ import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactor
 import com.netflix.spinnaker.clouddriver.saga.flow.SagaAction
 import com.netflix.spinnaker.clouddriver.saga.models.Saga
 import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository
+import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -78,5 +80,17 @@ class ModifyServerGroupLaunchTemplateSpec extends Specification {
       true            |        false              |        false        ||      true            ||     null           // update ASG MIP properties without creating a new LT version
       false           |        true               |        true         ||      true            ||      2L            // update ASG LT with new LT version and convert ASG to use MIP
       false           |        true               |        false        ||      false           ||      2L            // update ASG LT with new LT version, but don't use MIP
+  }
+
+  def "should not throw JsonProcessingException when deserializing"() {
+    given:
+    def objectMapper = AmazonObjectMapperConfigurer.createConfigured()
+    def json = objectMapper.writeValueAsString(dummyDescription)
+
+    when:
+    objectMapper.readValue(json, ModifyServerGroupLaunchTemplateDescription.class)
+
+    then:
+    notThrown(JsonMappingException)
   }
 }


### PR DESCRIPTION
Fix a JsonProcessingException when deserializing ModifyServerGroupLaunchTemplateDescription by ignoring derived property getServerGroupNames.