### PR TITLE
fix(google): adding autowired for cacheview and objectmapper

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
@@ -59,12 +59,14 @@ class UpsertGoogleAutoscalingPolicyAtomicOperation extends GoogleAtomicOperation
 
   private final UpsertGoogleAutoscalingPolicyDescription description
 
-  UpsertGoogleAutoscalingPolicyAtomicOperation(UpsertGoogleAutoscalingPolicyDescription description, @Autowired GoogleClusterProvider googleClusterProvider, @Autowired GoogleOperationPoller googleOperationPoller, @Autowired AtomicOperationsRegistry atomicOperationsRegistry, @Autowired OrchestrationProcessor orchestrationProcessor) {
+  UpsertGoogleAutoscalingPolicyAtomicOperation(UpsertGoogleAutoscalingPolicyDescription description, @Autowired GoogleClusterProvider googleClusterProvider, @Autowired GoogleOperationPoller googleOperationPoller, @Autowired AtomicOperationsRegistry atomicOperationsRegistry, @Autowired OrchestrationProcessor orchestrationProcessor, @Autowired Cache cacheView, @Autowired ObjectMapper objectMapper) {
     this.description = description
     this.googleClusterProvider = googleClusterProvider
     this.googleOperationPoller = googleOperationPoller
     this.atomicOperationsRegistry = atomicOperationsRegistry
     this.orchestrationProcessor = orchestrationProcessor
+    this.cacheView = cacheView
+    this.objectMapper = objectMapper
    }
 
   /**


### PR DESCRIPTION
adding Autowired for cacheview and objectmapper for UpsertGoogleAutoscalingPolicyAtomicOperation.groovy

This PR is meant to fix the following issue: https://github.com/spinnaker/spinnaker/issues/6963
