### PR TITLE
fix: Change the agent type name to not include the account name since this would generate LOTS of tables and cause problems long term

### DIFF
--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgent.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgent.java
@@ -209,7 +209,7 @@ public class AmazonInstanceTypeCachingAgent implements CachingAgent, AccountAwar
 
   @Override
   public String getAgentType() {
-    return String.format("%s/%s/%s", account.getName(), region, getClass().getSimpleName());
+    return getClass().getSimpleName() + "/" + region;
   }
 
   @Override


### PR DESCRIPTION
The standard in spinnaker is to use a single table for a cache agent TYPE without the account name,