### PR TITLE
fix(databaseChangeLog): fix for 'addAfterColumn is not allowed on postgresql'

### DIFF
--- a/clouddriver-sql/src/main/resources/db/changelog/20181120-cats.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog/20181120-cats.yml
@@ -1,4 +1,8 @@
 databaseChangeLog:
+- removeChangeSetProperty:
+    change: addColumn
+    dbms: postgresql
+    remove: afterColumn
 - changeSet:
     id: create-cats-resource-table-v1
     author: afeldman

--- a/clouddriver-sql/src/main/resources/db/changelog/20190913-task-sagaids.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog/20190913-task-sagaids.yml
@@ -1,4 +1,8 @@
 databaseChangeLog:
+  - removeChangeSetProperty:
+      change: addColumn
+      dbms: postgresql
+      remove: afterColumn
   - changeSet:
       id: add-task-sagaids-column
       author: robzienert


### PR DESCRIPTION
This PR addresses https://github.com/spinnaker/spinnaker/issues/6942

The following PR provides more details on the issue and similar fix provided for orca: https://github.com/spinnaker/orca/pull/4594

