### PR TITLE
fix(aws): Fix bug in AWS provider after Groovy 3 upgrade

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
@@ -82,9 +82,9 @@ class AmazonApplicationLoadBalancerCachingAgent extends AbstractAmazonLoadBalanc
 
   @Override
   Optional<Map<String, String>> getCacheKeyPatterns() {
-    return [
+    return Optional.of([
       (LOAD_BALANCERS.ns): Keys.getLoadBalancerKey('*', account.name, region, 'vpc-????????', '*')
-    ]
+    ])
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
@@ -17,7 +17,12 @@
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing
-import com.amazonaws.services.elasticloadbalancing.model.*
+import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancerAttributesRequest
+import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
+import com.amazonaws.services.elasticloadbalancing.model.DescribeTagsRequest
+import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerAttributes
+import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
+import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerNotFoundException
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
@@ -32,9 +37,10 @@ import com.netflix.spinnaker.clouddriver.aws.edda.EddaApi
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
-import com.netflix.spinnaker.clouddriver.model.LoadBalancer
 
-import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.LOAD_BALANCERS
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.ON_DEMAND
 
 class AmazonLoadBalancerCachingAgent extends AbstractAmazonLoadBalancerCachingAgent {
 
@@ -55,9 +61,9 @@ class AmazonLoadBalancerCachingAgent extends AbstractAmazonLoadBalancerCachingAg
 
   @Override
   Optional<Map<String, String>> getCacheKeyPatterns() {
-    return [
+    return Optional.of([
       (LOAD_BALANCERS.ns): Keys.getLoadBalancerKey('*', account.name, region, 'vpc-????????', null)
-    ]
+    ])
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
@@ -141,9 +141,9 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
 
   @Override
   Optional<Map<String, String>> getCacheKeyPatterns() {
-    return [
+    return Optional.of([
       (SERVER_GROUPS.ns): Keys.getServerGroupKey('*', '*', account.name, region)
-    ]
+    ])
   }
 
   static class AmazonClients {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgentSpec.groovy
@@ -112,6 +112,20 @@ class AmazonApplicationLoadBalancerCachingAgentSpec extends Specification {
     [taggify(".*", "ciao")]       | [taggify("hello", ".*")]      | buildCacheKeys([])
   }
 
+  void "should get correct cache key pattern"() {
+    given:
+    def agent = getAgent()
+
+    when:
+    def cacheKeyPatterns = agent.getCacheKeyPatterns()
+
+    then:
+    cacheKeyPatterns.isPresent()
+    cacheKeyPatterns.get() == [
+      loadBalancers: buildCacheKey("*:vpc-????????:*")
+    ]
+  }
+
   private static final Map<LoadBalancer, List<TagDescription>> filterableLBs() {
     return [
       (new LoadBalancer().withLoadBalancerName("test-hello-tag-value").withLoadBalancerArn(buildELBArn("test-hello-tag-value")))                    :

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgentSpec.groovy
@@ -95,6 +95,20 @@ class AmazonLoadBalancerCachingAgentSpec extends Specification {
     [taggify(".*", "ciao")]       | [taggify("hello", ".*")]      | buildCacheKeys([])
   }
 
+  void "should get correct cache key pattern"() {
+    given:
+    def agent = getAgent()
+
+    when:
+    def cacheKeyPatterns = agent.getCacheKeyPatterns()
+
+    then:
+    cacheKeyPatterns.isPresent()
+    cacheKeyPatterns.get() == [
+      loadBalancers: buildCacheKey("*:vpc-????????")
+    ]
+  }
+
   private static final Map<LoadBalancerDescription, List<TagDescription>> filterableLBs() {
     return [
       (new LoadBalancerDescription().withLoadBalancerName("test-hello-tag-value")):

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgentSpec.groovy
@@ -98,4 +98,18 @@ class AmazonSecurityGroupCachingAgentSpec extends Specification {
     cache.cacheResults[SECURITY_GROUPS.ns] == existingCacheData
 
   }
+
+  void "should get correct cache key pattern"() {
+    given:
+    def agent = getAgent()
+
+    when:
+    def cacheKeyPatterns = agent.getCacheKeyPatterns()
+
+    then:
+    cacheKeyPatterns.isPresent()
+    cacheKeyPatterns.get() == [
+      (SECURITY_GROUPS.ns): "aws:securityGroups:*:*:region:account:*"
+    ]
+  }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgentSpec.groovy
@@ -37,6 +37,8 @@ import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.SERVER_GROUPS
+
 class ClusterCachingAgentSpec extends Specification {
   static String region = 'region'
   static String accountName = 'accountName'
@@ -214,6 +216,20 @@ class ClusterCachingAgentSpec extends Specification {
     null                          | [taggify("hello", "goodbye")] | ["test-hello-tag-value-different", "test-hello-tag-no-value", "test-no-hello-tag", "test-no-tags"]
     [taggify("hello", "goodbye")] | [taggify("hello")]            | []
     [taggify(".*", "ciao")]       | [taggify("hello", ".*")]      | []
+  }
+
+  void "should get correct cache key pattern"() {
+    given:
+    def agent = getAgent()
+
+    when:
+    def cacheKeyPatterns = agent.getCacheKeyPatterns()
+
+    then:
+    cacheKeyPatterns.isPresent()
+    cacheKeyPatterns.get() == [
+      (SERVER_GROUPS.ns): "aws:serverGroups:*:accountName:region:*"
+    ]
   }
 
   private static final List<AutoScalingGroup> filterableASGs = [


### PR DESCRIPTION
I'm unsure how this code has ever worked, but after the upgrade to Groovy 3, it started crashing.

```
org.codehaus.groovy.runtime.typehandling.GroovyCastException: 
Cannot cast object '{loadBalancers=aws:loadBalancers:my-aws-account:eu-west-1:*:vpc-????????:*}' 
with class 'java.util.LinkedHashMap' to class 'java.util.Optional' due to: groovy.lang.GroovyRuntimeException: 
Could not find matching constructor for: java.util.Optional(LinkedHashMap)
```