### PR TITLE
refactor(test): remove extracting() method due to introduction of breaking change during upgrade to spring boot 2.7.x

### DIFF
--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgentTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgentTest.java
@@ -787,9 +787,10 @@ class AbstractGoogleServerGroupCachingAgentTest {
       assertThat(convertedCustomMetric.getMetric()).isEqualTo(inputCustomMetric.getMetric());
       assertThat(convertedCustomMetric.getUtilizationTarget())
           .isEqualTo(inputCustomMetric.getUtilizationTarget());
-      assertThat(convertedCustomMetric.getUtilizationTargetType())
-          .extracting(
-              enumValue -> Optional.ofNullable(enumValue).map(Object::toString).orElse(null))
+      assertThat(
+              Optional.ofNullable(convertedCustomMetric.getUtilizationTargetType())
+                  .map(Object::toString)
+                  .orElse(null))
           .isEqualTo(inputCustomMetric.getUtilizationTargetType());
     }
   }


### PR DESCRIPTION
While upgrading spring boot 2.7.18, encounter below error during execution of tests under clouddriver-google module:
```
> Task :clouddriver-google:test

AbstractGoogleServerGroupCachingAgentTest > serverGroupAutoscalingPolicy_allFields() FAILED
    java.lang.AssertionError:
    Expecting actual not to be null
        at com.netflix.spinnaker.clouddriver.google.provider.agent.AbstractGoogleServerGroupCachingAgentTest.serverGroupAutoscalingPolicy_allFields(AbstractGoogleServerGroupCachingAgentTest.java:791)

646 tests completed, 1 failed, 1 skipped

> Task :clouddriver-google:test FAILED
```
The root cause is a breaking change brought by assertj-core:3.22.0 as transitive dependency of spring boot 2.7.18. The breaking change is that extracting() now throws an assertion error if actual is null.

https://assertj.github.io/doc/#assertj-core-3-22-0-release-notes

Before:
```
$ ./gradlew clouddriver-google:dI --dependency assertj-core --configuration testRuntimeClasspath

> Task :clouddriver-google:dependencyInsight
org.assertj:assertj-core:3.21.0
  Variant runtime:
    | Attribute Name                     | Provided     | Requested    |
    |------------------------------------|--------------|--------------|
    | org.gradle.status                  | release      |              |
    | org.gradle.category                | library      | library      |
    | org.gradle.libraryelements         | jar          | jar          |
    | org.gradle.usage                   | java-runtime | java-runtime |
    | org.gradle.dependency.bundling     |              | external     |
    | org.gradle.jvm.environment         |              | standard-jvm |
    | org.gradle.jvm.version             |              | 11           |
    | org.jetbrains.kotlin.platform.type |              | jvm          |
   Selection reasons:
      - By constraint
      - Forced

org.assertj:assertj-core:3.21.0
\--- io.spinnaker.kork:kork-bom:7.227.0
     +--- testRuntimeClasspath
     +--- project :clouddriver-artifacts
     |    \--- testRuntimeClasspath
     +--- project :clouddriver-consul
     |    \--- testRuntimeClasspath
     +--- project :clouddriver-core
     |    +--- testRuntimeClasspath
     |    +--- project :clouddriver-artifacts (*)
     |    \--- project :clouddriver-consul (*)
     +--- project :clouddriver-security
     |    +--- testRuntimeClasspath
     |    \--- project :clouddriver-core (*)
     +--- project :cats:cats-redis
     |    \--- project :clouddriver-core (*)
     +--- project :cats:cats-core
     |    +--- testRuntimeClasspath
     |    +--- project :clouddriver-core (*)
     |    +--- project :clouddriver-security (*)
     |    \--- project :cats:cats-redis (*)
     +--- project :clouddriver-api
     |    +--- testRuntimeClasspath
     |    +--- project :clouddriver-artifacts (*)
     |    +--- project :clouddriver-core (*)
     |    +--- project :clouddriver-security (*)
     |    +--- project :cats:cats-redis (*)
     |    \--- project :cats:cats-core (*)
     +--- project :clouddriver-google-common
     |    \--- testRuntimeClasspath
     +--- project :clouddriver-saga
     |    \--- project :clouddriver-core (*)
     \--- project :clouddriver-event
          \--- project :clouddriver-saga (*)

org.assertj:assertj-core -> 3.21.0
\--- testRuntimeClasspath

org.assertj:assertj-core:3.20.2 -> 3.21.0
\--- org.junit.platform:junit-platform-testkit:1.8.2
     +--- io.spinnaker.kork:kork-bom:7.227.0
     |    +--- testRuntimeClasspath
     |    +--- project :clouddriver-artifacts
     |    |    \--- testRuntimeClasspath
     |    +--- project :clouddriver-consul
     |    |    \--- testRuntimeClasspath
     |    +--- project :clouddriver-core
     |    |    +--- testRuntimeClasspath
     |    |    +--- project :clouddriver-artifacts (*)
     |    |    \--- project :clouddriver-consul (*)
     |    +--- project :clouddriver-security
     |    |    +--- testRuntimeClasspath
     |    |    \--- project :clouddriver-core (*)
     |    +--- project :cats:cats-redis
     |    |    \--- project :clouddriver-core (*)
     |    +--- project :cats:cats-core
     |    |    +--- testRuntimeClasspath
     |    |    +--- project :clouddriver-core (*)
     |    |    +--- project :clouddriver-security (*)
     |    |    \--- project :cats:cats-redis (*)
     |    +--- project :clouddriver-api
     |    |    +--- testRuntimeClasspath
     |    |    +--- project :clouddriver-artifacts (*)
     |    |    +--- project :clouddriver-core (*)
     |    |    +--- project :clouddriver-security (*)
     |    |    +--- project :cats:cats-redis (*)
     |    |    \--- project :cats:cats-core (*)
     |    +--- project :clouddriver-google-common
     |    |    \--- testRuntimeClasspath
     |    +--- project :clouddriver-saga
     |    |    \--- project :clouddriver-core (*)
     |    \--- project :clouddriver-event
     |         \--- project :clouddriver-saga (*)
     +--- org.spockframework:spock-core:2.0-groovy-3.0 (requested org.junit.platform:junit-platform-testkit)
     |    +--- testRuntimeClasspath (requested org.spockframework:spock-core)
     |    +--- io.spinnaker.kork:kork-bom:7.227.0 (*)
     |    \--- org.spockframework:spock-spring:2.0-groovy-3.0
     |         +--- testRuntimeClasspath (requested org.spockframework:spock-spring)
     |         \--- io.spinnaker.kork:kork-bom:7.227.0 (*)
     \--- org.junit:junit-bom:5.8.2
          +--- org.spockframework:spock-spring:2.0-groovy-3.0 (requested org.junit:junit-bom:5.7.2) (*)
          +--- org.spockframework:spock-core:2.0-groovy-3.0 (requested org.junit:junit-bom:5.7.2) (*)
          +--- org.junit.jupiter:junit-jupiter-engine:5.8.2
          |    +--- testRuntimeClasspath (requested org.junit.jupiter:junit-jupiter-engine)
          |    +--- io.spinnaker.kork:kork-bom:7.227.0 (*)
          |    \--- org.junit:junit-bom:5.8.2 (*)
          +--- org.junit.jupiter:junit-jupiter-api:5.8.2
          |    +--- testRuntimeClasspath (requested org.junit.jupiter:junit-jupiter-api)
          |    +--- io.spinnaker.kork:kork-bom:7.227.0 (*)
          |    +--- org.junit.jupiter:junit-jupiter-engine:5.8.2 (*)
          |    +--- org.mockito:mockito-junit-jupiter:4.0.0 (requested org.junit.jupiter:junit-jupiter-api:5.8.1)
          |    |    +--- testRuntimeClasspath (requested org.mockito:mockito-junit-jupiter)
          |    |    \--- io.spinnaker.kork:kork-bom:7.227.0 (*)
          |    \--- org.junit:junit-bom:5.8.2 (*)
          +--- org.junit.platform:junit-platform-launcher:1.8.2
          |    +--- io.spinnaker.kork:kork-bom:7.227.0 (*)
          |    +--- org.junit:junit-bom:5.8.2 (*)
          |    \--- org.junit.platform:junit-platform-testkit:1.8.2 (*)
          +--- org.junit.platform:junit-platform-engine:1.8.2
          |    +--- io.spinnaker.kork:kork-bom:7.227.0 (*)
          |    +--- org.spockframework:spock-core:2.0-groovy-3.0 (requested org.junit.platform:junit-platform-engine) (*)
          |    +--- org.junit.jupiter:junit-jupiter-engine:5.8.2 (*)
          |    +--- org.junit.platform:junit-platform-launcher:1.8.2 (*)
          |    \--- org.junit:junit-bom:5.8.2 (*)
          +--- org.junit.platform:junit-platform-commons:1.8.2
          |    +--- io.spinnaker.kork:kork-bom:7.227.0 (*)
          |    +--- org.junit.jupiter:junit-jupiter-api:5.8.2 (*)
          |    +--- org.junit.platform:junit-platform-engine:1.8.2 (*)
          |    \--- org.junit:junit-bom:5.8.2 (*)
          \--- org.junit.platform:junit-platform-testkit:1.8.2 (*)

```

After
```
$ ./gradlew clouddriver-google:dI --dependency assertj-core --configuration testRuntimeClasspath

> Task :clouddriver-google:dependencyInsight
org.assertj:assertj-core:3.22.0
  Variant runtime:
    | Attribute Name                     | Provided     | Requested    |
    |------------------------------------|--------------|--------------|
    | org.gradle.status                  | release      |              |
    | org.gradle.category                | library      | library      |
    | org.gradle.libraryelements         | jar          | jar          |
    | org.gradle.usage                   | java-runtime | java-runtime |
    | org.gradle.dependency.bundling     |              | external     |
    | org.gradle.jvm.environment         |              | standard-jvm |
    | org.gradle.jvm.version             |              | 11           |
    | org.jetbrains.kotlin.platform.type |              | jvm          |
   Selection reasons:
      - By constraint
      - Forced

org.assertj:assertj-core:3.22.0…ing upgrade to spring boot 2.7.x
\--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT
     +--- testRuntimeClasspath
     +--- project :clouddriver-artifacts
     |    \--- testRuntimeClasspath
     +--- project :clouddriver-consul
     |    \--- testRuntimeClasspath
     +--- project :clouddriver-core
     |    +--- testRuntimeClasspath
     |    +--- project :clouddriver-artifacts (*)
     |    \--- project :clouddriver-consul (*)
     +--- project :clouddriver-security
     |    +--- testRuntimeClasspath
     |    \--- project :clouddriver-core (*)
     +--- project :cats:cats-redis
     |    \--- project :clouddriver-core (*)
     +--- project :cats:cats-core
     |    +--- testRuntimeClasspath
     |    +--- project :clouddriver-core (*)
     |    +--- project :clouddriver-security (*)
     |    \--- project :cats:cats-redis (*)
     +--- project :clouddriver-api
     |    +--- testRuntimeClasspath
     |    +--- project :clouddriver-artifacts (*)
     |    +--- project :clouddriver-core (*)
     |    +--- project :clouddriver-security (*)
     |    +--- project :cats:cats-redis (*)
     |    \--- project :cats:cats-core (*)
     +--- project :clouddriver-google-common
     |    \--- testRuntimeClasspath
     +--- project :clouddriver-saga
     |    \--- project :clouddriver-core (*)
     \--- project :clouddriver-event
          \--- project :clouddriver-saga (*)

org.assertj:assertj-core -> 3.22.0
\--- testRuntimeClasspath

org.assertj:assertj-core:3.20.2 -> 3.22.0
\--- org.junit.platform:junit-platform-testkit:1.8.2
     +--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT
     |    +--- testRuntimeClasspath
     |    +--- project :clouddriver-artifacts
     |    |    \--- testRuntimeClasspath
     |    +--- project :clouddriver-consul
     |    |    \--- testRuntimeClasspath
     |    +--- project :clouddriver-core
     |    |    +--- testRuntimeClasspath
     |    |    +--- project :clouddriver-artifacts (*)
     |    |    \--- project :clouddriver-consul (*)
     |    +--- project :clouddriver-security
     |    |    +--- testRuntimeClasspath
     |    |    \--- project :clouddriver-core (*)
     |    +--- project :cats:cats-redis
     |    |    \--- project :clouddriver-core (*)
     |    +--- project :cats:cats-core
     |    |    +--- testRuntimeClasspath
     |    |    +--- project :clouddriver-core (*)
     |    |    +--- project :clouddriver-security (*)
     |    |    \--- project :cats:cats-redis (*)
     |    +--- project :clouddriver-api
     |    |    +--- testRuntimeClasspath
     |    |    +--- project :clouddriver-artifacts (*)
     |    |    +--- project :clouddriver-core (*)
     |    |    +--- project :clouddriver-security (*)
     |    |    +--- project :cats:cats-redis (*)
     |    |    \--- project :cats:cats-core (*)
     |    +--- project :clouddriver-google-common
     |    |    \--- testRuntimeClasspath
     |    +--- project :clouddriver-saga
     |    |    \--- project :clouddriver-core (*)
     |    \--- project :clouddriver-event
     |         \--- project :clouddriver-saga (*)
     +--- org.spockframework:spock-core:2.0-groovy-3.0 (requested org.junit.platform:junit-platform-testkit)
     |    +--- testRuntimeClasspath (requested org.spockframework:spock-core)
     |    +--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT (*)
     |    \--- org.spockframework:spock-spring:2.0-groovy-3.0
     |         +--- testRuntimeClasspath (requested org.spockframework:spock-spring)
     |         \--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT (*)
     \--- org.junit:junit-bom:5.8.2
          +--- org.spockframework:spock-spring:2.0-groovy-3.0 (requested org.junit:junit-bom:5.7.2) (*)
          +--- org.spockframework:spock-core:2.0-groovy-3.0 (requested org.junit:junit-bom:5.7.2) (*)
          +--- org.junit.jupiter:junit-jupiter-engine:5.8.2
          |    +--- testRuntimeClasspath (requested org.junit.jupiter:junit-jupiter-engine)
          |    +--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT (*)
          |    \--- org.junit:junit-bom:5.8.2 (*)
          +--- org.junit.jupiter:junit-jupiter-api:5.8.2
          |    +--- testRuntimeClasspath (requested org.junit.jupiter:junit-jupiter-api)
          |    +--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT (*)
          |    +--- org.junit.jupiter:junit-jupiter-engine:5.8.2 (*)
          |    +--- org.mockito:mockito-junit-jupiter:4.5.1
          |    |    +--- testRuntimeClasspath (requested org.mockito:mockito-junit-jupiter)
          |    |    \--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT (*)
          |    \--- org.junit:junit-bom:5.8.2 (*)
          +--- org.junit.platform:junit-platform-launcher:1.8.2
          |    +--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT (*)
          |    +--- org.junit:junit-bom:5.8.2 (*)
          |    \--- org.junit.platform:junit-platform-testkit:1.8.2 (*)
          +--- org.junit.platform:junit-platform-engine:1.8.2
          |    +--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT (*)
          |    +--- org.spockframework:spock-core:2.0-groovy-3.0 (requested org.junit.platform:junit-platform-engine) (*)
          |    +--- org.junit.jupiter:junit-jupiter-engine:5.8.2 (*)
          |    +--- org.junit.platform:junit-platform-launcher:1.8.2 (*)
          |    \--- org.junit:junit-bom:5.8.2 (*)
          +--- org.junit.platform:junit-platform-commons:1.8.2
          |    +--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT (*)
          |    +--- org.junit.jupiter:junit-jupiter-api:5.8.2 (*)
          |    +--- org.junit.platform:junit-platform-engine:1.8.2 (*)
          |    \--- org.junit:junit-bom:5.8.2 (*)
          \--- org.junit.platform:junit-platform-testkit:1.8.2 (*)

```