### PR TITLE
fix(deps): Fixes gradle deps to use strictly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,10 @@ subprojects {
 
     sourceSets.main.java.srcDirs = []
     sourceSets.main.groovy.srcDirs += ["src/main/java"]
-
+    // See clouddriver-google - overrides to deps from kork NEED to be done here.  NOT in sub projects or they wont' apply at the end and compiles will fail
+    configurations.all {
+       resolutionStrategy.force 'com.google.apis:google-api-services-compute:beta-rev20201102-1.30.10'
+    }
     dependencies {
       api enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
 

--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -13,6 +13,7 @@ dependencies {
   implementation("com.google.apis:google-api-services-compute") {
     version {
       // This breaks unless AT LEAST this revision is set.  Should be updated in kork/spinnaker-dependencies nominally as well
+      // DO NOT remove this - the project WILL compile but this also protects transitive deps in case of parent changes.
       strictly("beta-rev20201102-1.30.10")
     }
   }

--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -10,7 +10,12 @@ dependencies {
   implementation "org.codehaus.groovy:groovy"
   implementation "org.codehaus.groovy:groovy-json"
   implementation "org.apache.commons:commons-lang3"
-  implementation "com.google.apis:google-api-services-compute"
+  implementation("com.google.apis:google-api-services-compute") {
+    version {
+      // This breaks unless AT LEAST this revision is set.  Should be updated in kork/spinnaker-dependencies nominally as well
+      strictly("beta-rev20201102-1.30.10")
+    }
+  }
   implementation "com.google.guava:guava"
   implementation "com.google.apis:google-api-services-iam"
   implementation 'com.google.auth:google-auth-library-oauth2-http'
@@ -47,8 +52,4 @@ dependencies {
   testImplementation "org.springframework:spring-test"
   testImplementation "org.springframework.boot:spring-boot-test"
   testImplementation "org.codehaus.groovy:groovy-test"
-}
-
-configurations.all {
-   resolutionStrategy.force 'com.google.apis:google-api-services-compute:beta-rev20201102-1.30.10'
 }

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -56,3 +56,7 @@ dependencies {
     implementation project(":${it}")
   }
 }
+// See clouddriver-google
+configurations.all {
+   resolutionStrategy.force 'com.google.apis:google-api-services-compute:beta-rev20201102-1.30.10'
+}

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -56,7 +56,3 @@ dependencies {
     implementation project(":${it}")
   }
 }
-// See clouddriver-google
-configurations.all {
-   resolutionStrategy.force 'com.google.apis:google-api-services-compute:beta-rev20201102-1.30.10'
-}


### PR DESCRIPTION
See: https://github.com/gradle/gradle/issues/29506#issuecomment-2162486040 - "strictly" is apparently the way to go for transitive deps (aka clouddriver-web) that would tell web I MUST have this version.  The configuration strategy resolution doesn't work for downstream projects.  This WILL Cause breakage until Kork is updated as well OR clouddriver-web does a force beyond what was set.  It's non ideal IMHO but an issue more with gradle and how it's handling transitive dependencies & force overrides.