### PR TITLE
chore(dependencies): upgrade bouncycastle from 1.70 to 1.77

### DIFF
--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -44,6 +44,7 @@ dependencies {
   implementation "com.oracle.oci.sdk:oci-java-sdk-core"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.sun.jersey:jersey-client:1.9.1"
+  implementation 'commons-io:commons-io:2.15.1'
   implementation "org.apache.commons:commons-lang3"
   implementation "org.apache.ivy:ivy:2.4.0"
   implementation "org.apache.maven:maven-resolver-provider:3.5.4"

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/CredentialReader.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/CredentialReader.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.artifacts;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 
@@ -25,7 +26,7 @@ import org.apache.commons.io.FileUtils;
 public class CredentialReader {
   public static String credentialsFromFile(String filename) {
     try {
-      String credentials = FileUtils.readFileToString(new File(filename));
+      String credentials = FileUtils.readFileToString(new File(filename), Charset.defaultCharset());
       return credentials.replace("\n", "");
     } catch (IOException e) {
       throw new IllegalStateException("Could not read credentials file: " + filename, e);

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactClient.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactClient.java
@@ -9,7 +9,6 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.oracle;
 
-import com.google.common.base.Supplier;
 import com.oracle.bmc.auth.AuthenticationDetailsProvider;
 import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.SimplePrivateKeySupplier;
@@ -26,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import javax.ws.rs.core.MediaType;
 
 class OracleArtifactClient {

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/provider/agent/AbstractOracleCachingAgent.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/provider/agent/AbstractOracleCachingAgent.groovy
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider
 import com.netflix.spinnaker.cats.agent.CachingAgent
 import com.netflix.spinnaker.clouddriver.oracle.OracleCloudProvider
 import com.netflix.spinnaker.clouddriver.oracle.security.OracleNamedAccountCredentials
-import com.oracle.bmc.http.internal.ExplicitlySetFilter
 
 abstract class AbstractOracleCachingAgent implements CachingAgent {
 
@@ -32,7 +31,7 @@ abstract class AbstractOracleCachingAgent implements CachingAgent {
     this.credentials = credentials
     this.clouddriverUserAgentApplicationName = clouddriverUserAgentApplicationName
     agentType = "${credentials.name}/${credentials.region}/${this.class.simpleName}"
-    
+
     FilterProvider filters = new SimpleFilterProvider().setFailOnUnknownId(false)
     //Alternatives of adding explicitlySetFilter:
     //- FilterProvider filters = new SimpleFilterProvider().addFilter("explicitlySetFilter", (SimpleBeanPropertyFilter) SimpleBeanPropertyFilter.serializeAllExcept(['__explicitlySet__'].toSet()));

--- a/clouddriver-yandex/clouddriver-yandex.gradle
+++ b/clouddriver-yandex/clouddriver-yandex.gradle
@@ -9,7 +9,11 @@ dependencies {
   implementation project(":clouddriver-core")
   implementation project(":clouddriver-security")
 
-  implementation 'com.yandex.cloud:java-sdk-services:2.1.1'
+  //exclude BC -jdk15on libraries to remove CVE-2023-33201. *-jdk18on libraries are already present in the classpath
+  implementation ('com.yandex.cloud:java-sdk-services:2.1.1'){
+    exclude group: "org.bouncycastle", module: "bcpkix-jdk15on"
+    exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
+  }
   compileOnly "io.opencensus:opencensus-api"
   compileOnly "io.opencensus:opencensus-contrib-grpc-metrics"
   implementation "org.codehaus.groovy:groovy-datetime"


### PR DESCRIPTION
This is a continuation to this kork PR: https://github.com/spinnaker/kork/pull/1146

As part of upgrading bouncycastle, com.oracle.oci.sdk:oci-java-sdk-bom was upgraded and this PR addresses the errors due to this upgrade.

As the bouncycastle version of the latest com.yandex.cloud:java-sdk-services is still 1.61, (where as >=1.74 is CVE free), it's modules are excluded from java-sdk-services.