### PR TITLE
fix(databaseChangeLog): rollback element's indentation correction

### DIFF
--- a/clouddriver-sql/src/main/resources/db/changelog/20210106-task-outputs.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog/20210106-task-outputs.yml
@@ -38,6 +38,6 @@ databaseChangeLog:
             dbms: mysql
             append:
               value: " engine innodb"
-    rollback:
-      - dropTable:
-          tableName: task_outputs
+      rollback:
+        - dropTable:
+            tableName: task_outputs


### PR DESCRIPTION
This bug is discovered while working on liquibase upgrade. The newer versions of liquibase have strict enforcements on incorrect indentation of elements in databaseChangeLog files. Hence this correction is needed before upgrading the liquibase.