### PR TITLE
refactor(saga/test): replace deprecated method during upgrade to Kotlin 1.5.32

### DIFF
--- a/clouddriver-saga-test/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/TestingSagaRepository.kt
+++ b/clouddriver-saga-test/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/TestingSagaRepository.kt
@@ -35,7 +35,7 @@ class TestingSagaRepository : SagaRepository {
   override fun save(saga: Saga, additionalEvents: List<SagaEvent>) {
     sagas.putIfAbsent(createId(saga), saga)
 
-    val currentSequence = saga.getEvents().map { it.getMetadata().sequence }.max() ?: 0
+    val currentSequence = saga.getEvents().map { it.getMetadata().sequence }.maxOrNull() ?: 0
     val originatingVersion = saga.getVersion()
 
     saga.getPendingEvents()

--- a/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/flow/SagaFlowIterator.kt
+++ b/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/flow/SagaFlowIterator.kt
@@ -182,7 +182,7 @@ class SagaFlowIterator(
 
     index = listOf(SagaCommandCompletedEventSeeker(), SagaCommandEventSeeker())
       .mapNotNull { it.invoke(index, steps, saga)?.coerceAtLeast(0) }
-      .min()
+      .minOrNull()
       ?: index
 
     if (index != 0) {

--- a/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/models/Saga.kt
+++ b/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/models/Saga.kt
@@ -59,7 +59,7 @@ class Saga(
   fun isCompensating(): Boolean = events.filterIsInstance<SagaRollbackStarted>().isNotEmpty()
 
   fun getVersion(): Long {
-    return events.map { it.getMetadata().originatingVersion }.max()?.let { it + 1 } ?: 0
+    return events.map { it.getMetadata().originatingVersion }.maxOrNull()?.let { it + 1 } ?: 0
   }
 
   fun addEvent(event: SagaEvent) {


### PR DESCRIPTION
While upgrading Kotlin 1.5.32, encounter below error in clouddriver-saga and clouddriver-saga-test module:
```
> Task :clouddriver-saga:compileKotlin FAILED
e: /clouddriver/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/flow/SagaFlowIterator.kt: (185, 8): Using 'min(): T?' is an error. Use minOrNull instead.
e: /clouddriver/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/models/Saga.kt: (62, 63): Using 'max(): T?' is an error. Use maxOrNull instead.
```

```
> Task :clouddriver-saga-test:compileKotlin FAILED
'compileJava' task (current target is 11) and 'compileKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version.
e: /clouddriver/clouddriver-saga-test/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/TestingSagaRepository.kt: (38, 78): Using 'max(): T?' is an error. Use maxOrNull instead.
```
To fix this error, replaced the deprecated method.