### PR TITLE
fix(ClusterController): Fix GetClusters to return all providers clusterNames of an application

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterController.groovy
@@ -79,23 +79,14 @@ class ClusterController {
       .sorted(Comparator.comparing({ Application it -> it.getName().toLowerCase() }))
       .collect(Collectors.toList())
 
-    Map<String, Set<String>> clusterNames = Map.of()
-    def lastApp = null
-    for (app in apps) {
-      if (!lastApp) {
-        clusterNames = app.getClusterNames()
-      } else {
-        clusterNames = mergeClusters(lastApp, app)
-      }
-      lastApp = app
-    }
+    Map<String, Set<String>> clusterNames = mergeClusters(apps)
     return clusterNames
   }
 
-  private Map<String, Set<String>> mergeClusters(Application a, Application b) {
+  private Map<String, Set<String>> mergeClusters(List<Application> a) {
     Map<String, Set<String>> map = new HashMap<>()
 
-    Stream.of(a, b)
+    a.stream()
       .flatMap({ it.getClusterNames().entrySet().stream() })
       .forEach({ entry ->
         map.computeIfAbsent(entry.getKey(), { new HashSet<>() }).addAll(entry.getValue())

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterControllerSpec.groovy
@@ -56,13 +56,21 @@ class ClusterControllerSpec extends Specification {
         getApplication("app") >> app2
       }
 
-      clusterController.applicationProviders = [appProvider1, appProvider2]
+      def app3 = Stub(Application) {
+        getName() >> "app"
+        getClusterNames() >> ["stage": ["we-need-all-clusters-to-be-returned"] as Set]
+      }
+      def appProvider3 = Stub(ApplicationProvider) {
+        getApplication("app") >> app3
+      }
+
+      clusterController.applicationProviders = [appProvider1, appProvider2, appProvider3]
 
     when:
       def result = clusterController.listByAccount("app")
 
     then:
-      result == [test: ["foo", "bar"] as Set, prod: ["baz"] as Set]
+      result == [test: ["foo", "bar"] as Set, prod: ["baz"] as Set, stage: ["we-need-all-clusters-to-be-returned"] as Set]
   }
 
   void "should throw exception when looking for specific cluster that doesnt exist"() {


### PR DESCRIPTION
When an application includes clusters for more than 2 cloud-providers then the GET /clusters endpoint was returning only the last 2 providers clusterNames instead of ALL the clusters deployed by the application. 

We didnt notice this bug existed because Deck is rendering based on the clusters and serverGroups and when not filtered the serverGroups was including the missing clusters.

It is noticeable though for the end-user when the SETTINGS.onDemandClusterThreshold  is used to make a searchable rendering of clusters/serverGroups in Deck. 

