### PR TITLE
chore(ecs/dependencies): make spring-boot-starter-test a testImplemem…

### DIFF
--- a/clouddriver-ecs/clouddriver-ecs.gradle
+++ b/clouddriver-ecs/clouddriver-ecs.gradle
@@ -41,7 +41,6 @@ dependencies {
   implementation "org.apache.httpcomponents:httpclient"
   implementation "org.apache.httpcomponents:httpcore"
   implementation "org.codehaus.groovy:groovy"
-  implementation "org.springframework.boot:spring-boot-starter-test"
   implementation "org.springframework.boot:spring-boot-starter-web"
 
   testImplementation "cglib:cglib-nodep"
@@ -49,6 +48,7 @@ dependencies {
   testImplementation "org.objenesis:objenesis"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"
+  testImplementation "org.springframework.boot:spring-boot-starter-test"
 
   integrationImplementation project(":clouddriver-web")
   integrationImplementation "org.springframework:spring-test"


### PR DESCRIPTION
…tation dependency

since it's not used in actual shipping code.  This reduces the size of the image and reduces exposure to CVEs
(e.g. https://github.com/xmlunit/xmlunit/security/advisories/GHSA-chfm-68vv-pvw5).
