### PR TITLE
fix(kubernetes): Kubernetes job stage - pod deleted failure

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
@@ -95,9 +95,13 @@ public class KubernetesJobProvider implements JobProvider<KubernetesJobStatus> {
                 })
             .collect(Collectors.toList());
 
-    V1Pod mostRecentPod = typedPods.get(typedPods.size() - 1);
-    jobStatus.setMostRecentPodName(
-        mostRecentPod.getMetadata() != null ? mostRecentPod.getMetadata().getName() : "");
+    if (typedPods.size() > 0) {
+      V1Pod mostRecentPod = typedPods.get(typedPods.size() - 1);
+      jobStatus.setMostRecentPodName(
+          mostRecentPod.getMetadata() != null ? mostRecentPod.getMetadata().getName() : "");
+    } else {
+      jobStatus.setMostRecentPodName("");
+    }
 
     jobStatus.setPods(
         typedPods.stream().map(KubernetesJobStatus.PodStatus::new).collect(Collectors.toList()));

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/succeeded-job.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/succeeded-job.yml
@@ -1,0 +1,12 @@
+# Job has succeeded
+status:
+  completionTime: "2024-07-16T14:51:40Z"
+  conditions:
+  - lastProbeTime: "2024-07-16T14:51:40Z"
+    lastTransitionTime: "2024-07-16T14:51:40Z"
+    status: "True"
+    type: Complete
+  ready: 0
+  startTime: "2024-07-16T14:51:22Z"
+  succeeded: 5
+  uncountedTerminatedPods: {}


### PR DESCRIPTION
When running a Kubernetes job stage it is possible for the pod to be
deleted between the job succeeding and clouddriver running the
`collectJob` function.  When this happens clouddriver hits an
`IndexOutOfBoundsException` error as it attempts to get the name
of the deleted pod.

<details>
<summary>Stack trace</summary>
```
spin-clouddriver-57c75df64f-glzkq clouddriver 2024-07-16 14:34:53.115 ERROR 1 --- [.0-7002-exec-75] c.n.s.k.w.e.GenericExceptionHandlers     : Internal Server Error
spin-clouddriver-57c75df64f-glzkq clouddriver 
spin-clouddriver-57c75df64f-glzkq clouddriver java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 0
spin-clouddriver-57c75df64f-glzkq clouddriver 	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64) ~[na:na]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70) ~[na:na]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266) ~[na:na]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at java.base/java.util.Objects.checkIndex(Objects.java:361) ~[na:na]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at java.base/java.util.ArrayList.get(ArrayList.java:427) ~[na:na]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at com.netflix.spinnaker.clouddriver.kubernetes.provider.view.KubernetesJobProvider.collectJob(KubernetesJobProvider.java:98) ~[clouddriver-kubernetes-5.83.0.jar:5.83.0]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at com.netflix.spinnaker.clouddriver.kubernetes.provider.view.KubernetesJobProvider.collectJob(KubernetesJobProvider.java:44) ~[clouddriver-kubernetes-5.83.0.jar:5.83.0]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at com.netflix.spinnaker.clouddriver.model.JobProvider$collectJob.call(Unknown Source) ~[na:na]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at com.netflix.spinnaker.clouddriver.controllers.JobController$_collectJob_closure1.doCall(JobController.groovy:53) ~[clouddriver-web-5.83.0.jar:5.83.0]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at jdk.internal.reflect.GeneratedMethodAccessor369.invoke(Unknown Source) ~[na:na]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:107) ~[groovy-3.0.17.jar:3.0.17]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323) ~[groovy-3.0.17.jar:3.0.17]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:274) ~[groovy-3.0.17.jar:3.0.17]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1035) ~[groovy-3.0.17.jar:3.0.17]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at groovy.lang.Closure.call(Closure.java:412) ~[groovy-3.0.17.jar:3.0.17]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at groovy.lang.Closure.call(Closure.java:428) ~[groovy-3.0.17.jar:3.0.17]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.codehaus.groovy.runtime.DefaultGroovyMethods.findResults(DefaultGroovyMethods.java:4760) ~[groovy-3.0.17.jar:3.0.17]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.codehaus.groovy.runtime.DefaultGroovyMethods.findResults(DefaultGroovyMethods.java:4744) ~[groovy-3.0.17.jar:3.0.17]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.codehaus.groovy.runtime.dgm$285.invoke(Unknown Source) ~[groovy-3.0.17.jar:3.0.17]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:242) ~[groovy-3.0.17.jar:3.0.17]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:51) ~[groovy-3.0.17.jar:3.0.17]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:139) ~[groovy-3.0.17.jar:3.0.17]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at com.netflix.spinnaker.clouddriver.controllers.JobController.collectJob(JobController.groovy:52) ~[clouddriver-web-5.83.0.jar:5.83.0]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at com.netflix.spinnaker.clouddriver.controllers.JobController$$FastClassBySpringCGLIB$$890030fd.invoke(<generated>) ~[clouddriver-web-5.83.0.jar:5.83.0]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793) ~[spring-aop-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.security.access.intercept.aopalliance.MethodSecurityInterceptor.invoke(MethodSecurityInterceptor.java:61) ~[spring-security-core-5.5.8.jar:5.5.8]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708) ~[spring-aop-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at com.netflix.spinnaker.clouddriver.controllers.JobController$$EnhancerBySpringCGLIB$$92739c13.collectJob(<generated>) ~[clouddriver-web-5.83.0.jar:5.83.0]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at jdk.internal.reflect.GeneratedMethodAccessor368.invoke(Unknown Source) ~[na:na]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205) ~[spring-web-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150) ~[spring-web-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117) ~[spring-webmvc-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895) ~[spring-webmvc-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808) ~[spring-webmvc-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87) ~[spring-webmvc-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1072) ~[spring-webmvc-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:965) ~[spring-webmvc-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006) ~[spring-webmvc-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898) ~[spring-webmvc-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at javax.servlet.http.HttpServlet.service(HttpServlet.java:670) ~[tomcat-embed-core-9.0.69.jar:4.0.FR]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883) ~[spring-webmvc-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at javax.servlet.http.HttpServlet.service(HttpServlet.java:779) ~[tomcat-embed-core-9.0.69.jar:4.0.FR]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227) ~[tomcat-embed-core-9.0.69.jar:9.0.69]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat-embed-core-9.0.69.jar:9.0.69]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53) ~[tomcat-embed-websocket-9.0.69.jar:9.0.69]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189) ~[tomcat-embed-core-9.0.69.jar:9.0.69]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat-embed-core-9.0.69.jar:9.0.69]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.web.filter.ShallowEtagHeaderFilter.doFilterInternal(ShallowEtagHeaderFilter.java:106) ~[spring-web-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.27.jar:5.3.27]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189) ~[tomcat-embed-core-9.0.69.jar:9.0.69]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat-embed-core-9.0.69.jar:9.0.69]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:327) ~[spring-security-web-5.5.8.jar:5.5.8]
spin-clouddriver-57c75df64f-glzkq clouddriver 	at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:121) ~[spring-security-web-5.5.8.jar:5.5.8]
```
</details>

<hr>

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
