### PR TITLE
refactor(google): remove isDisabled() method with groovy 3 upgrade

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
@@ -143,11 +143,6 @@ class GoogleServerGroup implements GoogleLabeledResource {
     }
 
     @Override
-    Boolean isDisabled() { // Because groovy isn't smart enough to generate this method :-(
-      disabled
-    }
-
-    @Override
     Long getCreatedTime() {
       launchConfig ? launchConfig.createdTime as Long : null
     }


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encounter below error in clouddriver-google module as groovy 3 is smart enough to create implicit getter with name isDisabled() for `disabled` boolean property.
```
/clouddriver/clouddriver-google/build/tmp/compileGroovy/groovy-java-stubs/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.java:167: error: method isDisabled() is already defined in class GoogleServerGroup.View
@java.lang.Override() public  java.lang.Boolean isDisabled() { return (java.lang.Boolean)null;}
```
To fix this issue removed `isDisabled()` method.