### PR TITLE
refactor(azure): fix incompatible generic type issue faced during upgrade to springboot 2.5.15

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
@@ -202,7 +202,7 @@ class AzureNetworkClient extends AzureBaseClient {
    * @return a Collection of objects which represent an Application Gateway in Azure
    */
   Collection<AzureAppGatewayDescription> getAppGatewaysAll(String region) {
-    def result = []
+    Collection<AzureAppGatewayDescription> result = []
 
     try {
       def currentTime = System.currentTimeMillis()

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentialsInitializer.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentialsInitializer.groovy
@@ -33,7 +33,7 @@ class AzureCredentialsInitializer {
                                                                   AccountCredentialsRepository accountCredentialsRepository,
                                                                   String clouddriverUserAgentApplicationName) {
 
-    def azureAccounts = []
+    List<AzureNamedAccountCredentials> azureAccounts = []
     azureConfigurationProperties.accounts.each { AzureConfigurationProperties.ManagedAccount managedAccount ->
       try {
         def azureAccount = new AzureNamedAccountCredentials(


### PR DESCRIPTION
While upgrading springboot 2.5.15, encounter below error in clouddriver-azure module:
```
startup failed:
/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy: 234: [Static type checking] - Incompatible generic argument types. Cannot assign java.util.List <java.lang.Object> to: java.util.Collection <AzureAppGatewayDescription>
 @ line 234, column 5.
       result
       ^

/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentialsInitializer.groovy: 63: [Static type checking] - Incompatible generic argument types. Cannot assign java.util.List <java.lang.Object> to: java.util.List <AzureNamedAccountCredentials>
 @ line 63, column 5.
       azureAccounts
       ^

2 errors

> Task :clouddriver-azure:compileGroovy FAILED
```
To fix this issue use explicit typecasting of relevant variable.