### PR TITLE
fix(google): fixing UpsertGoogleAutoscalingPolicyAtomicOperation missing Autowired for objectMapper and cacheView

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/ResizeGoogleServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/ResizeGoogleServerGroupAtomicOperationConverter.groovy
@@ -16,7 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.converters
 
-import com.google.api.services.compute.model.AutoscalingPolicy
+
+import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
@@ -28,12 +29,9 @@ import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy
 import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationsRegistry
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription
-import com.netflix.spinnaker.clouddriver.orchestration.OrchestrationProcessor
+import com.netflix.spinnaker.clouddriver.orchestration.*
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsConverter
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -53,6 +51,12 @@ class ResizeGoogleServerGroupAtomicOperationConverter extends AbstractAtomicOper
   @Autowired
   OrchestrationProcessor orchestrationProcessor
 
+  @Autowired
+  Cache cacheView
+
+  @Autowired
+  ObjectMapper objectMapper
+
   @Override
   AtomicOperation convertOperation(Map input) {
     // If the target server group has an Autoscaler configured we need to modify that policy as opposed to the
@@ -61,7 +65,7 @@ class ResizeGoogleServerGroupAtomicOperationConverter extends AbstractAtomicOper
     def convertedDescription = convertDescription(input, autoscalingPolicy)
 
     if (autoscalingPolicy) {
-      new UpsertGoogleAutoscalingPolicyAtomicOperation(convertedDescription, googleClusterProvider, googleOperationPoller, atomicOperationsRegistry, orchestrationProcessor)
+      new UpsertGoogleAutoscalingPolicyAtomicOperation(convertedDescription, googleClusterProvider, googleOperationPoller, atomicOperationsRegistry, orchestrationProcessor, cacheView, objectMapper)
     } else {
       new ResizeGoogleServerGroupAtomicOperation(convertedDescription)
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/UpsertGoogleAutoscalingPolicyAtomicOperationConverter.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/UpsertGoogleAutoscalingPolicyAtomicOperationConverter.groovy
@@ -16,17 +16,19 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.converters
 
+import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleAutoscalingPolicyDescription
-import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.deploy.ops.UpsertGoogleAutoscalingPolicyAtomicOperation
+import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationsRegistry
 import com.netflix.spinnaker.clouddriver.orchestration.OrchestrationProcessor
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsConverter
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -46,9 +48,15 @@ class UpsertGoogleAutoscalingPolicyAtomicOperationConverter extends AbstractAtom
   @Autowired
   OrchestrationProcessor orchestrationProcessor
 
+  @Autowired
+  Cache cacheView
+
+  @Autowired
+  ObjectMapper objectMapper
+
   @Override
   AtomicOperation convertOperation(Map input) {
-    new UpsertGoogleAutoscalingPolicyAtomicOperation(convertDescription(input), googleClusterProvider, googleOperationPoller, atomicOperationsRegistry, orchestrationProcessor)
+    new UpsertGoogleAutoscalingPolicyAtomicOperation(convertDescription(input), googleClusterProvider, googleOperationPoller, atomicOperationsRegistry, orchestrationProcessor, cacheView, objectMapper)
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
@@ -59,12 +59,14 @@ class UpsertGoogleAutoscalingPolicyAtomicOperation extends GoogleAtomicOperation
 
   private final UpsertGoogleAutoscalingPolicyDescription description
 
-  UpsertGoogleAutoscalingPolicyAtomicOperation(UpsertGoogleAutoscalingPolicyDescription description, @Autowired GoogleClusterProvider googleClusterProvider, @Autowired GoogleOperationPoller googleOperationPoller, @Autowired AtomicOperationsRegistry atomicOperationsRegistry, @Autowired OrchestrationProcessor orchestrationProcessor) {
+  UpsertGoogleAutoscalingPolicyAtomicOperation(UpsertGoogleAutoscalingPolicyDescription description, @Autowired GoogleClusterProvider googleClusterProvider, @Autowired GoogleOperationPoller googleOperationPoller, @Autowired AtomicOperationsRegistry atomicOperationsRegistry, @Autowired OrchestrationProcessor orchestrationProcessor, @Autowired Cache cacheView, @Autowired ObjectMapper objectMapper) {
     this.description = description
     this.googleClusterProvider = googleClusterProvider
     this.googleOperationPoller = googleOperationPoller
     this.atomicOperationsRegistry = atomicOperationsRegistry
     this.orchestrationProcessor = orchestrationProcessor
+    this.cacheView = cacheView
+    this.objectMapper = objectMapper
    }
 
   /**

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/ResizeGoogleServerGroupAtomicOperationConverterUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/ResizeGoogleServerGroupAtomicOperationConverterUnitSpec.groovy
@@ -50,7 +50,7 @@ class ResizeGoogleServerGroupAtomicOperationConverterUnitSpec extends Specificat
                    accountName: ACCOUNT_NAME]
       GoogleClusterProvider googleClusterProviderMock = Mock(GoogleClusterProvider)
       ResizeGoogleServerGroupAtomicOperationConverter converter =
-        new ResizeGoogleServerGroupAtomicOperationConverter(googleClusterProvider: googleClusterProviderMock)
+        new ResizeGoogleServerGroupAtomicOperationConverter(googleClusterProvider: googleClusterProviderMock, objectMapper: mapper)
       def credentialsRepository = Mock(CredentialsRepository)
       def mockCredentials = Mock(GoogleNamedAccountCredentials)
       credentialsRepository.getOne(_) >> mockCredentials
@@ -83,7 +83,7 @@ class ResizeGoogleServerGroupAtomicOperationConverterUnitSpec extends Specificat
       def input = [application: "app", targetSize: desired, region: REGION]
       GoogleClusterProvider googleClusterProviderMock = Mock(GoogleClusterProvider)
       ResizeGoogleServerGroupAtomicOperationConverter converter =
-        new ResizeGoogleServerGroupAtomicOperationConverter(googleClusterProvider: googleClusterProviderMock)
+        new ResizeGoogleServerGroupAtomicOperationConverter(googleClusterProvider: googleClusterProviderMock, objectMapper: mapper)
       def credentialsRepository = Mock(CredentialsRepository)
       def mockCredentials = Mock(GoogleNamedAccountCredentials)
       credentialsRepository.getOne(_) >> mockCredentials

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/UpsertGoogleAutoscalingPolicyAtomicOperationConverterUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/UpsertGoogleAutoscalingPolicyAtomicOperationConverterUnitSpec.groovy
@@ -43,6 +43,7 @@ class UpsertGoogleAutoscalingPolicyAtomicOperationConverterUnitSpec extends Spec
     def mockCredentials = Mock(GoogleNamedAccountCredentials)
     credentialsRepository.getOne(_) >> mockCredentials
     converter.credentialsRepository = credentialsRepository
+    converter.objectMapper = mapper
   }
 
   void "upsertGoogleScalingPolicyDescription type returns UpsertGoogleScalingPolicyDescription and UpsertGoogleScalingPolicyAtomicOperation"() {

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperationUnitSpec.groovy
@@ -17,7 +17,9 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
 import com.google.api.services.compute.Compute
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.api.services.compute.model.*
+import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -75,6 +77,8 @@ class UpsertGoogleAutoscalingPolicyAtomicOperationUnitSpec extends Specification
   GoogleOperationPoller operationPollerMock = Mock(GoogleOperationPoller)
   AtomicOperationsRegistry atomicOperationsRegistryMock = Mock(AtomicOperationsRegistry)
   DefaultOrchestrationProcessor orchestrationProcessorMock = Mock(DefaultOrchestrationProcessor)
+  Cache cacheView = Mock(Cache)
+  ObjectMapper objectMapper = Mock(ObjectMapper)
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -107,7 +111,7 @@ class UpsertGoogleAutoscalingPolicyAtomicOperationUnitSpec extends Specification
     def regionalTimerId = GoogleApiTestUtils.makeOkId(registry, "compute.regionAutoscalers.insert", [scope: "regional", region: REGION])
     registry.timer(regionalTimerId)
 
-    @Subject def operation = Spy(UpsertGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description, googleClusterProviderMock, operationPollerMock,atomicOperationsRegistryMock, orchestrationProcessorMock])
+    @Subject def operation = Spy(UpsertGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description, googleClusterProviderMock, operationPollerMock,atomicOperationsRegistryMock, orchestrationProcessorMock, cacheView, objectMapper])
     operation.registry = registry
 
     when:
@@ -166,7 +170,7 @@ class UpsertGoogleAutoscalingPolicyAtomicOperationUnitSpec extends Specification
     def regionUpdateMock = Mock(Compute.RegionAutoscalers.Update)
     def regionalTimerId = GoogleApiTestUtils.makeOkId(registry, "compute.regionAutoscalers.update", [scope: "regional", region: REGION])
 
-    @Subject def operation = Spy(UpsertGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description, googleClusterProviderMock, operationPollerMock,atomicOperationsRegistryMock, orchestrationProcessorMock])
+    @Subject def operation = Spy(UpsertGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description, googleClusterProviderMock, operationPollerMock,atomicOperationsRegistryMock, orchestrationProcessorMock, cacheView, objectMapper])
     operation.registry = registry
 
     when:
@@ -235,7 +239,7 @@ class UpsertGoogleAutoscalingPolicyAtomicOperationUnitSpec extends Specification
     def regionAutoscalerMock = Mock(Compute.RegionAutoscalers)
     def regionUpdateMock = Mock(Compute.RegionAutoscalers.Update)
 
-    @Subject def operation = Spy(UpsertGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description, googleClusterProviderMock, operationPollerMock,atomicOperationsRegistryMock, orchestrationProcessorMock])
+    @Subject def operation = Spy(UpsertGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description, googleClusterProviderMock, operationPollerMock,atomicOperationsRegistryMock, orchestrationProcessorMock, cacheView, objectMapper])
     operation.registry = registry
 
     when:
@@ -310,7 +314,7 @@ class UpsertGoogleAutoscalingPolicyAtomicOperationUnitSpec extends Specification
     def regionAutoscalerMock = Mock(Compute.RegionAutoscalers)
     def regionUpdateMock = Mock(Compute.RegionAutoscalers.Update)
 
-    @Subject def operation = Spy(UpsertGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description, googleClusterProviderMock, operationPollerMock,atomicOperationsRegistryMock, orchestrationProcessorMock])
+    @Subject def operation = Spy(UpsertGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description, googleClusterProviderMock, operationPollerMock,atomicOperationsRegistryMock, orchestrationProcessorMock, cacheView, objectMapper])
     operation.registry = registry
 
     when:
@@ -422,7 +426,7 @@ class UpsertGoogleAutoscalingPolicyAtomicOperationUnitSpec extends Specification
       serviceAccounts: [[email: 'serviceAccount@google.com']]
     ])
 
-    @Subject def operation = Spy(UpsertGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description, googleClusterProviderMock, operationPollerMock,atomicOperationsRegistryMock, orchestrationProcessorMock])
+    @Subject def operation = Spy(UpsertGoogleAutoscalingPolicyAtomicOperation, constructorArgs: [description, googleClusterProviderMock, operationPollerMock,atomicOperationsRegistryMock, orchestrationProcessorMock, cacheView, objectMapper])
     operation.registry = registry
 
     when:


### PR DESCRIPTION
Fixing the following [issue](https://github.com/spinnaker/spinnaker/issues/6963) 
It was introduced as part of this [PR](https://github.com/spinnaker/clouddriver/pull/6057/files#diff-77886cd9f754611f6844f38a9d1eaa13a7306a5c311d58aa07fa7aff2ab1de88L67) 

