### PR TITLE
fix(azure): circular dependencies

### DIFF
--- a/clouddriver-azure/clouddriver-azure.gradle
+++ b/clouddriver-azure/clouddriver-azure.gradle
@@ -25,6 +25,7 @@ dependencies {
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
+  testImplementation "org.springframework.boot:spring-boot-test"
   testImplementation 'org.mockito:mockito-inline:4.8.0'
   testImplementation 'org.assertj:assertj-core:3.23.1'
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProvider.groovy
@@ -54,16 +54,13 @@ class AzureLoadBalancerProvider implements LoadBalancerProvider<AzureLoadBalance
   @Autowired
   AzureClusterProvider clusterProvider
 
-  @Autowired
-  AzureLoadBalancerProvider azureLoadBalancerProvider
-
   List<AzureLoadBalancerSummary> list() {
     getSummaryForLoadBalancers().values() as List
   }
 
   private Map<String, AzureLoadBalancerSummary> getSummaryForLoadBalancers() {
     Map<String, AzureLoadBalancerSummary> map = [:]
-    def loadBalancers = azureLoadBalancerProvider.getApplicationLoadBalancers('*')
+    def loadBalancers = getApplicationLoadBalancers('*')
 
     loadBalancers?.each() { lb ->
       def summary = map.get(lb.name)
@@ -86,7 +83,7 @@ class AzureLoadBalancerProvider implements LoadBalancerProvider<AzureLoadBalance
 
   List<Map> byAccountAndRegionAndName(String account, String region, String name) {
     String appName = AzureUtilities.getAppNameFromAzureResourceName(name)
-    AzureLoadBalancerDescription azureLoadBalancerDescription = azureLoadBalancerProvider.getLoadBalancerDescription(account, appName, region, name)
+    AzureLoadBalancerDescription azureLoadBalancerDescription = getLoadBalancerDescription(account, appName, region, name)
 
     if (azureLoadBalancerDescription) {
       def lbDetail = [

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProvider.groovy
@@ -30,7 +30,6 @@ import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.Azur
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import org.springframework.web.bind.annotation.PathVariable
@@ -47,9 +46,6 @@ class AzureLoadBalancerProvider implements LoadBalancerProvider<AzureLoadBalance
   private final AzureCloudProvider azureCloudProvider
   private final Cache cacheView
   final ObjectMapper objectMapper
-
-  @Autowired
-  AccountCredentialsProvider accountCredentialsProvider
 
   @Autowired
   AzureClusterProvider clusterProvider

--- a/clouddriver-azure/src/test/java/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProviderTest.java
+++ b/clouddriver-azure/src/test/java/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProviderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.cats.cache.Cache;
+import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider;
+import com.netflix.spinnaker.clouddriver.azure.resources.application.view.AzureApplicationProvider;
+import com.netflix.spinnaker.clouddriver.azure.resources.cluster.view.AzureClusterProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.annotation.UserConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+public class AzureLoadBalancerProviderTest {
+
+  private static class AzureTestConfig {
+
+    @Bean
+    AzureCloudProvider azureCloudProvider() {
+      return mock(AzureCloudProvider.class);
+    }
+
+    @Bean
+    AzureClusterProvider azureClusterProvider() {
+      return mock(AzureClusterProvider.class);
+    }
+
+    @Bean
+    AzureApplicationProvider azureApplicationProvider() {
+      return mock(AzureApplicationProvider.class);
+    }
+
+    @Bean
+    Cache cache() {
+      return mock(Cache.class);
+    }
+
+    @Bean
+    ObjectMapper getObjectMapper() {
+      return new ObjectMapper();
+    }
+  }
+
+  private final ApplicationContextRunner applicationContextRunner =
+      new ApplicationContextRunner()
+          .withConfiguration(UserConfigurations.of(AzureTestConfig.class))
+          .withBean(AzureLoadBalancerProvider.class);
+
+  /**
+   * The AzureLoadBalancerProvider class previously had a self-reference, which resulted in a
+   * circular reference exception. The intention of this test is to detect that exception scenario,
+   * without enabling the Azure provider.
+   */
+  @Test
+  public void testCircularDependenciesException() {
+    assertDoesNotThrow(
+        () ->
+            applicationContextRunner.run(
+                ctx -> assertThat(ctx).hasSingleBean(AzureLoadBalancerProvider.class)));
+  }
+}


### PR DESCRIPTION
Circular dependencies error when you enable azure

```
***************************                                                                                                            
APPLICATION FAILED TO START                                                                                                             
***************************                                                                                                             
                                                                                                                                        
Description:                                                                                                                            
                                                                                                                                        
The dependencies of some of the beans in the application context form a cycle:                                                          │
                                                                                                                                        │
┌──->──┐                                                                                                                                │
|  azureLoadBalancerProvider (field private com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.view.AzureLoadBalancerProvide│
r com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.view.AzureLoadBalancerProvider.azureLoadBalancerProvider)              │
└──<-──┘                                                                                                                                │
```

similar to https://github.com/spinnaker/gate/pull/1780
fixes: spinnaker/spinnaker/issues/6935