### PR TITLE
fix(cats): timeoutSeconds and errorIntervalSeconds config are not respected

### DIFF
--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/cache/RedisCacheConfig.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/cache/RedisCacheConfig.java
@@ -56,8 +56,8 @@ class RedisCacheConfig {
       RedisConfigurationProperties redisConfigurationProperties) {
     return new CustomSchedulableAgentIntervalProvider(
         TimeUnit.SECONDS.toMillis(redisConfigurationProperties.getPoll().getIntervalSeconds()),
-        TimeUnit.SECONDS.toMillis(redisConfigurationProperties.getPoll().getIntervalSeconds()),
-        TimeUnit.SECONDS.toMillis(redisConfigurationProperties.getPoll().getIntervalSeconds()));
+        TimeUnit.SECONDS.toMillis(redisConfigurationProperties.getPoll().getErrorIntervalSeconds()),
+        TimeUnit.SECONDS.toMillis(redisConfigurationProperties.getPoll().getTimeoutSeconds()));
   }
 
   @Bean


### PR DESCRIPTION
Fixed `redis.poll.errorIntervalSeconds` and `redis.poll.timeoutSeconds` configs are not respected. This bug was introduced when converting `RedisCacheConfig` from Groovy to Java. See related [PR](https://github.com/spinnaker/clouddriver/pull/5703/files#diff-8db17292fc8921bc3d45504a73d5a93cc9a5b7ce6fb1a1537b8532648f131b6d).


