### PR TITLE
refactor(oracle): remove isDisabled() method with groovy 3 upgrade

### DIFF
--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/model/OracleServerGroup.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/model/OracleServerGroup.groovy
@@ -74,11 +74,6 @@ class OracleServerGroup {
     }
 
     @Override
-    Boolean isDisabled() { // Because groovy isn't smart enough to generate this method :-(
-      disabled
-    }
-
-    @Override
     Long getCreatedTime() {
       launchConfig ? launchConfig.createdTime as Long : null
     }


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encounter below error in clouddriver-oracle module as groovy 3 is smart enough to create implicit getter with name isDisabled() for `disabled` boolean property.
```
startup failed:
/clouddriver/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/model/OracleServerGroup.groovy: 76: Repetitive method name/signature for method 'java.lang.Boolean isDisabled()' in class 'com.netflix.spinnaker.clouddriver.oracle.model.OracleServerGroup$View'.
 @ line 76, column 5.
       @Override
       ^
/clouddriver/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/model/OracleServerGroup.groovy: -1: Repetitive method name/signature for method 'java.lang.Boolean isDisabled()' in class 'com.netflix.spinnaker.clouddriver.oracle.model.OracleServerGroup$View'.
 @ line -1, column -1.
2 errors
> Task :clouddriver-oracle:compileGroovy FAILED

```
To fix this issue removed `isDisabled()` method.