### PR TITLE
fix(clouddriver): fix broken TARGETARCH comparison on ubuntu base

### DIFF
--- a/Dockerfile.java11.ubuntu
+++ b/Dockerfile.java11.ubuntu
@@ -36,7 +36,7 @@ RUN wget https://cdn.dl.k8s.io/release/v${KUBECTL_RELEASE}/bin/linux/${TARGETARC
     && ln -sf /usr/local/bin/aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws
 
 # Google cloud SDK
-RUN [ $TARGETARCH == 'amd64' ] &&  export GCP_ARCH="x86_64" || export GCP_ARCH="arm"  \
+RUN [ $TARGETARCH = 'amd64' ] &&  export GCP_ARCH="x86_64" || export GCP_ARCH="arm"  \
   && wget -nv https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-${GCP_ARCH}.tar.gz \
   && mkdir -p /opt && cd /opt \
   && tar -xzf /google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-${GCP_ARCH}.tar.gz \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -36,7 +36,7 @@ RUN wget https://cdn.dl.k8s.io/release/v${KUBECTL_RELEASE}/bin/linux/${TARGETARC
     && ln -sf /usr/local/bin/aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws
 
 # Google cloud SDK
-RUN [ $TARGETARCH == 'amd64' ] &&  export GCP_ARCH="x86_64" || export GCP_ARCH="arm"  \
+RUN [ $TARGETARCH = 'amd64' ] &&  export GCP_ARCH="x86_64" || export GCP_ARCH="arm"  \
   && wget -nv https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-${GCP_ARCH}.tar.gz \
   && mkdir -p /opt && cd /opt \
   && tar -xzf /google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-${GCP_ARCH}.tar.gz \


### PR DESCRIPTION
Fixed broken Target Architecture comparison in the Ubuntu base Dockerfiles.

Ubuntu based images are using `sh` as a shell and `sh` shell does not support `==` operator.

But the Dockerfiles for Ubuntu based images are using this unsupported operator and it always fall back to `arm` regardless what the target platform is.

```
RUN [ $TARGETARCH == 'amd64' ] &&  export GCP_ARCH="x86_64" || export GCP_ARCH="arm"  \
```
eg> https://github.com/spinnaker/clouddriver/actions/runs/7180313240/job/19552298170
```
#13 [linux/amd64 5/8] RUN [ amd64 == 'amd64' ] &&  export GCP_ARCH="x86_64" || export GCP_ARCH="arm"    && wget -nv https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-412.0.0-linux-$***GCP_ARCH***.tar.gz   && mkdir -p /opt && cd /opt   && tar -xzf /google-cloud-sdk-412.0.0-linux-$***GCP_ARCH***.tar.gz   && rm /google-cloud-sdk-412.0.0-linux-$***GCP_ARCH***.tar.gz   && CLOUDSDK_PYTHON="python3" /opt/google-cloud-sdk/install.sh --usage-reporting=false --bash-completion=false       --additional-components app-engine-java app-engine-go gke-gcloud-auth-plugin    && rm -rf ~/.config/gcloud   && rm -rf /opt/google-cloud-sdk/.install/.backup
#13 0.071 /bin/sh: 1: [: amd64: unexpected operator
#13 2.160 2023-12-12 11:36:40 URL:https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-412.0.0-linux-arm.tar.gz [96294446/96294446] -> "google-cloud-sdk-412.0.0-linux-arm.tar.gz" [1]
```

Replaced bash equality operator `==` in Ubuntu Dockerfiles to sh string equality operator `=`