### PR TITLE
refactor(mysql): update mysql connector coordinate during upgrade to spring boot 2.7.x

### DIFF
--- a/cats/cats-sql/cats-sql.gradle
+++ b/cats/cats-sql/cats-sql.gradle
@@ -59,6 +59,6 @@ dependencies {
   testImplementation "org.springframework:spring-test"
   testImplementation "org.testcontainers:mysql"
   testImplementation "org.testcontainers:postgresql"
-  testImplementation "mysql:mysql-connector-java"
+  testImplementation "com.mysql:mysql-connector-j"
   testImplementation "org.postgresql:postgresql"
 }

--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -70,7 +70,7 @@ dependencies {
   integrationImplementation "org.testcontainers:testcontainers"
   integrationImplementation "org.testcontainers:mysql"
   integrationImplementation "org.testcontainers:junit-jupiter"
-  integrationImplementation "mysql:mysql-connector-java"
+  integrationImplementation "com.mysql:mysql-connector-j"
   integrationImplementation ("io.rest-assured:rest-assured:4.0.0") {
     // Exclude groovy pulled in by rest-assured, so we use kork's version
     exclude group: "org.codehaus.groovy", module: "groovy"

--- a/clouddriver-ecs/clouddriver-ecs.gradle
+++ b/clouddriver-ecs/clouddriver-ecs.gradle
@@ -53,7 +53,7 @@ dependencies {
   integrationImplementation project(":clouddriver-web")
   integrationImplementation "org.springframework:spring-test"
   integrationImplementation "org.testcontainers:mysql"
-  integrationImplementation "mysql:mysql-connector-java"
+  integrationImplementation "com.mysql:mysql-connector-j"
   integrationImplementation sourceSets.test.output
   integrationImplementation sourceSets.main.output
   integrationImplementation ("io.rest-assured:rest-assured:4.0.0") {

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -106,7 +106,7 @@ dependencies {
   integrationImplementation "org.testcontainers:testcontainers"
   integrationImplementation "org.testcontainers:mysql"
   integrationImplementation "org.testcontainers:junit-jupiter"
-  integrationImplementation "mysql:mysql-connector-java"
+  integrationImplementation "com.mysql:mysql-connector-j"
   integrationImplementation ("io.rest-assured:rest-assured:4.0.0") {
     // Exclude groovy pulled in by rest-assured, so we use kork's version
     exclude group: "org.codehaus.groovy", module: "groovy"

--- a/clouddriver-sql-mysql/clouddriver-sql-mysql.gradle
+++ b/clouddriver-sql-mysql/clouddriver-sql-mysql.gradle
@@ -2,5 +2,5 @@ dependencies {
   implementation project(":cats:cats-sql")
   implementation project(":clouddriver-sql")
 
-  runtimeOnly "mysql:mysql-connector-java"
+  runtimeOnly "com.mysql:mysql-connector-j"
 }

--- a/clouddriver-sql/clouddriver-sql.gradle
+++ b/clouddriver-sql/clouddriver-sql.gradle
@@ -38,7 +38,7 @@ dependencies {
 
   testImplementation "io.spinnaker.kork:kork-sql-test"
   testImplementation "org.testcontainers:mysql"
-  testImplementation "mysql:mysql-connector-java"
+  testImplementation "com.mysql:mysql-connector-j"
 
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"


### PR DESCRIPTION
In spring boot 2.7.8 onwards mysql connector coordinate `mysql:mysql-connector-java` has been removed and only `com.mysql:mysql-connector-j` coordinate exist.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#mysql-jdbc-driver

So, updating the mysql connector coordinate as `com.mysql:mysql-connector-j` with spring boot upgrade to 2.7.18.

https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.18/spring-boot-dependencies-2.7.18.pom