### PR TITLE
refactor(appengine): remove isDisabled() method with groovy 3 upgrade

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppengineServerGroup.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppengineServerGroup.groovy
@@ -168,11 +168,6 @@ class AppengineServerGroup implements ServerGroup, Serializable {
     null
   }
 
-  @Override
-  Boolean isDisabled() {
-    disabled
-  }
-
   enum ServingStatus {
     SERVING,
     STOPPED,


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encounter below error in clouddriver-appengine module as groovy 3 is smart enough to create implicit getter with name `isDisabled()` for `disabled` boolean property.
```
/clouddriver/clouddriver-appengine/build/tmp/compileGroovy/groovy-java-stubs/com/netflix/spinnaker/clouddriver/appengine/model/AppengineServerGroup.java:65: error: method isDisabled() is already defined in class AppengineServerGroup
@java.lang.Override() public  java.lang.Boolean isDisabled() { return (java.lang.Boolean)null;}
                                                ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: /clouddriver/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/config/AppengineCredentialsConfiguration.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error
startup failed:
Compilation failed; see the compiler error output for details.
1 error
> Task :clouddriver-appengine:compileGroovy FAILED
```
To fix this issue removed `isDisabled()` method.
