### PR TITLE
feat(account): Implement the isAccountManager flag

### DIFF
--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionService.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionService.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.kork.annotations.Beta;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.annotations.VisibleForTesting;
 import com.netflix.spinnaker.kork.secrets.SecretException;
 import com.netflix.spinnaker.kork.secrets.user.UserSecretReference;
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
@@ -126,14 +127,21 @@ public class AccountDefinitionService {
     if (policy.isAdmin(username)) {
       return;
     }
-    var accountName = definition.getName();
+    Set<String> userRoles = policy.getRoles(username);
+    validateAccountAuthorization(userRoles, definition, action);
+    validateUserSecretAuthorization(userRoles, definition, action);
+  }
+
+  @VisibleForTesting
+  void validateAccountAuthorization(
+      Set<String> userRoles, CredentialsDefinition definition, AccountAction action) {
+    String accountName = definition.getName();
     var type = definition.getClass();
     Set<String> authorizedRoles =
         extractors.stream()
             .filter(extractor -> extractor.supportsType(type))
             .flatMap(extractor -> extractor.getAuthorizedRoles(definition).stream())
             .collect(Collectors.toSet());
-    var userRoles = policy.getRoles(username);
     // if the account defines authorized roles and the user has no roles in common with these
     // authorized roles, then the user attempted to create an account they'd immediately be
     // locked out from which is a poor user experience
@@ -144,6 +152,12 @@ public class AccountDefinitionService {
               "Cannot %s account without granting permissions for current user (name: %s)",
               action.name().toLowerCase(Locale.ROOT), accountName));
     }
+  }
+
+  @VisibleForTesting
+  void validateUserSecretAuthorization(
+      Set<String> userRoles, CredentialsDefinition definition, AccountAction action) {
+    var type = definition.getClass();
     Set<UserSecretReference> secretReferences = new HashSet<>();
     ReflectionUtils.doWithFields(
         type,
@@ -169,7 +183,8 @@ public class AccountDefinitionService {
     }
   }
 
-  private enum AccountAction {
+  @VisibleForTesting
+  enum AccountAction {
     CREATE,
     UPDATE,
     SAVE

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionService.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionService.java
@@ -161,8 +161,10 @@ public class AccountDefinitionService {
     Set<UserSecretReference> secretReferences = new HashSet<>();
     ReflectionUtils.doWithFields(
         type,
-        field ->
-            UserSecretReference.tryParse(field.get(definition)).ifPresent(secretReferences::add),
+        field -> {
+          field.setAccessible(true);
+          UserSecretReference.tryParse(field.get(definition)).ifPresent(secretReferences::add);
+        },
         field -> field.getType() == String.class);
     // if the account uses any UserSecrets and the user has no roles in common with any of
     // the UserSecrets, then don't allow the user to save this account due to lack of authorization

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/DefaultAccountSecurityPolicy.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/DefaultAccountSecurityPolicy.java
@@ -84,7 +84,6 @@ public class DefaultAccountSecurityPolicy implements AccountSecurityPolicy {
   }
 
   private static boolean isAccountManager(UserPermission.View permission) {
-    // TODO(jvz): replace with UserPermission.View::isAccountManager after fiat updated
-    return permission.isAdmin();
+    return permission.isAccountManager();
   }
 }

--- a/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionServiceTest.java
+++ b/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/security/AccountDefinitionServiceTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2024 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.security;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
+import com.netflix.spinnaker.kork.secrets.user.UserSecret;
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
+import io.spinnaker.test.security.ValueAccount;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.AccessDeniedException;
+
+public class AccountDefinitionServiceTest {
+  AccountDefinitionRepository repository;
+  AccountDefinitionSecretManager secretManager;
+  AccountCredentialsProvider accountCredentialsProvider;
+  AccountSecurityPolicy policy;
+  AuthorizedRolesExtractor extractor;
+  CredentialsDefinition definition =
+      ValueAccount.builder().name("name").value("secret://test?k=value").build();
+  AccountDefinitionService accountDefinitionService;
+  Set<String> authorizedRoles = Set.of("role1", "role2");
+
+  @BeforeEach
+  public void setup() {
+    repository = mock(AccountDefinitionRepository.class);
+    secretManager = mock(AccountDefinitionSecretManager.class);
+    accountCredentialsProvider = mock(AccountCredentialsProvider.class);
+    policy = mock(AccountSecurityPolicy.class);
+    extractor = mock(AuthorizedRolesExtractor.class);
+    List<AuthorizedRolesExtractor> extractors = List.of(extractor);
+    accountDefinitionService =
+        new AccountDefinitionService(
+            repository, secretManager, accountCredentialsProvider, policy, extractors);
+
+    doReturn(true).when(extractor).supportsType(definition.getClass());
+  }
+
+  @Test
+  public void testValidateAccountAuthorizationWithCommonRole() {
+    doReturn(authorizedRoles).when(extractor).getAuthorizedRoles(definition);
+    Set<String> userRoles = Set.of("role1");
+    assertDoesNotThrow(
+        () ->
+            accountDefinitionService.validateAccountAuthorization(
+                userRoles, definition, AccountDefinitionService.AccountAction.UPDATE));
+  }
+
+  @Test
+  public void testValidateAccountAuthorizationEmptyAuthorizedRoles() {
+    doReturn(Set.of()).when(extractor).getAuthorizedRoles(definition);
+    Set<String> userRoles = Set.of("role1");
+    assertDoesNotThrow(
+        () ->
+            accountDefinitionService.validateAccountAuthorization(
+                userRoles, definition, AccountDefinitionService.AccountAction.UPDATE));
+  }
+
+  @Test
+  public void testValidateAccountAuthorizationNoCommonRoles() {
+    doReturn(authorizedRoles).when(extractor).getAuthorizedRoles(definition);
+    Set<String> userRoles = Set.of("oneRole", "anotherRole");
+    assertThrows(
+        InvalidRequestException.class,
+        () ->
+            accountDefinitionService.validateAccountAuthorization(
+                userRoles, definition, AccountDefinitionService.AccountAction.UPDATE));
+  }
+
+  @Test
+  public void testValidateUserSecretAuthorizationWithCommonRole() {
+    UserSecret userSecret = mock(UserSecret.class);
+    doReturn(List.copyOf(authorizedRoles)).when(userSecret).getRoles();
+    doReturn(userSecret).when(secretManager).getUserSecret(any());
+    Set<String> userRoles = Set.of("role1", "role3");
+
+    assertDoesNotThrow(
+        () ->
+            accountDefinitionService.validateUserSecretAuthorization(
+                userRoles, definition, AccountDefinitionService.AccountAction.UPDATE));
+  }
+
+  @Test
+  public void testValidateUserSecretAuthorizationEmptyAuthorizedRoles() {
+    UserSecret userSecret = mock(UserSecret.class);
+    doReturn(List.of()).when(userSecret).getRoles();
+    doReturn(userSecret).when(secretManager).getUserSecret(any());
+    Set<String> userRoles = Set.of("role1", "role3");
+
+    assertThrows(
+        AccessDeniedException.class,
+        () ->
+            accountDefinitionService.validateUserSecretAuthorization(
+                userRoles, definition, AccountDefinitionService.AccountAction.UPDATE));
+  }
+
+  @Test
+  public void testValidateUserSecretAuthorizationNoCommonRoles() {
+    UserSecret userSecret = mock(UserSecret.class);
+    doReturn(List.copyOf(authorizedRoles)).when(userSecret).getRoles();
+    doReturn(userSecret).when(secretManager).getUserSecret(any());
+    Set<String> userRoles = Set.of("role3");
+
+    assertThrows(
+        AccessDeniedException.class,
+        () ->
+            accountDefinitionService.validateUserSecretAuthorization(
+                userRoles, definition, AccountDefinitionService.AccountAction.UPDATE));
+  }
+}


### PR DESCRIPTION
This change also includes a fix to allow reflection to read private fields in the authorization checking logic. Without the fix, trying to create an account as an accountManager leads to an IllegalAccessException:
`dztest.json` contents:
```
{
  "type": "kubernetes",
  "name": "dztest",
  "requiredGroupMembership": [],
  "providerVersion": "V2",
  "configureImagePullSecrets": true,
  "cacheThreads": 1,
  "namespaces": [],
  "kinds": [],
  "omitKinds": [
    "podPreset"
  ],
  "omitNamespaces": [],
  "metrics": false,
  "debug": true,
  "customResources": [],
  "cachingPolicies": [],
  "kubeconfigFile": "/opt/dztest.kubeconfig",
  "oAuthScopes": [],
  "onlySpinnakerManaged": true,
  "checkPermissionsOnStartup": false,
  "liveManifestCalls": true
}
```
Before the fix:
`> curl -X POST --cookie "SESSION=$COOKIE" -H "Content-Type: application/json" -d@dztest.json https://<spinnaker url>/credentials`
`{"timestamp":1705698542818,"status":500,"error":"Internal Server Error","exception":"com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers$RetrofitErrorWrapper","message":"500 ","body":"{\"error\":\"Internal Server Error\",\"exception\":\"java.lang.IllegalStateException\",\"message\":\"Not allowed to access field 'name': java.lang.IllegalAccessException: class com.netflix.spinnaker.clouddriver.security.AccountDefinitionService cannot access a member of class com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesAccountProperties$ManagedAccount with modifiers \\\"private\\\"\",\"status\":500,\"timestamp\":1705698542796}","url":"http://127.0.0.1:9102/credentials"}`

After the fix:
`> curl -X POST --cookie "SESSION=$COOKIE" -H "Content-Type: application/json" -d@dztest.json https://<spinnaker url>/credentials`
`{"type":"kubernetes","name":"dztest","debug":true,"omitKinds":["podPreset"],"kinds":[],"omitNamespaces":[],"serviceAccount":false,"customResources":[],"cacheAllApplicationRelationships":false,"checkPermissionsOnStartup":false,"kubeconfigFile":"/opt/dztest.kubeconfig","onlySpinnakerManaged":true,"permissions":{},"rawResourcesEndpointConfig":{"kindExpressions":[],"kindPatterns":[],"omitKindExpressions":[],"omitKindPatterns":[]},"cacheThreads":1,"metrics":false,"cachingPolicies":[],"requiredGroupMembership":[],"namespaces":[],"namingStrategy":"kubernetesAnnotations"}`

