### PR TITLE
refactor(azure): refactor boolean field to use default getter implementation of groovy 3.x

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -66,11 +66,11 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
     serverGroups?.each {
       try {
         if (it.loadBalancerType == AzureLoadBalancer.AzureLoadBalancerType.AZURE_LOAD_BALANCER.toString()) {
-          it.isDisabled = creds.networkClient.isServerGroupWithLoadBalancerDisabled(AzureUtilities.getResourceGroupName(it.appName, region), it.loadBalancerName, it.name)
+          it.disabled = creds.networkClient.isServerGroupWithLoadBalancerDisabled(AzureUtilities.getResourceGroupName(it.appName, region), it.loadBalancerName, it.name)
         } else if (it.loadBalancerType == AzureLoadBalancer.AzureLoadBalancerType.AZURE_APPLICATION_GATEWAY.toString()) {
-          it.isDisabled = creds.networkClient.isServerGroupWithAppGatewayDisabled(AzureUtilities.getResourceGroupName(it.appName, region), it.appGatewayName, it.name)
+          it.disabled = creds.networkClient.isServerGroupWithAppGatewayDisabled(AzureUtilities.getResourceGroupName(it.appName, region), it.appGatewayName, it.name)
         } else if (it.loadBalancerType == null) {
-          it.isDisabled = creds.networkClient.isServerGroupWithoutLoadBalancerDisabled(AzureUtilities.getResourceGroupName(it.appName, region), it.name)
+          it.disabled = creds.networkClient.isServerGroupWithoutLoadBalancerDisabled(AzureUtilities.getResourceGroupName(it.appName, region), it.name)
         } else {
           throw new RuntimeException("Invalid load balancer type $it.loadBalancerType")
         }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
@@ -62,7 +62,7 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
   String securityGroupName
   String subnetId /*Azure resource ID*/
   List<String> storageAccountNames
-  Boolean isDisabled = false
+  Boolean disabled = false
   List<AzureInboundPortConfig> inboundPortConfigs = []
   String vnet
   String subnet
@@ -138,11 +138,6 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
   @Override
   Set<String> getSecurityGroups() {
     return this.securityGroupName == null ? new HashSet<String>() : Sets.newHashSet(this.securityGroupName)
-  }
-
-  @Override
-  Boolean isDisabled() {
-    this.isDisabled
   }
 
   @Override


### PR DESCRIPTION
Refactoring the boolean field `isDisabled` to `disabled`, that allows groovy 3.x to generate its getter as `isDisabled()`, and removing the overridden method `isDisabled()`.
