### PR TITLE
fix(sql): Fix indexes for the accounts table

### DIFF
--- a/clouddriver-sql/src/main/resources/db/changelog-master.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog-master.yml
@@ -26,3 +26,6 @@ databaseChangeLog:
 - include:
     file: changelog/20210927-accounts.yml
     relativeToChangelogFile: true
+- include:
+    file: changelog/20240111-accounts-indexes.yml
+    relativeToChangelogFile: true

--- a/clouddriver-sql/src/main/resources/db/changelog/20240111-accounts-indexes.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog/20240111-accounts-indexes.yml
@@ -1,0 +1,47 @@
+databaseChangeLog:
+  - changeSet:
+      id: delete-unused-indexes
+      author: dzheng
+      changes:
+        - dropIndex:
+            indexName: accounts_type_index
+            tableName: accounts
+        - dropIndex:
+            indexName: accounts_timestamp_index
+            tableName: accounts
+      rollback:
+        - createIndex:
+            indexName: accounts_type_index
+            tableName: accounts
+            columns:
+              - column:
+                  name: id
+              - column:
+                  name: type
+        - createIndex:
+            indexName: accounts_timestamp_index
+            tableName: accounts
+            columns:
+              - column:
+                  name: id
+              - column:
+                  name: type
+              - column:
+                  name: created_at
+              - column:
+                  name: last_modified_at
+
+  - changeSet:
+      id: create-type-index
+      author: dzheng
+      changes:
+        - createIndex:
+            indexName: accounts_type_index
+            tableName: accounts
+            columns:
+              - column:
+                  name: type
+      rollback:
+        - dropIndex:
+            indexName: accounts_type_index
+            tableName: accounts


### PR DESCRIPTION
The current indexes on (id, type) and (id, type, created_at, modified_at) are never used by SqlAccountDefinitionRepository. Drop these indexes and replace them with an index on (type), which does get used by the query: SELECT body FROM accounts WHERE type='accountType';

Explain output before the change:
```
mysql> explain SELECT body FROM accounts where type='kubernetes';
+----+-------------+----------+------------+------+---------------+------+---------+------+------+----------+-------------+
| id | select_type | table    | partitions | type | possible_keys | key  | key_len | ref  | rows | filtered | Extra       |
+----+-------------+----------+------------+------+---------------+------+---------+------+------+----------+-------------+
|  1 | SIMPLE      | accounts | NULL       | ALL  | NULL          | NULL | NULL    | NULL |    5 |    20.00 | Using where |
+----+-------------+----------+------------+------+---------------+------+---------+------+------+----------+-------------+
```

Explain output after the change:
```
mysql> explain SELECT body FROM accounts where type='kubernetes';
+----+-------------+----------+------------+------+---------------------+---------------------+---------+-------+------+----------+-------+
| id | select_type | table    | partitions | type | possible_keys       | key                 | key_len | ref   | rows | filtered | Extra |
+----+-------------+----------+------------+------+---------------------+---------------------+---------+-------+------+----------+-------+
|  1 | SIMPLE      | accounts | NULL       | ref  | accounts_type_index | accounts_type_index | 202     | const |    3 |   100.00 | NULL  |
+----+-------------+----------+------------+------+---------------------+---------------------+---------+-------+------+----------+-------+
```