### PR TITLE
fix(configserver): make AbstractBootstrapCredentialsConfigurationProvider.getPropertiesMap aware of SecretAwarePropertySource

### DIFF
--- a/clouddriver-configserver/src/main/java/com/netflix/spinnaker/clouddriver/config/AbstractBootstrapCredentialsConfigurationProvider.java
+++ b/clouddriver-configserver/src/main/java/com/netflix/spinnaker/clouddriver/config/AbstractBootstrapCredentialsConfigurationProvider.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.wnameless.json.flattener.JsonFlattener;
 import com.netflix.spinnaker.kork.configserver.CloudConfigResourceService;
 import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
+import com.netflix.spinnaker.kork.secrets.SecretAwarePropertySource;
 import com.netflix.spinnaker.kork.secrets.SecretManager;
 import com.netflix.spinnaker.kork.secrets.SecretSession;
 import java.nio.file.Path;
@@ -65,7 +66,10 @@ public abstract class AbstractBootstrapCredentialsConfigurationProvider<T>
     Map<String, Object> map;
 
     for (PropertySource<?> propertySource : environment.getPropertySources()) {
-      if (propertySource instanceof BootstrapPropertySource) {
+      if (propertySource instanceof BootstrapPropertySource
+          || (propertySource instanceof SecretAwarePropertySource
+              && ((SecretAwarePropertySource<?>) propertySource).getDelegate()
+                  instanceof BootstrapPropertySource)) {
         map = (Map<String, Object>) propertySource.getSource();
         if (map.containsKey(property)) {
           return map;

--- a/clouddriver-web/src/main/java/com/netflix/spinnaker/clouddriver/listeners/ConfigurationRefreshListener.java
+++ b/clouddriver-web/src/main/java/com/netflix/spinnaker/clouddriver/listeners/ConfigurationRefreshListener.java
@@ -23,7 +23,8 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 
 @Component
-class ConfigurationRefreshListener implements ApplicationListener<RefreshScopeRefreshedEvent> {
+public class ConfigurationRefreshListener
+    implements ApplicationListener<RefreshScopeRefreshedEvent> {
 
   private final List<CredentialsInitializerSynchronizable> credentialsSynchronizers;
 

--- a/clouddriver-web/src/test/java/com/netflix/spinnaker/clouddriver/controllers/KubernetesCustomPropertyBindingRefreshTest.java
+++ b/clouddriver-web/src/test/java/com/netflix/spinnaker/clouddriver/controllers/KubernetesCustomPropertyBindingRefreshTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.controllers;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.netflix.spinnaker.clouddriver.Main;
+import com.netflix.spinnaker.clouddriver.listeners.ConfigurationRefreshListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@WebAppConfiguration
+@SpringBootTest(classes = {Main.class})
+@TestPropertySource(
+    properties = {
+      "redis.enabled = false",
+      "sql.enabled = false",
+      "spring.application.name = clouddriver",
+      "kubernetes.enabled = true",
+      "management.endpoints.web.exposure.include = refresh",
+      "kubernetes.customPropertyBindingEnabled = true",
+      "spring.cloud.bootstrap.enabled = true",
+      "spring.cloud.config.server.bootstrap = true",
+      "spring.profiles.active = native",
+      "spring.cloud.config.server.native.search-locations = classpath:/"
+    })
+public class KubernetesCustomPropertyBindingRefreshTest {
+  private MockMvc mockMvc;
+
+  @Autowired private WebApplicationContext webApplicationContext;
+
+  @SpyBean private ConfigurationRefreshListener listener;
+
+  @BeforeEach
+  void setup(TestInfo testInfo) {
+    System.out.println("--------------- Test " + testInfo.getDisplayName());
+    mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+  }
+
+  @Test
+  public void testRefreshScopeRefreshedEvent() throws Exception {
+    mockMvc.perform(post("/refresh")).andExpect(status().isOk());
+
+    verify(listener).onApplicationEvent(any(RefreshScopeRefreshedEvent.class));
+  }
+}

--- a/clouddriver-web/src/test/resources/clouddriver.yml
+++ b/clouddriver-web/src/test/resources/clouddriver.yml
@@ -1,0 +1,5 @@
+kubernetes:
+  enabled: true
+  accounts:
+    - name: my-k8s-account
+      cacheIntervalSeconds: 60


### PR DESCRIPTION
Since SecretAwarePropertySource is now shadowing the underlying PropertySource, delegate is made public through https://github.com/spinnaker/kork/pull/1122, and it's being used to identify BootstrapPropertySource.

`KubernetesCustomPropertyBindingRefreshTest`  is added to verify the `/refresh` scenario.

minor changes are added to accommodate the test class.
