### PR TITLE
chore(junit): centralize org.junit.jupiter:junit-jupiter-engine dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ subprojects {
       annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
       testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
       testAnnotationProcessor "org.projectlombok:lombok"
+      testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
       testRuntimeOnly "org.junit.vintage:junit-vintage-engine" // Required for Spock tests to execute along with Junit5 tests.
     }
 

--- a/cats/cats-sql/cats-sql.gradle
+++ b/cats/cats-sql/cats-sql.gradle
@@ -53,7 +53,6 @@ dependencies {
   testImplementation "junit:junit"
   testImplementation "org.hamcrest:hamcrest-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.jupiter:junit-jupiter-engine"
   testImplementation "org.objenesis:objenesis"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"

--- a/clouddriver-appengine/clouddriver-appengine.gradle
+++ b/clouddriver-appengine/clouddriver-appengine.gradle
@@ -44,7 +44,6 @@ dependencies {
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.jupiter:junit-jupiter-engine"
   testImplementation "org.mockito:mockito-core"
 
 }

--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -67,8 +67,6 @@ dependencies {
   testImplementation "org.testcontainers:localstack"
   testImplementation "ru.lanwen.wiremock:wiremock-junit5:1.2.0"
 
-  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
-
   integrationImplementation project(":clouddriver-web")
   integrationImplementation project(":clouddriver-artifacts")
   integrationImplementation "org.springframework.boot:spring-boot-starter-test"

--- a/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
+++ b/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
@@ -71,7 +71,6 @@ dependencies {
 
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.jupiter:junit-jupiter-engine"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.mockito:mockito-core"
   testImplementation "com.github.tomakehurst:wiremock-jre8-standalone"

--- a/clouddriver-cloudrun/clouddriver-cloudrun.gradle
+++ b/clouddriver-cloudrun/clouddriver-cloudrun.gradle
@@ -41,7 +41,6 @@ dependencies {
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.jupiter:junit-jupiter-engine"
   testImplementation "org.mockito:mockito-core"
 
 }

--- a/clouddriver-core/clouddriver-core.gradle
+++ b/clouddriver-core/clouddriver-core.gradle
@@ -64,7 +64,6 @@ dependencies {
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-  testImplementation "org.junit.jupiter:junit-jupiter-engine"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.springframework.boot:spring-boot-test"

--- a/clouddriver-docker/clouddriver-docker.gradle
+++ b/clouddriver-docker/clouddriver-docker.gradle
@@ -33,5 +33,4 @@ dependencies {
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
-  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/clouddriver-event/clouddriver-event.gradle
+++ b/clouddriver-event/clouddriver-event.gradle
@@ -38,6 +38,4 @@ dependencies {
   testImplementation "io.strikt:strikt-core"
   testImplementation "dev.minutest:minutest"
   testImplementation "io.mockk:mockk"
-
-  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -51,8 +51,6 @@ dependencies {
   testImplementation "org.springframework:spring-test"
   testImplementation "org.springframework.boot:spring-boot-test"
   testImplementation "org.codehaus.groovy:groovy-test"
-
-  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
 
 configurations.all {

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -105,8 +105,6 @@ dependencies {
   testImplementation "org.springframework.boot:spring-boot-test"
   testImplementation "org.codehaus.groovy:groovy-templates"
 
-  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
-
   integrationImplementation project(":clouddriver-web")
   integrationImplementation "org.springframework.boot:spring-boot-starter-test"
   integrationImplementation "org.testcontainers:testcontainers"

--- a/clouddriver-lambda/clouddriver-lambda.gradle
+++ b/clouddriver-lambda/clouddriver-lambda.gradle
@@ -41,6 +41,4 @@ dependencies {
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
-
-  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/clouddriver-saga/clouddriver-saga.gradle
+++ b/clouddriver-saga/clouddriver-saga.gradle
@@ -26,6 +26,4 @@ dependencies {
   testImplementation "io.strikt:strikt-core"
   testImplementation "dev.minutest:minutest"
   testImplementation "io.mockk:mockk"
-
-  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/clouddriver-sql/clouddriver-sql.gradle
+++ b/clouddriver-sql/clouddriver-sql.gradle
@@ -51,6 +51,4 @@ dependencies {
   testImplementation "io.mockk:mockk"
   testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin"
   testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
-
-  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/gradle/kotlin-test.gradle
+++ b/gradle/kotlin-test.gradle
@@ -27,7 +27,6 @@ dependencies {
   testImplementation "io.mockk:mockk"
 
   testRuntimeOnly "org.junit.platform:junit-platform-launcher"
-  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
 
 test {


### PR DESCRIPTION
in build.gradle

and make it testRuntimeOnly since that's sufficient.  See https://junit.org/junit5/docs/current/user-guide/#dependency-metadata-junit-jupiter for background.
