### PR TITLE
refactor(aws/test): remove isDisabled() method with groovy 3 upgrade

### DIFF
--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/SimpleServerGroup.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/SimpleServerGroup.groovy
@@ -36,9 +36,4 @@ class SimpleServerGroup implements ServerGroup {
   ServerGroup.Capacity capacity
   ServerGroup.ImageSummary imageSummary
   ServerGroup.ImagesSummary imagesSummary
-
-  @Override
-  Boolean isDisabled() {
-    return disabled
-  }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/DiscoverySupportUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/DiscoverySupportUnitSpec.groovy
@@ -570,7 +570,6 @@ class DiscoverySupportUnitSpec extends Specification {
     Map<String, Object> launchConfig
     ServerGroup.InstanceCounts instanceCounts
     ServerGroup.Capacity capacity
-    Boolean isDisabled() {disabled}
     ServerGroup.ImageSummary getImageSummary() {}
     ServerGroup.ImagesSummary getImagesSummary() {}
   }


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encounter below error in clouddriver-aws module as groovy 3 is smart enough to create implicit getter with name isDisabled() for `disabled` boolean property.
```
startup failed:
/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/SimpleServerGroup.groovy: 40: Repetitive method name/signature for method 'java.lang.Boolean isDisabled()' in class 'com.netflix.spinnaker.clouddriver.aws.deploy.asg.SimpleServerGroup'.
 @ line 40, column 3.
     @Override
     ^
/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/SimpleServerGroup.groovy: -1: Repetitive method name/signature for method 'java.lang.Boolean isDisabled()' in class 'com.netflix.spinnaker.clouddriver.aws.deploy.asg.SimpleServerGroup'.
 @ line -1, column -1.
2 errors
> Task :clouddriver-aws:compileTestGroovy FAILED
```

```
startup failed:
/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/DiscoverySupportUnitSpec.groovy: 573: Repetitive method name/signature for method 'java.lang.Boolean isDisabled()' in class 'com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.DiscoverySupportUnitSpec$DefaultServerGroup'.
 @ line 573, column 5.
       Boolean isDisabled() {disabled}
       ^
/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/DiscoverySupportUnitSpec.groovy: -1: Repetitive method name/signature for method 'java.lang.Boolean isDisabled()' in class 'com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.DiscoverySupportUnitSpec$DefaultServerGroup'.
 @ line -1, column -1.
2 errors
> Task :clouddriver-aws:compileTestGroovy FAILED
```
To fix this issue removed `isDisabled()` method.