### PR TITLE
fix(aws): allow enabledMetrics: [] to enable all metrics

### DIFF
--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/asg/asgbuilders/AsgBuilder.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/deploy/asg/asgbuilders/AsgBuilder.java
@@ -220,7 +220,6 @@ public abstract class AsgBuilder {
 
     // enable metrics and monitoring
     if (cfg.getEnabledMetrics() != null
-        && !cfg.getEnabledMetrics().isEmpty()
         && cfg.getInstanceMonitoring() != null
         && cfg.getInstanceMonitoring()) {
       task.updateStatus(taskPhase, "Enabling metrics collection for: " + asgName);

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/asgbuilders/AsgWithLaunchConfigurationBuilderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/asgbuilders/AsgWithLaunchConfigurationBuilderSpec.groovy
@@ -365,11 +365,26 @@ class AsgWithLaunchConfigurationBuilderSpec extends Specification {
             null                     | null                |  0
             []                       | null                |  0
             []                       | false               |  0
-            []                       | true                |  0
     ['GroupMinSize', 'GroupMaxSize'] | null                |  0
     ['GroupMinSize', 'GroupMaxSize'] | []                  |  0
     ['GroupMinSize', 'GroupMaxSize'] | false               |  0
     ['GroupMinSize', 'GroupMaxSize'] | true                |  1
+  }
+
+  void "enables metrics collection for all metrics when enabledMetrics is an empty list and instanceMonitoring is true"() {
+    setup:
+    def asgWithLcBuilder = new AsgWithLaunchConfigurationBuilder(lcBuilder, autoScaling, amazonEC2, asgLifecycleHookWorker)
+    asgConfig.enabledMetrics = []
+    asgConfig.instanceMonitoring = true
+
+    when:
+    asgWithLcBuilder.build(task, taskPhase, asgName, asgConfig)
+
+    then:
+    // According to
+    // https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_EnableMetricsCollection.html,
+    // specifying granularity with no metrics means all metrics.
+    1 * autoScaling.enableMetricsCollection({ (it.granularity == '1Minute') && (it.metrics == []) })
   }
 
   void "continues if serverGroup already exists, is reasonably the same and within safety window"() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/asgbuilders/AsgWithLaunchTemplateBuilderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/asg/asgbuilders/AsgWithLaunchTemplateBuilderSpec.groovy
@@ -340,11 +340,27 @@ class AsgWithLaunchTemplateBuilderSpec extends Specification {
     null                             | null                |  0
     []                               | null                |  0
     []                               | false               |  0
-    []                               | true                |  0
     ['GroupMinSize', 'GroupMaxSize'] | null                |  0
     ['GroupMinSize', 'GroupMaxSize'] | []                  |  0
     ['GroupMinSize', 'GroupMaxSize'] | false               |  0
     ['GroupMinSize', 'GroupMaxSize'] | true                |  1
+  }
+
+  void "enables metrics collection for all metrics when enabledMetrics is an empty list and instanceMonitoring is true"() {
+    setup:
+    def asgWithLtBuilder = new AsgWithLaunchTemplateBuilder(ltService, securityGroupService, deployDefaults,  autoScaling, amazonEC2, asgLifecycleHookWorker)
+    asgConfig.enabledMetrics = []
+    asgConfig.instanceMonitoring = true
+
+    when:
+    asgWithLtBuilder.build(task, taskPhase, asgName, asgConfig)
+
+    then:
+    1 * ltService.createLaunchTemplate(asgConfig, asgName, _) >> lt
+    // According to
+    // https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_EnableMetricsCollection.html,
+    // specifying granularity with no metrics means all metrics.
+    1 * autoScaling.enableMetricsCollection({ (it.granularity == '1Minute') && (it.metrics == []) })
   }
 
   void "continues if serverGroup already exists, is reasonably the same and within safety window"() {


### PR DESCRIPTION
when building an auto scaling group.  https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_EnableMetricsCollection.html says:

> If you specify Granularity and don't specify any metrics, all metrics are enabled.

Before this change
```
  enabledMetrics: []
```
in a deploy stage would enable no metrics, like this:
```
$ aws autoscaling describe-auto-scaling-groups --region=us-west-2 --auto-scaling-group-names=my-asg-v001 | jq .AutoScalingGroups[0].EnabledMetrics
[]
```

After this PR, we get:
```
$ aws autoscaling describe-auto-scaling-groups --region=us-west-2 --auto-scaling-group-names=my-asg-v002 | jq .AutoScalingGroups[0].EnabledMetrics
[
  {
    "Metric": "GroupInServiceInstances",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupAndWarmPoolDesiredCapacity",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupTerminatingCapacity",
    "Granularity": "1Minute"
  },
  {
    "Metric": "WarmPoolMinSize",
    "Granularity": "1Minute"
  },
  {
    "Metric": "WarmPoolWarmedCapacity",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupTotalInstances",
    "Granularity": "1Minute"
  },
  {
    "Metric": "WarmPoolTotalCapacity",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupAndWarmPoolTotalCapacity",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupDesiredCapacity",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupPendingCapacity",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupStandbyInstances",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupPendingInstances",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupMinSize",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupStandbyCapacity",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupTotalCapacity",
    "Granularity": "1Minute"
  },
  {
    "Metric": "WarmPoolDesiredCapacity",
    "Granularity": "1Minute"
  },
  {
    "Metric": "WarmPoolPendingCapacity",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupTerminatingInstances",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupInServiceCapacity",
    "Granularity": "1Minute"
  },
  {
    "Metric": "GroupMaxSize",
    "Granularity": "1Minute"
  },
  {
    "Metric": "WarmPoolTerminatingCapacity",
    "Granularity": "1Minute"
  }
]
```