### PR TITLE
chore(dependency): add explicit dependency of groovy-json in clouddriver-web while upgrading groovy 3.x

### DIFF
--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -53,6 +53,7 @@ dependencies {
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "org.spockframework:spock-core"
   testImplementation "io.kubernetes:client-java"
+  testImplementation "org.codehaus.groovy:groovy-json"
 
   // Add each included cloud provider project as a runtime dependency
   gradle.includedCloudProviderProjects.each {


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, groovy-json is not part of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/2.0-groovy-3.0) and encounter below error during test compilation:
```
startup failed:
/clouddriver/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsControllerSpec.groovy: 27: unable to resolve class groovy.json.JsonSlurper
 @ line 27, column 1.
   import groovy.json.JsonSlurper
   ^
1 error
> Task :clouddriver-web:compileTestGroovy FAILED

```
So, adding explicit dependency of groovy-json in clouddriver-web.gradle.

With groovy 2.5.15 and spockframework 1.3-groovy-2.5, groovy-json appear as transitive dependency of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/1.3-groovy-2.5) as shown below:

```
$ ./gradlew clouddriver-web:dI --dependency groovy-json --configuration testCompileClasspath

> Task :clouddriver-web:dependencyInsight
org.codehaus.groovy:groovy-json:2.5.15
  Variant compile:
    | Attribute Name                     | Provided | Requested         |
    |------------------------------------|----------|-------------------|
    | org.gradle.status                  | release  |                   |
    | org.gradle.category                | library  | library           |
    | org.gradle.libraryelements         | jar      | classes+resources |
    | org.gradle.usage                   | java-api | java-api          |
    | org.gradle.dependency.bundling     |          | external          |
    | org.gradle.jvm.environment         |          | standard-jvm      |
    | org.gradle.jvm.version             |          | 11                |
    | org.jetbrains.kotlin.platform.type |          | jvm               |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy-json:2.5.15
\--- io.spinnaker.kork:kork-bom:7.191.0
     \--- testCompileClasspath

org.codehaus.groovy:groovy-json:2.5.4 -> 2.5.15
\--- org.spockframework:spock-core:1.3-groovy-2.5
     +--- testCompileClasspath (requested org.spockframework:spock-core)
     \--- io.spinnaker.kork:kork-bom:7.191.0
          \--- testCompileClasspath

```