### PR TITLE
remove failures from ./gradlew dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ subprojects {
     sourceSets.main.groovy.srcDirs += ["src/main/java"]
 
     dependencies {
+      api enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
       implementation enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
 
       annotationProcessor enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ subprojects {
       annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
       testAnnotationProcessor enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
       testAnnotationProcessor "org.projectlombok:lombok"
+      testRuntimeOnly enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
       testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,11 +56,19 @@ subprojects {
     dependencies {
       api enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
 
+      compileOnly enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
+      compileOnly "org.projectlombok:lombok"
+
       annotationProcessor enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
       annotationProcessor "org.projectlombok:lombok"
       annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
       testAnnotationProcessor enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
       testAnnotationProcessor "org.projectlombok:lombok"
+
+      testCompileOnly enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
+      testCompileOnly "org.projectlombok:lombok"
+
       testRuntimeOnly enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
       testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -56,10 +56,10 @@ subprojects {
     dependencies {
       implementation enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
 
-      annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
+      annotationProcessor enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
       annotationProcessor "org.projectlombok:lombok"
       annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-      testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
+      testAnnotationProcessor enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
       testAnnotationProcessor "org.projectlombok:lombok"
       testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,6 @@ subprojects {
 
     dependencies {
       api enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
-      implementation enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
 
       annotationProcessor enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
       annotationProcessor "org.projectlombok:lombok"

--- a/cats/cats-core/cats-core.gradle
+++ b/cats/cats-core/cats-core.gradle
@@ -6,15 +6,8 @@ dependencies {
   implementation "org.codehaus.groovy:groovy"
   implementation "com.google.guava:guava"
 
-  compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
-
   testImplementation project(":cats:cats-test")
 
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
-}
-test{
-  useJUnitPlatform()
 }

--- a/cats/cats-redis/cats-redis.gradle
+++ b/cats/cats-redis/cats-redis.gradle
@@ -2,8 +2,6 @@ dependencies {
   implementation project(":cats:cats-core")
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "org.codehaus.groovy:groovy"
   implementation "com.fasterxml.jackson.core:jackson-databind"

--- a/cats/cats-test/cats-test.gradle
+++ b/cats/cats-test/cats-test.gradle
@@ -11,11 +11,4 @@ dependencies {
   implementation "org.objenesis:objenesis"
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
-
-  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
-}
-test{
-  useJUnitPlatform()
 }

--- a/cats/cats-test/cats-test.gradle
+++ b/cats/cats-test/cats-test.gradle
@@ -9,6 +9,4 @@ dependencies {
   implementation "org.spockframework:spock-spring"
   implementation "cglib:cglib-nodep"
   implementation "org.objenesis:objenesis"
-
-  compileOnly "org.projectlombok:lombok"
 }

--- a/clouddriver-alicloud/clouddriver-alicloud.gradle
+++ b/clouddriver-alicloud/clouddriver-alicloud.gradle
@@ -5,8 +5,6 @@ dependencies {
   implementation project(":clouddriver-security")
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "io.spinnaker.kork:kork-core"
   implementation "io.spinnaker.kork:kork-exceptions"

--- a/clouddriver-alicloud/clouddriver-alicloud.gradle
+++ b/clouddriver-alicloud/clouddriver-alicloud.gradle
@@ -4,8 +4,6 @@ dependencies {
   implementation project(":clouddriver-eureka")
   implementation project(":clouddriver-security")
 
-  compileOnly "org.projectlombok:lombok"
-
   implementation "io.spinnaker.kork:kork-core"
   implementation "io.spinnaker.kork:kork-exceptions"
   implementation "io.spinnaker.kork:kork-security"

--- a/clouddriver-api/clouddriver-api.gradle
+++ b/clouddriver-api/clouddriver-api.gradle
@@ -17,8 +17,8 @@
 apply plugin: 'java-library'
 
 dependencies {
-  implementation platform("io.spinnaker.kork:kork-bom:$korkVersion")
-  annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
+  implementation enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
+  annotationProcessor enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
 
   api("io.spinnaker.kork:kork-plugins-api")
   api("io.spinnaker.kork:kork-credentials-api")

--- a/clouddriver-appengine/clouddriver-appengine.gradle
+++ b/clouddriver-appengine/clouddriver-appengine.gradle
@@ -7,8 +7,6 @@ dependencies {
   implementation project(":clouddriver-security")
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "com.google.apis:google-api-services-appengine:v1-rev92-1.25.0"
   implementation "com.google.apis:google-api-services-storage"

--- a/clouddriver-appengine/clouddriver-appengine.gradle
+++ b/clouddriver-appengine/clouddriver-appengine.gradle
@@ -6,8 +6,6 @@ dependencies {
   implementation project(":clouddriver-google-common")
   implementation project(":clouddriver-security")
 
-  compileOnly "org.projectlombok:lombok"
-
   implementation "com.google.apis:google-api-services-appengine:v1-rev92-1.25.0"
   implementation "com.google.apis:google-api-services-storage"
   implementation 'com.google.auth:google-auth-library-oauth2-http'

--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -22,8 +22,6 @@ dependencies {
   implementation project(":clouddriver-api")
   implementation project(":clouddriver-core")
 
-  compileOnly "org.projectlombok:lombok"
-
   implementation "com.amazonaws:aws-java-sdk-s3"
   implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
   implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"

--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -23,8 +23,6 @@ dependencies {
   implementation project(":clouddriver-core")
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "com.amazonaws:aws-java-sdk-s3"
   implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"

--- a/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver-aws/clouddriver-aws.gradle
@@ -24,8 +24,6 @@ dependencies {
   implementation project(":clouddriver-security")
   implementation project(":clouddriver-saga")
 
-  compileOnly "org.projectlombok:lombok"
-
   implementation "javax.inject:javax.inject:1"
   implementation "com.amazonaws:aws-java-sdk"
   implementation "com.github.ben-manes.caffeine:guava"

--- a/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver-aws/clouddriver-aws.gradle
@@ -25,8 +25,6 @@ dependencies {
   implementation project(":clouddriver-saga")
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "javax.inject:javax.inject:1"
   implementation "com.amazonaws:aws-java-sdk"

--- a/clouddriver-bom/clouddriver-bom.gradle
+++ b/clouddriver-bom/clouddriver-bom.gradle
@@ -22,7 +22,7 @@ javaPlatform {
 }
 
 dependencies {
-  api(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
+  api(enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion"))
 
   constraints {
     api("io.spinnaker.fiat:fiat-api:$fiatVersion")

--- a/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
+++ b/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
@@ -35,8 +35,6 @@ dependencies {
   implementation project(":cats:cats-core")
   implementation project(":clouddriver-docker")
 
-  compileOnly "org.projectlombok:lombok"
-
   implementation "org.codehaus.groovy:groovy"
 
   implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"

--- a/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
+++ b/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
@@ -36,8 +36,6 @@ dependencies {
   implementation project(":clouddriver-docker")
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "org.codehaus.groovy:groovy"
 

--- a/clouddriver-cloudrun/clouddriver-cloudrun.gradle
+++ b/clouddriver-cloudrun/clouddriver-cloudrun.gradle
@@ -7,8 +7,6 @@ dependencies {
   implementation project(":clouddriver-security")
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "com.google.apis:google-api-services-run:v1-rev49-1.25.0"
   implementation "com.google.apis:google-api-services-storage"

--- a/clouddriver-cloudrun/clouddriver-cloudrun.gradle
+++ b/clouddriver-cloudrun/clouddriver-cloudrun.gradle
@@ -6,8 +6,6 @@ dependencies {
   implementation project(":clouddriver-google-common")
   implementation project(":clouddriver-security")
 
-  compileOnly "org.projectlombok:lombok"
-
   implementation "com.google.apis:google-api-services-run:v1-rev49-1.25.0"
   implementation "com.google.apis:google-api-services-storage"
   implementation 'com.google.auth:google-auth-library-oauth2-http'

--- a/clouddriver-configserver/clouddriver-configserver.gradle
+++ b/clouddriver-configserver/clouddriver-configserver.gradle
@@ -9,9 +9,6 @@ sourceSets {
 }
 
 dependencies {
-  compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-
   implementation "com.google.guava:guava"
   implementation "io.spinnaker.kork:kork-annotations"
   implementation "io.spinnaker.kork:kork-config"

--- a/clouddriver-core/clouddriver-core.gradle
+++ b/clouddriver-core/clouddriver-core.gradle
@@ -8,9 +8,6 @@ dependencies {
   implementation project(":clouddriver-security")
   implementation project(":clouddriver-saga")
 
-  compileOnly "org.projectlombok:lombok"
-  testCompileOnly "org.projectlombok:lombok"
-
   // Because a JobRequest constructor takes a org.apache.commons.exec.CommandLine argument
   api "org.apache.commons:commons-exec"
 

--- a/clouddriver-core/clouddriver-core.gradle
+++ b/clouddriver-core/clouddriver-core.gradle
@@ -10,8 +10,6 @@ dependencies {
 
   compileOnly "org.projectlombok:lombok"
   testCompileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   // Because a JobRequest constructor takes a org.apache.commons.exec.CommandLine argument
   api "org.apache.commons:commons-exec"

--- a/clouddriver-docker/clouddriver-docker.gradle
+++ b/clouddriver-docker/clouddriver-docker.gradle
@@ -4,9 +4,6 @@ dependencies {
   implementation project(":clouddriver-security")
   implementation project(":cats:cats-core")
 
-  compileOnly "org.projectlombok:lombok"
-  testCompileOnly "org.projectlombok:lombok"
-
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.springframework.cloud:spring-cloud-context"

--- a/clouddriver-ecs/clouddriver-ecs.gradle
+++ b/clouddriver-ecs/clouddriver-ecs.gradle
@@ -19,8 +19,6 @@ dependencies {
   implementation project(":clouddriver-core")
   implementation project(":clouddriver-security")
 
-  compileOnly "org.projectlombok:lombok"
-
   implementation "com.amazonaws:aws-java-sdk"
   implementation "com.github.ben-manes.caffeine:guava"
   implementation "com.netflix.awsobjectmapper:awsobjectmapper"

--- a/clouddriver-ecs/clouddriver-ecs.gradle
+++ b/clouddriver-ecs/clouddriver-ecs.gradle
@@ -20,8 +20,6 @@ dependencies {
   implementation project(":clouddriver-security")
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "com.amazonaws:aws-java-sdk"
   implementation "com.github.ben-manes.caffeine:guava"

--- a/clouddriver-google-common/clouddriver-google-common.gradle
+++ b/clouddriver-google-common/clouddriver-google-common.gradle
@@ -1,6 +1,4 @@
 dependencies {
-  compileOnly "org.projectlombok:lombok"
-
   implementation "com.google.api-client:google-api-client"
   implementation 'com.google.auth:google-auth-library-oauth2-http'
   implementation "io.spinnaker.kork:kork-annotations"

--- a/clouddriver-google-common/clouddriver-google-common.gradle
+++ b/clouddriver-google-common/clouddriver-google-common.gradle
@@ -1,7 +1,5 @@
 dependencies {
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "com.google.api-client:google-api-client"
   implementation 'com.google.auth:google-auth-library-oauth2-http'

--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -8,8 +8,6 @@ dependencies {
   implementation project(":clouddriver-security")
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "org.codehaus.groovy:groovy"
   implementation "org.codehaus.groovy:groovy-json"

--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -7,8 +7,6 @@ dependencies {
   implementation project(":clouddriver-google-common")
   implementation project(":clouddriver-security")
 
-  compileOnly "org.projectlombok:lombok"
-
   implementation "org.codehaus.groovy:groovy"
   implementation "org.codehaus.groovy:groovy-json"
   implementation "org.apache.commons:commons-lang3"

--- a/clouddriver-huaweicloud/clouddriver-huaweicloud.gradle
+++ b/clouddriver-huaweicloud/clouddriver-huaweicloud.gradle
@@ -4,8 +4,6 @@ dependencies {
   implementation project(":clouddriver-core")
   implementation project(":clouddriver-security")
 
-  compileOnly "org.projectlombok:lombok"
-
   implementation "io.spinnaker.kork:kork-exceptions"
   implementation "com.netflix.frigga:frigga"
   implementation "com.netflix.spectator:spectator-api"

--- a/clouddriver-huaweicloud/clouddriver-huaweicloud.gradle
+++ b/clouddriver-huaweicloud/clouddriver-huaweicloud.gradle
@@ -5,8 +5,6 @@ dependencies {
   implementation project(":clouddriver-security")
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "io.spinnaker.kork:kork-exceptions"
   implementation "com.netflix.frigga:frigga"

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -56,9 +56,6 @@ dependencies {
   implementation project(":cats:cats-core")
   implementation project(":clouddriver-security")
 
-  compileOnly "org.projectlombok:lombok"
-  testCompileOnly "org.projectlombok:lombok"
-
   implementation "org.codehaus.groovy:groovy"
 
   implementation "com.google.code.findbugs:jsr305"

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -58,8 +58,6 @@ dependencies {
 
   compileOnly "org.projectlombok:lombok"
   testCompileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "org.codehaus.groovy:groovy"
 

--- a/clouddriver-lambda/clouddriver-lambda.gradle
+++ b/clouddriver-lambda/clouddriver-lambda.gradle
@@ -6,9 +6,6 @@ dependencies {
   implementation project(":clouddriver-core")
   implementation project(":clouddriver-security")
 
-  compileOnly "org.projectlombok:lombok"
-  testCompileOnly "org.projectlombok:lombok"
-
   implementation "commons-io:commons-io"
   implementation "com.amazonaws:aws-java-sdk"
   implementation "com.github.ben-manes.caffeine:guava"

--- a/clouddriver-lambda/clouddriver-lambda.gradle
+++ b/clouddriver-lambda/clouddriver-lambda.gradle
@@ -9,9 +9,6 @@ dependencies {
   compileOnly "org.projectlombok:lombok"
   testCompileOnly "org.projectlombok:lombok"
 
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
-
   implementation "commons-io:commons-io"
   implementation "com.amazonaws:aws-java-sdk"
   implementation "com.github.ben-manes.caffeine:guava"

--- a/clouddriver-oracle/clouddriver-oracle.gradle
+++ b/clouddriver-oracle/clouddriver-oracle.gradle
@@ -5,8 +5,6 @@ dependencies {
   implementation project(":clouddriver-security")
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "com.github.ben-manes.caffeine:guava"
   implementation "com.netflix.frigga:frigga"

--- a/clouddriver-oracle/clouddriver-oracle.gradle
+++ b/clouddriver-oracle/clouddriver-oracle.gradle
@@ -4,8 +4,6 @@ dependencies {
   implementation project(":clouddriver-core")
   implementation project(":clouddriver-security")
 
-  compileOnly "org.projectlombok:lombok"
-
   implementation "com.github.ben-manes.caffeine:guava"
   implementation "com.netflix.frigga:frigga"
   implementation "com.netflix.spectator:spectator-api"

--- a/clouddriver-tencentcloud/clouddriver-tencentcloud.gradle
+++ b/clouddriver-tencentcloud/clouddriver-tencentcloud.gradle
@@ -7,9 +7,6 @@ dependencies {
   implementation project(":clouddriver-eureka")
   implementation project(":clouddriver-security")
 
-  compileOnly "org.projectlombok:lombok"
-  testCompileOnly "org.projectlombok:lombok"
-
   implementation "com.netflix.frigga:frigga"
   implementation "com.netflix.spectator:spectator-api"
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"

--- a/clouddriver-tencentcloud/clouddriver-tencentcloud.gradle
+++ b/clouddriver-tencentcloud/clouddriver-tencentcloud.gradle
@@ -9,8 +9,6 @@ dependencies {
 
   compileOnly "org.projectlombok:lombok"
   testCompileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "com.netflix.frigga:frigga"
   implementation "com.netflix.spectator:spectator-api"

--- a/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver-titus/clouddriver-titus.gradle
@@ -16,9 +16,7 @@ dependencies {
   implementation project(":clouddriver-saga")
   implementation project(":clouddriver-security")
 
-  annotationProcessor "org.projectlombok:lombok"
   compileOnly "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "javax.inject:javax.inject:1"
   implementation "com.amazonaws:aws-java-sdk"

--- a/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver-titus/clouddriver-titus.gradle
@@ -16,8 +16,6 @@ dependencies {
   implementation project(":clouddriver-saga")
   implementation project(":clouddriver-security")
 
-  compileOnly "org.projectlombok:lombok"
-
   implementation "javax.inject:javax.inject:1"
   implementation "com.amazonaws:aws-java-sdk"
   implementation "com.google.protobuf:protobuf-java"

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -22,8 +22,6 @@ dependencies {
   }
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation "com.netflix.frigga:frigga"
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -21,8 +21,6 @@ dependencies {
     runtimeOnly(project(":clouddriver-sql-postgres"))
   }
 
-  compileOnly "org.projectlombok:lombok"
-
   implementation "com.netflix.frigga:frigga"
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
   implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"

--- a/clouddriver-yandex/clouddriver-yandex.gradle
+++ b/clouddriver-yandex/clouddriver-yandex.gradle
@@ -9,8 +9,6 @@ dependencies {
   implementation project(":clouddriver-core")
   implementation project(":clouddriver-security")
 
-  compileOnly "org.projectlombok:lombok"
-
   implementation 'com.yandex.cloud:java-sdk-services:2.1.1'
   compileOnly "io.opencensus:opencensus-api"
   compileOnly "io.opencensus:opencensus-contrib-grpc-metrics"

--- a/clouddriver-yandex/clouddriver-yandex.gradle
+++ b/clouddriver-yandex/clouddriver-yandex.gradle
@@ -10,8 +10,6 @@ dependencies {
   implementation project(":clouddriver-security")
 
   compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
-  testAnnotationProcessor "org.projectlombok:lombok"
 
   implementation 'com.yandex.cloud:java-sdk-services:2.1.1'
   compileOnly "io.opencensus:opencensus-api"


### PR DESCRIPTION
Various gradle cleanups with the goal of removing failures from `$ ./gradlew dependencies` output from all clouddriver modules.  Happily, all the failures are gone.

FWIW, I often use this to poke around for dependency changes
```
alias gradle-all-deps='./gradlew --no-parallel --stacktrace dependencies $(./gradlew -q projects \
    | grep -Fe ---\ Project \
    | sed -Ee "s/^.+--- Project '"'([^']+)'/\1:dependencies/"'" | sort)'
```
inspired by https://stackoverflow.com/a/65945289