### PR TITLE
refactor(event): replace deprecated method to fix error during upgrade to Kotlin 1.5.32

### DIFF
--- a/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/persistence/InMemoryEventRepository.kt
+++ b/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/persistence/InMemoryEventRepository.kt
@@ -68,7 +68,7 @@ class InMemoryEventRepository(
     }
 
     events.getOrPut(aggregate) { mutableListOf() }.let { aggregateEvents ->
-      val currentSequence = aggregateEvents.map { it.getMetadata().sequence }.max() ?: 0
+      val currentSequence = aggregateEvents.map { it.getMetadata().sequence }.maxOrNull() ?: 0
 
       newEvents.forEachIndexed { index, newEvent ->
         // TODO(rz): Plugin more metadata (provenance, serviceVersion, etc)


### PR DESCRIPTION
While upgrading Kotlin 1.5.32, encounter below error in clouddriver-event module:
```
> Task :clouddriver-event:compileKotlin FAILED
e: /clouddriver/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/persistence/InMemoryEventRepository.kt: (71, 79): Using 'max(): T?' is an error. Use maxOrNull instead.
```
To fix this error, replaced the deprecated method.
