### PR TITLE
perf(cache): Optimise heap usage in KubernetesCachingAgent

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesServiceHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesServiceHandler.java
@@ -160,7 +160,7 @@ public class KubernetesServiceHandler extends KubernetesHandler implements CanLo
 
     for (Map.Entry<String, String> label : podLabels.entrySet()) {
       String labelKey = podLabelKey(namespace, label);
-      enterManifest(entries, labelKey, KubernetesCacheDataConverter.convertToManifest(replicaSet));
+      enterManifest(entries, labelKey, replicaSet);
     }
   }
 


### PR DESCRIPTION
This pull request addresses a performance issue discovered in the Clouddriver, specifically within the `KubernetesServiceHandler.addAllReplicaSetLabels` method.

With allocation profiling I found that 40% of allocations happen for converting `replicaSet` object to `KubernetesManifest` class. The thing is that this conversion is redundant because `replicaSet` is already `KubernetesManifest`.

The objects aren't changed later, so it should be safe to stop parsing and making a copy. After this optimisation we reduced memory usage by half and also got rid of regular GC pauses.

Screenshots

Allocation profile:
![image](https://github.com/user-attachments/assets/34ff5656-b4ca-4507-8742-925ef371a5ed)

Memory usage:
![image](https://github.com/user-attachments/assets/d62a3f7c-696a-4813-80d8-38bdc6f58931)

GC pauses:
![image](https://github.com/user-attachments/assets/4f2d2617-5c3e-4787-b7ec-d26885760d99)

Memory allocation rate:
![image](https://github.com/user-attachments/assets/aa8436f6-e288-4bbd-a043-40284e2b2bbc)

GC promotion rate:
![image](https://github.com/user-attachments/assets/376c8618-d376-4919-984e-535b3b98193a)
