### PR TITLE
fix(gcp): Relaxed health check for GCP accounts

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/config/GoogleConfiguration.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/config/GoogleConfiguration.groovy
@@ -48,12 +48,6 @@ class GoogleConfiguration {
   }
 
   @Bean
-  @ConditionalOnProperty("google.health.verifyAccountHealth")
-  GoogleHealthIndicator googleHealthIndicator() {
-    new GoogleHealthIndicator()
-  }
-
-  @Bean
   GoogleOperationPoller googleOperationPoller() {
     new GoogleOperationPoller()
   }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/health/GoogleHealthIndicatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/health/GoogleHealthIndicatorSpec.groovy
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.provider.agent.StubComputeFactory
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.credentials.CredentialsRepository
@@ -66,7 +67,7 @@ class GoogleHealthIndicatorSpec extends Specification {
     def credentialsTypeBaseConfiguration = new CredentialsTypeBaseConfiguration(applicationContext, null)
     credentialsTypeBaseConfiguration.credentialsRepository = credentialsRepository
 
-    def indicator = new GoogleHealthIndicator()
+    def indicator = new GoogleHealthIndicator(googleConfigurationProperties: new GoogleConfigurationProperties())
     indicator.registry = REGISTRY
     indicator.credentialsTypeBaseConfiguration = credentialsTypeBaseConfiguration
 
@@ -107,7 +108,7 @@ class GoogleHealthIndicatorSpec extends Specification {
     def credentialsTypeBaseConfiguration = new CredentialsTypeBaseConfiguration(applicationContext, null)
     credentialsTypeBaseConfiguration.credentialsRepository = credentialsRepository
 
-    def indicator = new GoogleHealthIndicator()
+    def indicator = new GoogleHealthIndicator(googleConfigurationProperties: new GoogleConfigurationProperties())
     indicator.registry = REGISTRY
     indicator.credentialsTypeBaseConfiguration = credentialsTypeBaseConfiguration
 
@@ -119,5 +120,48 @@ class GoogleHealthIndicatorSpec extends Specification {
     thrown(GoogleHealthIndicator.GoogleIOException)
 
     health == null
+  }
+
+  @Unroll
+  def "health succeeds when google is unreachable and verifyAccountHealth is false"() {
+    setup:
+    def applicationContext = Mock(ApplicationContext)
+    def project = new Project()
+    project.setName(PROJECT)
+
+    def compute = new StubComputeFactory()
+      .setProjects(project)
+      .setProjectException(new IOException("Read timed out"))
+      .create()
+
+    def googleNamedAccountCredentials =
+      new GoogleNamedAccountCredentials.Builder()
+        .project(PROJECT)
+        .name(ACCOUNT_NAME)
+        .compute(compute)
+        .regionToZonesMap(ImmutableMap.of(REGION, ImmutableList.of(ZONE)))
+        .build()
+
+    def credentials = [googleNamedAccountCredentials]
+    def credentialsRepository = Stub(CredentialsRepository) {
+      getAll() >> credentials
+    }
+
+    def credentialsTypeBaseConfiguration = new CredentialsTypeBaseConfiguration(applicationContext, null)
+    credentialsTypeBaseConfiguration.credentialsRepository = credentialsRepository
+
+    def indicator = new GoogleHealthIndicator(googleConfigurationProperties: new GoogleConfigurationProperties())
+    indicator.googleConfigurationProperties.health.setVerifyAccountHealth(false)
+    indicator.registry = REGISTRY
+    indicator.credentialsTypeBaseConfiguration = credentialsTypeBaseConfiguration
+
+
+    when:
+    indicator.checkHealth()
+    def health = indicator.health()
+
+    then:
+    health.status == Status.UP
+    health.details.isEmpty()
   }
 }


### PR DESCRIPTION
The majority of cloud providers (AWS, K8s) and dockerRegistry have already implementations for relaxed health checks via a configuration property in the respective provider block.

On GCP provider though it was attempted to be addressed by https://github.com/spinnaker/clouddriver/pull/6093 which however was not the correct implementation since the Health check is registered in initialisation and it is a scheduled task. 

This PR fixes the issue https://github.com/spinnaker/spinnaker/issues/3923 for the GCP provider