### PR TITLE
fix(liquibase): fix checkSum errors occurring with spinnaker upgrade

### DIFF
--- a/clouddriver-integration/src/test/java/com/netflix/spinnaker/clouddriver/BaseContainerTest.java
+++ b/clouddriver-integration/src/test/java/com/netflix/spinnaker/clouddriver/BaseContainerTest.java
@@ -40,7 +40,7 @@ public class BaseContainerTest {
 
   protected final Network network = Network.newNetwork();
 
-  private static final int CLOUDDRIVER_PORT = 7002;
+  protected static final int CLOUDDRIVER_PORT = 7002;
 
   protected GenericContainer<?> clouddriverContainer;
 

--- a/clouddriver-integration/src/test/java/com/netflix/spinnaker/clouddriver/PostgresMigrationContainerTest.java
+++ b/clouddriver-integration/src/test/java/com/netflix/spinnaker/clouddriver/PostgresMigrationContainerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Testcontainers
+public class PostgresMigrationContainerTest extends BaseContainerTest {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(PostgresMigrationContainerTest.class);
+
+  private static final String POSTGRES_NETWORK_ALIAS = "postgresHost";
+
+  private static final int POSTGRES_PORT = 5432;
+
+  private PostgreSQLContainer<?> postgres;
+
+  private GenericContainer<?> clouddriverInitialContainer;
+
+  private static DockerImageName previousDockerImageName;
+
+  private String jdbcUrl = "";
+
+  @BeforeAll
+  static void setupInitial() {
+    String fullDockerImageName = System.getenv("PREVIOUS_FULL_DOCKER_IMAGE_NAME");
+    // Skip the tests if there's no docker image.  This allows gradlew build to work.
+    assumeTrue(fullDockerImageName != null);
+    previousDockerImageName = DockerImageName.parse(fullDockerImageName);
+  }
+
+  @BeforeEach
+  void setup() throws Exception {
+    postgres =
+        new PostgreSQLContainer<>("postgres:15")
+            .withDatabaseName("clouddriver")
+            .withUsername("postgres")
+            .withPassword("postgres")
+            .withNetwork(network)
+            .withNetworkAliases(POSTGRES_NETWORK_ALIAS)
+            .withInitScript("postgres_init.sql")
+            .withReuse(true);
+    postgres.start();
+    jdbcUrl =
+        String.format("jdbc:postgresql://%s:%d/clouddriver", POSTGRES_NETWORK_ALIAS, POSTGRES_PORT);
+
+    // Start the first clouddriver(from previous release) container so that all the db changelog
+    // sets are executed
+    clouddriverInitialContainer =
+        new GenericContainer(previousDockerImageName)
+            .withNetwork(network)
+            .withExposedPorts(7002)
+            .waitingFor(Wait.forHealthcheck().withStartupTimeout(Duration.ofSeconds(120)))
+            .dependsOn(postgres)
+            .withEnv("SPRING_APPLICATION_JSON", getSpringApplicationJson());
+    clouddriverInitialContainer.start();
+    Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(logger);
+    clouddriverInitialContainer.followOutput(logConsumer);
+    clouddriverInitialContainer.stop();
+
+    // Start the second clouddriver(latest) container to validate migration
+    clouddriverContainer
+        .dependsOn(postgres)
+        .withEnv("SPRING_APPLICATION_JSON", getSpringApplicationJson())
+        .start();
+
+    clouddriverContainer.followOutput(logConsumer);
+  }
+
+  private String getSpringApplicationJson() throws JsonProcessingException {
+    logger.info("----------- jdbcUrl: '{}'", jdbcUrl);
+    Map<String, String> connectionPool =
+        Map.of("jdbcUrl", jdbcUrl, "user", "clouddriver_service", "password", "c10uddriver");
+    Map<String, String> migration =
+        Map.of("jdbcUrl", jdbcUrl, "user", "clouddriver_migrate", "password", "c10uddriver");
+
+    Map<String, Object> properties =
+        Map.of(
+            "sql.enabled",
+            "true",
+            "services.fiat.baseUrl",
+            "http://nowhere",
+            "sql.connectionPool",
+            connectionPool,
+            "redis.enabled",
+            "false",
+            "sql.migration",
+            migration);
+    ObjectMapper mapper = new ObjectMapper();
+    return mapper.writeValueAsString(properties);
+  }
+
+  @AfterAll
+  void cleanupOnce() {
+    if (clouddriverContainer != null) {
+      clouddriverContainer.stop();
+    }
+
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @Test
+  void testHealthCheckWithPostgres() throws Exception {
+    super.testHealthCheck();
+  }
+}

--- a/clouddriver-sql/src/main/resources/db/changelog/20180919-initial-schema.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog/20180919-initial-schema.yml
@@ -82,6 +82,7 @@ databaseChangeLog:
         tableName: task_states
 
 - changeSet:
+    validCheckSum: 8:f0bfebd55de9168e38a8ef9c7217c610
     id: mysql-change-state-stauts-to-enum-type
     author: robzienert
     changes:
@@ -171,6 +172,7 @@ databaseChangeLog:
         tableName: task_results
 
 - changeSet:
+    validCheckSum: 8:d6f5eedc195011826620cc0355e8352d
     id: mysql-revert-change-state-stauts-to-enum-type
     author: afeldman
     changes:

--- a/clouddriver-sql/src/main/resources/db/changelog/20181120-cats.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog/20181120-cats.yml
@@ -216,6 +216,7 @@ databaseChangeLog:
         newDataType: varchar(255)
 
 - changeSet:
+    validCheckSum: 8:03b00d0af09f2e7081d187f246ea4d26
     id: application-index
     author: afeldman
     changes:

--- a/clouddriver-sql/src/main/resources/db/changelog/20190913-task-sagaids.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog/20190913-task-sagaids.yml
@@ -4,6 +4,7 @@ databaseChangeLog:
       dbms: postgresql
       remove: afterColumn
   - changeSet:
+      validCheckSum: 8:91cfabe4a8fa0517124436ef9675708e
       id: add-task-sagaids-column
       author: robzienert
       changes:
@@ -19,6 +20,7 @@ databaseChangeLog:
             columnName: saga_ids
 
   - changeSet:
+      validCheckSum: 8:9601af668599fbc12e338b9b84c66f56
       id: mysql-update-state-enum-values
       author: robzienert
       changes:


### PR DESCRIPTION
This PR fixes checkSum errors caused after liquibase upgrade(to 4.24.0) as the checksum calculation underwent some changes causing this issue.

This PR fixes the checksum errors by adding validChecksum tags to the failing changesets.

Added an integration test to verify the migration scenario with postgres. This will be useful to identify and avoid issues when liquibase is upgraded or if any changesets are modified.

Similar orca PR for reference: https://github.com/spinnaker/orca/pull/4727


