### PR TITLE
feat(aws): Install AWS CLI v2 and upgrade aws-iam-authenticator

### DIFF
--- a/Dockerfile.java11.slim
+++ b/Dockerfile.java11.slim
@@ -4,9 +4,8 @@ ARG TARGETARCH
 
 ENV KUBECTL_DEFAULT_RELEASE=1.22.17
 ENV KUBECTL_RELEASES="${KUBECTL_DEFAULT_RELEASE} 1.26.12 1.27.9 1.28.5 1.29.0"
-ENV AWS_CLI_VERSION=1.22
-ENV AWS_CLI_S3_CMD=2.0.2
-ENV AWS_AIM_AUTHENTICATOR_VERSION=0.5.9
+ENV AWS_CLI_VERSION=2.15.22
+ENV AWS_AIM_AUTHENTICATOR_VERSION=0.6.14
 ENV GOOGLE_CLOUD_SDK_VERSION=412.0.0
 ENV ECR_TOKEN_VERSION=v1.0.2
 
@@ -20,11 +19,18 @@ RUN apk update \
     wget \
     openjdk11 \
     git \
-    openssh-client
+    openssh-client \
+    unzip
 
-# AWS CLI
-RUN pip install --upgrade  --no-build-isolation awscli==${AWS_CLI_VERSION} s3cmd==${AWS_CLI_S3_CMD} python-magic \
-  && pip uninstall -y pip
+# AWS CLI 2
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip"; \
+  else \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip"; \
+  fi && \
+  unzip awscliv2.zip && \
+  ./aws/install && \
+  rm -rf ./awscliv2.zip ./aws
 
 # Google cloud SDK
 RUN [ $TARGETARCH == 'amd64' ] &&  export GCP_ARCH="x86_64" || export GCP_ARCH="arm"  \

--- a/Dockerfile.java11.ubuntu
+++ b/Dockerfile.java11.ubuntu
@@ -5,9 +5,8 @@ ENV GOOGLE_CLOUD_SDK_VERSION=412.0.0
 ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
 ENV KUBECTL_DEFAULT_RELEASE=1.22.17
 ENV KUBECTL_RELEASES="${KUBECTL_DEFAULT_RELEASE} 1.26.12 1.27.9 1.28.5 1.29.0"
-ENV AWS_CLI_VERSION=1.22
-ENV AWS_CLI_S3_CMD=2.0.2
-ENV AWS_AIM_AUTHENTICATOR_VERSION=0.5.9
+ENV AWS_CLI_VERSION=2.15.22
+ENV AWS_AIM_AUTHENTICATOR_VERSION=0.6.14
 
 RUN apt-get update && apt-get install -y curl gnupg && \
   curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
@@ -20,12 +19,19 @@ RUN apt-get update && apt-get install -y curl gnupg && \
   python3-pip \
   python3 \
   git \
-  openssh-client && \
+  openssh-client \
+  unzip && \
   rm -rf ~/.config/gcloud
 
-# AWS CLI
-RUN pip install --upgrade  --no-build-isolation awscli==${AWS_CLI_VERSION} s3cmd==${AWS_CLI_S3_CMD} python-magic \
-  && apt remove -y python3-pip
+# AWS CLI 2
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip"; \
+  else \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip"; \
+  fi && \
+  unzip awscliv2.zip && \
+  ./aws/install && \
+  rm -rf ./awscliv2.zip ./aws
 
 # kubectl + AWS IAM authenticator
 RUN for version in $KUBECTL_RELEASES; do \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -4,9 +4,8 @@ ARG TARGETARCH
 
 ENV KUBECTL_DEFAULT_RELEASE=1.22.17
 ENV KUBECTL_RELEASES="${KUBECTL_DEFAULT_RELEASE} 1.26.12 1.27.9 1.28.5 1.29.0"
-ENV AWS_CLI_VERSION=1.22
-ENV AWS_CLI_S3_CMD=2.0.2
-ENV AWS_AIM_AUTHENTICATOR_VERSION=0.5.9
+ENV AWS_CLI_VERSION=2.15.22
+ENV AWS_AIM_AUTHENTICATOR_VERSION=0.6.14
 ENV GOOGLE_CLOUD_SDK_VERSION=412.0.0
 ENV ECR_TOKEN_VERSION=v1.0.2
 
@@ -20,11 +19,18 @@ RUN apk update \
     wget \
     openjdk17 \
     git \
-    openssh-client
+    openssh-client \
+    unzip
 
-# AWS CLI
-RUN pip install --upgrade  --no-build-isolation awscli==${AWS_CLI_VERSION} s3cmd==${AWS_CLI_S3_CMD} python-magic \
-  && pip uninstall -y pip
+# AWS CLI 2
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip"; \
+  else \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip"; \
+  fi && \
+  unzip awscliv2.zip && \
+  ./aws/install && \
+  rm -rf ./awscliv2.zip ./aws
 
 # Google cloud SDK
 RUN [ $TARGETARCH == 'amd64' ] &&  export GCP_ARCH="x86_64" || export GCP_ARCH="arm"  \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -5,9 +5,8 @@ ENV GOOGLE_CLOUD_SDK_VERSION=412.0.0
 ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
 ENV KUBECTL_DEFAULT_RELEASE=1.22.17
 ENV KUBECTL_RELEASES="${KUBECTL_DEFAULT_RELEASE} 1.26.12 1.27.9 1.28.5 1.29.0"
-ENV AWS_CLI_VERSION=1.22
-ENV AWS_CLI_S3_CMD=2.0.2
-ENV AWS_AIM_AUTHENTICATOR_VERSION=0.5.9
+ENV AWS_CLI_VERSION=2.15.22
+ENV AWS_AIM_AUTHENTICATOR_VERSION=0.6.14
 
 RUN apt-get update && apt-get install -y curl gnupg && \
   curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
@@ -20,12 +19,19 @@ RUN apt-get update && apt-get install -y curl gnupg && \
   python3-pip \
   python3 \
   git \
-  openssh-client && \
+  openssh-client \
+  unzip && \
   rm -rf ~/.config/gcloud
 
-# AWS CLI
-RUN pip install --upgrade  --no-build-isolation awscli==${AWS_CLI_VERSION} s3cmd==${AWS_CLI_S3_CMD} python-magic \
-  && apt remove -y python3-pip
+# AWS CLI 2
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip"; \
+  else \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip"; \
+  fi && \
+  unzip awscliv2.zip && \
+  ./aws/install && \
+  rm -rf ./awscliv2.zip ./aws
 
 # kubectl + AWS IAM authenticator
 RUN for version in $KUBECTL_RELEASES; do \

--- a/clouddriver-web/pkg_scripts/postInstall.sh
+++ b/clouddriver-web/pkg_scripts/postInstall.sh
@@ -3,6 +3,8 @@
 # Remember to also update Dockerfile.*
 KUBECTL_DEFAULT_RELEASE=1.22.17
 KUBECTL_RELEASES="${KUBECTL_DEFAULT_RELEASE} 1.26.12 1.27.9 1.28.5 1.29.0"
+AWS_CLI_VERSION=2.15.22
+AWS_AIM_AUTHENTICATOR_VERSION=0.6.14
 
 # ubuntu
 # check that owner group exists
@@ -26,6 +28,18 @@ install_kubectl() {
   fi
 }
 
+install_awscli2() {
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip"
+  unzip awscliv2.zip
+  ./aws/install
+  rm -rf ./awscliv2.zip ./aws
+
+  curl "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AWS_AIM_AUTHENTICATOR_VERSION}/aws-iam-authenticator_${AWS_AIM_AUTHENTICATOR_VERSION}_linux_amd64" -O aws-iam-authenticator
+  chmod +x ./aws-iam-authenticator \
+  mv ./aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
+}
+
 install_kubectl
+install_awscli2
 
 install --mode=755 --owner=spinnaker --group=spinnaker --directory /var/log/spinnaker/clouddriver


### PR DESCRIPTION
AWS CLI v1 is becoming harder to use with newer Kubernetes versions. If you use `aws eks get-token` for EKS authentication instead of `aws-iam-authenticator`, you are stuck with `apiVersion: client.authentication.k8s.io/v1alpha1`, because `v1beta1` isn't supported by AWS CLI v2. Upgrading to v2 fixes this.