### PR TITLE
fix(kubernetes): use getFullResourceName in KubectlJobExecutor.create

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -654,7 +654,7 @@ public class KubectlJobExecutor {
 
   public KubernetesManifest create(
       KubernetesCredentials credentials, KubernetesManifest manifest, Task task, String opName) {
-    log.info("Creating manifest {}", manifest.getName());
+    log.info("Creating manifest {}", manifest.getFullResourceName());
     List<String> command = kubectlAuthPrefix(credentials);
 
     // Read from stdin


### PR DESCRIPTION
to get a meaningful manifest name when using generateName instead of name
