### PR TITLE
fix(kubernetes/job): Fix an edge case where a job can have no pods

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.java
@@ -95,9 +95,13 @@ public class KubernetesJobProvider implements JobProvider<KubernetesJobStatus> {
                 })
             .collect(Collectors.toList());
 
-    V1Pod mostRecentPod = typedPods.get(typedPods.size() - 1);
-    jobStatus.setMostRecentPodName(
-        mostRecentPod.getMetadata() != null ? mostRecentPod.getMetadata().getName() : "");
+    // Handle an edge case where a Job may not have any pods, for example
+    // if a webhook explicitly denies the creation of a pod
+    if (typedPods.size() != 0) {
+      V1Pod mostRecentPod = typedPods.get(typedPods.size() - 1);
+      jobStatus.setMostRecentPodName(
+          mostRecentPod.getMetadata() != null ? mostRecentPod.getMetadata().getName() : "");
+    }
 
     jobStatus.setPods(
         typedPods.stream().map(KubernetesJobStatus.PodStatus::new).collect(Collectors.toList()));


### PR DESCRIPTION
There is an edge case where in certain situations, a job can have 0 running pods. When clouddriver attempts to retrieve the pod name, it runs into an `IndexOutOfBoundsException`