### PR TITLE
refactor(kubernetes): refactor and upgrade kubernetes java client apis and its relevant dependency during upgrade to spring boot 2.6.x

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -81,6 +81,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-secrets"
   implementation "io.spinnaker.kork:kork-security"
   implementation "io.kubernetes:client-java"
+  implementation "io.kubernetes:client-java-api-fluent:13.0.2"
   implementation "org.apache.commons:commons-lang3"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesJobStatus.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesJobStatus.java
@@ -68,7 +68,7 @@ public class KubernetesJobStatus implements JobStatus {
     this.account = account;
     this.name = job.getMetadata().getName();
     this.location = job.getMetadata().getNamespace();
-    this.createdTime = job.getMetadata().getCreationTimestamp().getMillis();
+    this.createdTime = job.getMetadata().getCreationTimestamp().toInstant().toEpochMilli();
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
@@ -30,12 +30,12 @@ import com.netflix.spinnaker.clouddriver.model.JobState;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1Pod;
+import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import org.apache.commons.lang3.NotImplementedException;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -82,12 +82,12 @@ public class KubernetesJobProvider implements JobProvider<KubernetesJobStatus> {
             .map(m -> KubernetesCacheDataConverter.getResource(m, V1Pod.class))
             .sorted(
                 (p1, p2) -> {
-                  DateTime dtDefault = new DateTime(0);
-                  DateTime time1 =
+                  OffsetDateTime dtDefault = OffsetDateTime.now();
+                  OffsetDateTime time1 =
                       p1.getStatus() != null
                           ? Optional.ofNullable(p1.getStatus().getStartTime()).orElse(dtDefault)
                           : dtDefault;
-                  DateTime time2 =
+                  OffsetDateTime time2 =
                       p2.getStatus() != null
                           ? Optional.ofNullable(p2.getStatus().getStartTime()).orElse(dtDefault)
                           : dtDefault;

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -52,7 +52,7 @@ dependencies {
   testImplementation "io.spinnaker.kork:kork-test"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "org.spockframework:spock-core"
-  testImplementation "io.kubernetes:client-java"
+  testImplementation "io.kubernetes:client-java-api-fluent:13.0.2"
   testImplementation "org.codehaus.groovy:groovy-json"
 
   // Add each included cloud provider project as a runtime dependency

--- a/clouddriver-web/src/test/java/com/netflix/spinnaker/clouddriver/config/ObjectMapperTest.java
+++ b/clouddriver-web/src/test/java/com/netflix/spinnaker/clouddriver/config/ObjectMapperTest.java
@@ -26,8 +26,8 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodCondition;
 import io.kubernetes.client.openapi.models.V1PodStatus;
+import java.time.OffsetDateTime;
 import java.util.List;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,14 +53,14 @@ public class ObjectMapperTest {
   public void testJodaTimeSerializationForKubernetesJob() {
     V1Job job = new V1Job();
     V1ObjectMeta metadata = new V1ObjectMeta();
-    metadata.setCreationTimestamp(DateTime.now());
+    metadata.setCreationTimestamp(OffsetDateTime.now());
     job.setMetadata(metadata);
     KubernetesJobStatus kubernetesJobStatus = new KubernetesJobStatus(job, "kubernetesAccount");
 
     V1Pod pod = new V1Pod();
     V1PodStatus status = new V1PodStatus();
     V1PodCondition condition = new V1PodCondition();
-    condition.setLastTransitionTime(DateTime.now());
+    condition.setLastTransitionTime(OffsetDateTime.now());
     status.setConditions(List.of(condition));
     pod.setStatus(status);
     V1ObjectMeta metadataPod = new V1ObjectMeta();


### PR DESCRIPTION
While upgrading spring boot 2.6.15 and spring cloud 2021.0.8, encounter below errors in clouddriver-kubernetes module during build and test compilation:
```
> Task :clouddriver-kubernetes:compileTestJava FAILED
/clouddriver/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacerTest.java:33: error: cannot find symbol
import io.kubernetes.client.openapi.models.V1ContainerBuilder;
                                          ^
  symbol:   class V1ContainerBuilder
  location: package io.kubernetes.client.openapi.models
/clouddriver/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacerTest.java:35: error: cannot find symbol
import io.kubernetes.client.openapi.models.V1DeploymentBuilder;
                                          ^
  symbol:   class V1DeploymentBuilder
  location: package io.kubernetes.client.openapi.models
/clouddriver/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacerTest.java:38: error: cannot find symbol
import io.kubernetes.client.openapi.models.V1HorizontalPodAutoscalerBuilder;
                                          ^
  symbol:   class V1HorizontalPodAutoscalerBuilder
  location: package io.kubernetes.client.openapi.models
/clouddriver/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacerTest.java:42: error: cannot find symbol
import io.kubernetes.client.openapi.models.V1ReplicaSetBuilder;
                                          ^
  symbol:   class V1ReplicaSetBuilder
  location: package io.kubernetes.client.openapi.models
4 errors
```

```
> Task :clouddriver-kubernetes:compileJava FAILED
/clouddriver/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java:38: error: package org.joda.time does not exist
import org.joda.time.DateTime;
                    ^
1 error
```

```
/clouddriver/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesJobStatus.java:71: error: cannot find symbol
    this.createdTime = job.getMetadata().getCreationTimestamp().getMillis();
                                                               ^
  symbol:   method getMillis()
  location: class OffsetDateTime
```

First issue is due to upgrade in kubernetes java client from 11.0.4 to [13.0.2](https://github.com/kubernetes-client/java/blob/master/CHANGELOG.md#1300) brought by spring cloud upgrade to 2021.0.8, which add separate fluent builder classes (and also its generator) to new modules client-java-api-fluent and client-java-api-fluent-gen. https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/2021.0.8/spring-cloud-dependencies-2021.0.8.pom https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-kubernetes-dependencies/2.1.8/spring-cloud-kubernetes-dependencies-2.1.8.pom

Since these fluent builder module is not part of java client package pom, so adding explicit dependency of `io.kubernetes:client-java-api-fluent` and pinning the required version.

Second and third issue is due to change in required parameters, from `DateTime` to `OffsetDateTime`, of kubernetes client apis as part of upgrade like for [V1PodCondition.setLastTransitionTime(OffsetDateTime)](https://javadoc.io/static/io.kubernetes/client-java-api/13.0.2/io/kubernetes/client/openapi/models/V1PodCondition.html#setLastTransitionTime-java.time.OffsetDateTime-). Updating the required parameters in order to fix them.
