### PR TITLE
feat(kubernetes): Skip applying labels to spec.template.metadata if skipSpecTemplateLabels is true

### DIFF
--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationConverter.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationConverter.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.orchestration;
 
 import com.netflix.spinnaker.kork.annotations.Beta;
+import com.netflix.spinnaker.orchestration.OperationDescription;
 import java.util.Map;
 import javax.annotation.Nullable;
 

--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/OperationDescription.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/OperationDescription.java
@@ -1,4 +1,0 @@
-package com.netflix.spinnaker.clouddriver.orchestration;
-
-/** Marker interface for inputs to an {@link AtomicOperation}. */
-public interface OperationDescription {}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/AllowLaunchDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/AllowLaunchDescription.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription
+import com.netflix.spinnaker.orchestration.OperationDescription
 
 class AllowLaunchDescription extends AbstractAmazonCredentialsDescription {
   String targetAccount

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/AzureResourceOpsDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/AzureResourceOpsDescription.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.azure.resources.common
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription
+import com.netflix.spinnaker.orchestration.OperationDescription
 
 class AzureResourceOpsDescription  implements OperationDescription {
   static ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)

--- a/clouddriver-cloudrun/src/main/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/UpsertCloudrunLoadBalancerAtomicOperationConverter.java
+++ b/clouddriver-cloudrun/src/main/java/com/netflix/spinnaker/clouddriver/cloudrun/deploy/converters/UpsertCloudrunLoadBalancerAtomicOperationConverter.java
@@ -22,8 +22,8 @@ import com.netflix.spinnaker.clouddriver.cloudrun.deploy.ops.UpsertCloudrunLoadB
 import com.netflix.spinnaker.clouddriver.cloudrun.security.CloudrunNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsConverter;
+import com.netflix.spinnaker.orchestration.OperationDescription;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/NoopAtomicOperationConverter.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/NoopAtomicOperationConverter.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.core
 
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationConverter
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription
+import com.netflix.spinnaker.orchestration.OperationDescription
 import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DefaultDescriptionAuthorizer.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DefaultDescriptionAuthorizer.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.deploy;
 
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription;
+import com.netflix.spinnaker.orchestration.OperationDescription;
 import org.springframework.validation.Errors;
 
 public class DefaultDescriptionAuthorizer implements DescriptionAuthorizer {

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DeployDescription.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DeployDescription.java
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.deploy;
 
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription;
 import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent;
+import com.netflix.spinnaker.orchestration.OperationDescription;
 import java.util.Collection;
 import java.util.Collections;
 

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizer.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizer.java
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.clouddriver.deploy;
 
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription;
+import com.netflix.spinnaker.orchestration.OperationDescription;
 import org.springframework.validation.Errors;
 
 /** Authorizes atomic operation description objects. */

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/OperationsService.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/OperationsService.java
@@ -32,6 +32,7 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 import com.netflix.spinnaker.clouddriver.security.AllowedAccountsValidator;
 import com.netflix.spinnaker.kork.exceptions.SystemException;
 import com.netflix.spinnaker.kork.web.exceptions.ExceptionMessageDecorator;
+import com.netflix.spinnaker.orchestration.OperationDescription;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.lang.reflect.Method;
 import java.util.ArrayList;

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/orchestration/AnnotationsBasedAtomicOperationsRegistrySpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/orchestration/AnnotationsBasedAtomicOperationsRegistrySpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.orchestration
 import com.netflix.spinnaker.clouddriver.core.CloudProvider
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
+import com.netflix.spinnaker.orchestration.OperationDescription
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/orchestration/OperationsServiceSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/orchestration/OperationsServiceSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.deploy.DefaultDescriptionAuthorizer
 import com.netflix.spinnaker.clouddriver.saga.persistence.SagaRepository
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.kork.web.exceptions.ExceptionMessageDecorator
+import com.netflix.spinnaker.orchestration.OperationDescription
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/clouddriver-elasticsearch/clouddriver-elasticsearch.gradle
+++ b/clouddriver-elasticsearch/clouddriver-elasticsearch.gradle
@@ -6,6 +6,7 @@ dependencies {
   implementation "com.netflix.frigga:frigga"
   implementation "io.searchbox:jest:6.3.1"
   implementation "io.spinnaker.kork:kork-exceptions"
+  implementation "io.spinnaker.kork:kork-moniker"
   implementation "io.spinnaker.kork:kork-retrofit"
   implementation "io.spinnaker.kork:kork-security"
   implementation "com.squareup.retrofit:retrofit"

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/descriptions/DeleteEntityTagsDescription.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/descriptions/DeleteEntityTagsDescription.java
@@ -17,8 +17,8 @@
 package com.netflix.spinnaker.clouddriver.elasticsearch.descriptions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription;
 import com.netflix.spinnaker.clouddriver.security.resources.NonCredentialed;
+import com.netflix.spinnaker.orchestration.OperationDescription;
 import java.util.List;
 
 public class DeleteEntityTagsDescription implements NonCredentialed, OperationDescription {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/ResizeGoogleServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/ResizeGoogleServerGroupAtomicOperationConverter.groovy
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvi
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.orchestration.*
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsConverter
+import com.netflix.spinnaker.orchestration.OperationDescription
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesDeployManifestDescription.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesDeployManifestDescription.java
@@ -43,6 +43,7 @@ public class KubernetesDeployManifestDescription extends KubernetesAtomicOperati
   private List<String> services;
   private Strategy strategy;
   private KubernetesSelectorList labelSelectors = new KubernetesSelectorList();
+  private boolean skipSpecTemplateLabels = false;
 
   /**
    * If false, and using (non-empty) label selectors, fail if a deploy manifest operation doesn't

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestLabeler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestLabeler.java
@@ -55,11 +55,22 @@ public class KubernetesManifestLabeler {
   }
 
   public static void labelManifest(
-      String managedBySuffix, KubernetesManifest manifest, Moniker moniker) {
+      String managedBySuffix,
+      KubernetesManifest manifest,
+      Moniker moniker,
+      Boolean skipSpecTemplateLabels) {
     Map<String, String> labels = manifest.getLabels();
     storeLabels(managedBySuffix, labels, moniker);
 
-    manifest.getSpecTemplateLabels().ifPresent(l -> storeLabels(managedBySuffix, l, moniker));
+    // Deployment fails for some Kubernetes resources (e.g. Karpenter NodePool) when
+    // the app.kubernetes.io/* labels are applied to the manifest's
+    // .spec.template.metadata.labels. If skipSpecTemplateLabels is
+    // set to true in the manifest description, Spinnaker won't apply
+    // the Kubernetes and Moniker labels
+    // to the .spec.template.metadata.labels of the manifest.
+    if (!skipSpecTemplateLabels) {
+      manifest.getSpecTemplateLabels().ifPresent(l -> storeLabels(managedBySuffix, l, moniker));
+    }
   }
 
   public static void storeLabels(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/names/KubernetesManifestNamer.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/names/KubernetesManifestNamer.java
@@ -17,11 +17,13 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.names;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesDeployManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifestAnnotater;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifestLabeler;
 import com.netflix.spinnaker.clouddriver.names.NamingStrategy;
 import com.netflix.spinnaker.moniker.Moniker;
+import com.netflix.spinnaker.orchestration.OperationDescription;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -50,9 +52,46 @@ public class KubernetesManifestNamer implements NamingStrategy<KubernetesManifes
 
   @Override
   public void applyMoniker(KubernetesManifest obj, Moniker moniker) {
+    applyMoniker(obj, moniker, null);
+  }
+
+  /**
+   * Applies the given Moniker to the specified KubernetesManifest. If the provided
+   * OperationDescription is an instance of KubernetesDeployManifestDescription, the method will
+   * annotate and label the manifest. If
+   * KubernetesDeployManifestDescription.isSkipSpecTemplateLabels() is true, skip applying the
+   * Kubernetes and Moniker labels to the manifest's spec.template.metadata.labels. If the
+   * OperationDescription is null, or the
+   * KubernetesDeployManifestDescription.isSkipSpecTemplateLabels() is false, apply the Kubernetes
+   * and Moniker labels to the manifest's spec.template.metadata.labels
+   *
+   * @param obj the KubernetesManifest to which the moniker will be applied
+   * @param moniker the moniker to apply
+   * @param description a description expected to be of type KubernetesDeployManifestDescription
+   *     that provides context for the operation.
+   */
+  @Override
+  public void applyMoniker(
+      KubernetesManifest obj, Moniker moniker, OperationDescription description) {
+    // The OperationDescription passed to this method must
+    // always have the dynamic type of KubernetesDeployManifestDescription.
+    // If not, fail the operation.
+    if (description != null && !(description instanceof KubernetesDeployManifestDescription)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "OperationDescription passed to Namer.applyMoniker() must be a KubernetesDeployManifestDescription for the KubernetesDeployManifestOperation. Provided description: %s",
+              description.getClass().getName()));
+    }
     KubernetesManifestAnnotater.annotateManifest(obj, moniker);
     if (applyAppLabels) {
-      KubernetesManifestLabeler.labelManifest(managedBySuffix, obj, moniker);
+      KubernetesDeployManifestDescription kubernetesDeployManifestDescription =
+          (KubernetesDeployManifestDescription) description;
+      boolean skipSpecTemplateLabels =
+          (kubernetesDeployManifestDescription != null)
+              ? kubernetesDeployManifestDescription.isSkipSpecTemplateLabels()
+              : false;
+      KubernetesManifestLabeler.labelManifest(
+          managedBySuffix, obj, moniker, skipSpecTemplateLabels);
     }
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
@@ -137,7 +137,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
                     }
                   }
 
-                  credentials.getNamer().applyMoniker(manifest, moniker);
+                  credentials.getNamer().applyMoniker(manifest, moniker, description);
                   manifest.setName(artifact.getReference());
 
                   return new ManifestArtifactHolder(manifest, artifact, strategy);

--- a/clouddriver-lambda/clouddriver-lambda.gradle
+++ b/clouddriver-lambda/clouddriver-lambda.gradle
@@ -12,6 +12,7 @@ dependencies {
   implementation "com.netflix.awsobjectmapper:awsobjectmapper"
   implementation "io.spinnaker.kork:kork-artifacts"
   implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-moniker"
   implementation "org.apache.commons:commons-lang3"
   implementation "org.apache.httpcomponents:httpclient"
   implementation "org.apache.httpcomponents:httpcore"

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/converter/NoOpOracleAtomicOperationConverter.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/converter/NoOpOracleAtomicOperationConverter.groovy
@@ -11,7 +11,7 @@ package com.netflix.spinnaker.clouddriver.oracle.deploy.converter
 import com.netflix.spinnaker.clouddriver.oracle.OracleOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription
+import com.netflix.spinnaker.orchestration.OperationDescription
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import org.springframework.stereotype.Component
 

--- a/clouddriver-security/clouddriver-security.gradle
+++ b/clouddriver-security/clouddriver-security.gradle
@@ -9,6 +9,7 @@ dependencies {
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
   implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-moniker"
   implementation "org.codehaus.groovy:groovy"
   implementation "org.slf4j:jcl-over-slf4j"
   implementation "org.springframework.boot:spring-boot-starter-web"

--- a/clouddriver-security/src/main/java/com/netflix/spinnaker/clouddriver/security/resources/AccountNameable.java
+++ b/clouddriver-security/src/main/java/com/netflix/spinnaker/clouddriver/security/resources/AccountNameable.java
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.security.resources;
 
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription;
 import com.netflix.spinnaker.clouddriver.security.config.SecurityConfig;
+import com.netflix.spinnaker.orchestration.OperationDescription;
 
 /** Denotes an operation description operates on a specific account. */
 public interface AccountNameable extends OperationDescription {

--- a/clouddriver-security/src/main/java/com/netflix/spinnaker/clouddriver/security/resources/ApplicationNameable.java
+++ b/clouddriver-security/src/main/java/com/netflix/spinnaker/clouddriver/security/resources/ApplicationNameable.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.security.resources;
 
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription;
+import com.netflix.spinnaker.orchestration.OperationDescription;
 import java.util.Collection;
 
 /** Denotes an operation description operates on one or more specific application resources. */

--- a/clouddriver-security/src/main/java/com/netflix/spinnaker/clouddriver/security/resources/NonCredentialed.java
+++ b/clouddriver-security/src/main/java/com/netflix/spinnaker/clouddriver/security/resources/NonCredentialed.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.security.resources;
 
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription;
+import com.netflix.spinnaker.orchestration.OperationDescription;
 
 /**
  * Marker interface indicating that a description does not have account-level credentials specified.

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/FeaturesControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/FeaturesControllerSpec.groovy
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.clouddriver.elasticsearch.converters.UpsertEntityTa
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationConverter
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription
+import com.netflix.spinnaker.orchestration.OperationDescription
 import org.springframework.stereotype.Component
 import spock.lang.Specification
 

--- a/clouddriver-yandex/src/test/java/com/netflix/spinnaker/clouddriver/yandex/deploy/TestCredentialSupport.java
+++ b/clouddriver-yandex/src/test/java/com/netflix/spinnaker/clouddriver/yandex/deploy/TestCredentialSupport.java
@@ -17,8 +17,8 @@
 package com.netflix.spinnaker.clouddriver.yandex.deploy;
 
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
-import com.netflix.spinnaker.clouddriver.orchestration.OperationDescription;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import com.netflix.spinnaker.orchestration.OperationDescription;
 import java.util.Map;
 import javax.annotation.Nullable;
 


### PR DESCRIPTION
Moved the OperationDescription from clouddriver-api to kork-moniker and updated all the relevant references. This will allow us to pass Manifest Description to the Namer class.

Setting skipSpecTemplateLabels to true, clouddriver will not apply the app.kubernetes.io/* labels to the manifests' spec.template.metadata.labels.

Kork PR that needs to be included prior to this: https://github.com/spinnaker/kork/pull/1199