### PR TITLE
fix(core): Fix type migration issue

### DIFF
--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.java
@@ -94,8 +94,9 @@ import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRep
 import com.netflix.spinnaker.clouddriver.security.config.SecurityConfig;
 import com.netflix.spinnaker.config.PluginsAutoConfiguration;
 import com.netflix.spinnaker.credentials.CompositeCredentialsRepository;
+import com.netflix.spinnaker.credentials.Credentials;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
-import com.netflix.spinnaker.credentials.definition.AbstractCredentialsLoader;
+import com.netflix.spinnaker.credentials.definition.CredentialsLoader;
 import com.netflix.spinnaker.credentials.poller.PollerConfiguration;
 import com.netflix.spinnaker.credentials.poller.PollerConfigurationProperties;
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
@@ -111,6 +112,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.inject.Provider;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -216,7 +218,7 @@ class CloudDriverConfig {
 
   @Bean
   PollerConfiguration pollerConfiguration(
-      List<AbstractCredentialsLoader<?>> pollers,
+      ObjectProvider<CredentialsLoader<? extends Credentials>> pollers,
       PollerConfigurationProperties pollerConfigurationProperties) {
     return new PollerConfiguration(pollerConfigurationProperties, pollers);
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 fiatVersion=1.43.0
-korkVersion=7.208.0
+korkVersion=7.209.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.32.1
 targetJava11=true


### PR DESCRIPTION
In `PollerConfiguration`, this now takes an `ObjectProvider` instead of a `List`, and it uses the newly introduced `CredentialsLoader` interface instead.

Related to compilation failure in https://github.com/spinnaker/clouddriver/pull/6131