### PR TITLE
fix(aws/test): Fix requests for time in "where" not fixed

### DIFF
--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/AsgConfigHelperSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/AsgConfigHelperSpec.groovy
@@ -40,12 +40,13 @@ class AsgConfigHelperSpec extends Specification {
       .application("fooTest")
       .stack("stack").build()
 
-  void setup() {
+  void setupSpec() {
     // test code shouldn't assume it will run in less than one second, so let's control the clock
+    // we use setupSpec rather than setup because setup is called after a where block
     AsgConfigHelper.clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
   }
 
-  void cleanup() {
+  void cleanupSpec() {
     AsgConfigHelper.clock = Clock.systemDefaultZone()
   }
 


### PR DESCRIPTION
Previously, calls to `AsgConfigHelper.createDefaultSuffix()` in the `AsgConfigHelperSpec` test ["should return name correctly"](https://github.com/spinnaker/clouddriver/blob/8825c133897ae962c9de674ef5cf1b6f9fe8a3c6/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/AsgConfigHelperSpec.groovy#L63) used the actual local time, since the `setup` function runs after a `where` block. This would very occasionally result in a test failure.

This PR resolves the issue by using `setupSpec` instead (correspondingly changing `cleanup` to `cleanupSpec`).