### PR TITLE
fix(docker): Parse date into Instant when using sortTagsByDate

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
@@ -51,7 +51,21 @@ class DockerRegistryImageLookupController {
       Keys.getTaggedImageKey(account, repository, "*")
     ).sort { a, b ->
       if (credentials.sortTagsByDate) {
-        b.attributes.date.epochSecond <=> a.attributes.date.epochSecond
+        Instant dateA
+        if (a.attributes.date instanceof String) {
+          dateA = Instant.parse(a.attributes.date)
+        } else {
+          dateA = a.attributes.date
+        }
+
+        Instant dateB
+        if (b.attributes.date instanceof String) {
+          dateB = Instant.parse(b.attributes.date)
+        } else {
+          dateB = b.attributes.date
+        }
+
+        dateB.epochSecond <=> dateA.epochSecond      
       } else {
         a.id <=> b.id
       }


### PR DESCRIPTION
Potential fix for https://github.com/spinnaker/spinnaker/issues/6921

I know this feature isn't recommend (https://github.com/spinnaker/spinnaker/issues/5538), but we have a small repository we are caching and sorting the tags for it would be nice.

We are using Redis and the date value is cached as a string:
```
bash-4.4# redis-cli --scan --pattern dockerRegistry:taggedImage:attributes:dockerRegistry:taggedImage:**** | xargs redis-cli mget
1) "{\"account\":\"***\",\"date\":\"2024-01-08T15:23:15.280797435Z\",\"name\":\"***\"}"
```

With this change, the date value will be parsed to an `Instant` if the date is cached as a `String`.