### PR TITLE
chore(dependency): unpin mysql-connector-java

### DIFF
--- a/clouddriver-sql-mysql/clouddriver-sql-mysql.gradle
+++ b/clouddriver-sql-mysql/clouddriver-sql-mysql.gradle
@@ -2,5 +2,5 @@ dependencies {
   implementation project(":cats:cats-sql")
   implementation project(":clouddriver-sql")
 
-  runtimeOnly "mysql:mysql-connector-java:8.0.12"
+  runtimeOnly "mysql:mysql-connector-java"
 }


### PR DESCRIPTION
Before:
```
$ ./gradlew clouddriver-sql-mysql:dI --dependency mysql-connector-java --configuration runtimeClasspath

> Task :clouddriver-sql-mysql:dependencyInsight
mysql:mysql-connector-java:8.0.33
  Variant runtime:
    | Attribute Name                     | Provided     | Requested    |
    |------------------------------------|--------------|--------------|
    | org.gradle.status                  | release      |              |
    | org.gradle.category                | library      | library      |
    | org.gradle.libraryelements         | jar          | jar          |
    | org.gradle.usage                   | java-runtime | java-runtime |
    | org.gradle.dependency.bundling     |              | external     |
    | org.gradle.jvm.environment         |              | standard-jvm |
    | org.gradle.jvm.version             |              | 11           |
    | org.jetbrains.kotlin.platform.type |              | jvm          |
   Selection reasons:
      - By constraint
      - Forced

mysql:mysql-connector-java:8.0.33
\--- io.spinnaker.kork:kork-bom:7.227.0
     +--- runtimeClasspath
     +--- project :cats:cats-sql
     |    \--- runtimeClasspath
     +--- project :clouddriver-sql
     |    +--- runtimeClasspath
     |    \--- project :cats:cats-sql (*)
     +--- project :clouddriver-core
     |    +--- project :cats:cats-sql (*)
     |    \--- project :clouddriver-sql (*)
     +--- project :cats:cats-redis
     |    +--- project :cats:cats-sql (*)
     |    \--- project :clouddriver-core (*)
     +--- project :clouddriver-security
     |    +--- project :cats:cats-sql (*)
     |    \--- project :clouddriver-core (*)
     +--- project :cats:cats-core
     |    +--- project :cats:cats-sql (*)
     |    +--- project :clouddriver-sql (*)
     |    +--- project :clouddriver-core (*)
     |    +--- project :cats:cats-redis (*)
     |    \--- project :clouddriver-security (*)
     +--- project :clouddriver-api
     |    +--- project :cats:cats-sql (*)
     |    +--- project :clouddriver-sql (*)
     |    +--- project :clouddriver-core (*)
     |    +--- project :cats:cats-redis (*)
     |    +--- project :clouddriver-security (*)
     |    \--- project :cats:cats-core (*)
     +--- project :clouddriver-saga
     |    \--- project :clouddriver-core (*)
     \--- project :clouddriver-event
          +--- project :clouddriver-sql (*)
          \--- project :clouddriver-saga (*)

mysql:mysql-connector-java:8.0.12 -> 8.0.33
\--- runtimeClasspath

(*) - dependencies omitted (listed previously)
```

After:
```
$ ./gradlew clouddriver-sql-mysql:dI --dependency mysql-connector-java --configuration runtimeClasspath

> Task :clouddriver-sql-mysql:dependencyInsight
mysql:mysql-connector-java:8.0.33
  Variant runtime:
    | Attribute Name                     | Provided     | Requested    |
    |------------------------------------|--------------|--------------|
    | org.gradle.status                  | release      |              |
    | org.gradle.category                | library      | library      |
    | org.gradle.libraryelements         | jar          | jar          |
    | org.gradle.usage                   | java-runtime | java-runtime |
    | org.gradle.dependency.bundling     |              | external     |
    | org.gradle.jvm.environment         |              | standard-jvm |
    | org.gradle.jvm.version             |              | 11           |
    | org.jetbrains.kotlin.platform.type |              | jvm          |
   Selection reasons:
      - By constraint
      - Forced

mysql:mysql-connector-java:8.0.33
\--- io.spinnaker.kork:kork-bom:7.227.0
     +--- runtimeClasspath
     +--- project :cats:cats-sql
     |    \--- runtimeClasspath
     +--- project :clouddriver-sql
     |    +--- runtimeClasspath
     |    \--- project :cats:cats-sql (*)
     +--- project :clouddriver-core
     |    +--- project :cats:cats-sql (*)
     |    \--- project :clouddriver-sql (*)
     +--- project :cats:cats-redis
     |    +--- project :cats:cats-sql (*)
     |    \--- project :clouddriver-core (*)
     +--- project :clouddriver-security
     |    +--- project :cats:cats-sql (*)
     |    \--- project :clouddriver-core (*)
     +--- project :cats:cats-core
     |    +--- project :cats:cats-sql (*)
     |    +--- project :clouddriver-sql (*)
     |    +--- project :clouddriver-core (*)
     |    +--- project :cats:cats-redis (*)
     |    \--- project :clouddriver-security (*)
     +--- project :clouddriver-api
     |    +--- project :cats:cats-sql (*)
     |    +--- project :clouddriver-sql (*)
     |    +--- project :clouddriver-core (*)
     |    +--- project :cats:cats-redis (*)
     |    +--- project :clouddriver-security (*)
     |    \--- project :cats:cats-core (*)
     +--- project :clouddriver-saga
     |    \--- project :clouddriver-core (*)
     \--- project :clouddriver-event
          +--- project :clouddriver-sql (*)
          \--- project :clouddriver-saga (*)

mysql:mysql-connector-java -> 8.0.33
\--- runtimeClasspath

(*) - dependencies omitted (listed previously)
```