### PR TITLE
refactor(core/test): remove isDisabled() method with groovy 3 upgrade

### DIFF
--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/model/SimpleServerGroup.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/model/SimpleServerGroup.groovy
@@ -33,9 +33,4 @@ class SimpleServerGroup implements ServerGroup {
   Capacity capacity
   ImagesSummary imagesSummary
   ImageSummary imageSummary
-
-  @Override
-  Boolean isDisabled() {
-    return disabled
-  }
 }


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encounter below error in clouddriver-core module as groovy 3 is smart enough to create implicit getter with name isDisabled() for `disabled` boolean property.
```
> Task :clouddriver-core:compileTestGroovy FAILED
startup failed:
/clouddriver/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/model/SimpleServerGroup.groovy: 37: Repetitive method name/signature for method 'java.lang.Boolean isDisabled()' in class 'com.netflix.spinnaker.clouddriver.model.SimpleServerGroup'.
 @ line 37, column 3.
     @Override
     ^
/clouddriver/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/model/SimpleServerGroup.groovy: -1: Repetitive method name/signature for method 'java.lang.Boolean isDisabled()' in class 'com.netflix.spinnaker.clouddriver.model.SimpleServerGroup'.
 @ line -1, column -1.
2 errors
```
To fix this issue removed `isDisabled()` method.