### PR TITLE
perf(ecs): Narrowing the cache search for the ECS provider on views

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
@@ -201,8 +201,8 @@ public class Keys implements KeyParser {
     return buildKey(Namespace.TASK_DEFINITIONS.ns, account, region, taskDefinitionArn);
   }
 
-  public static String getAlarmKey(String account, String region, String alarmArn) {
-    return buildKey(Namespace.ALARMS.ns, account, region, alarmArn);
+  public static String getAlarmKey(String account, String region, String alarmArn, String cluster) {
+    return buildKey(Namespace.ALARMS.ns, account, region, alarmArn + SEPARATOR + cluster);
   }
 
   public static String getScalableTargetKey(String account, String region, String resourceId) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/AbstractCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/AbstractCacheClient.java
@@ -65,6 +65,11 @@ abstract class AbstractCacheClient<T> {
     return convertAll(data);
   }
 
+  public Collection<T> getAll(Collection<String> identifiers) {
+    Collection<CacheData> allData = cacheView.getAll(keyNamespace, identifiers);
+    return convertAll(allData);
+  }
+
   /**
    * @param key A key within the key namespace that will be used to retrieve the object.
    * @return An object of the generic type that is associated to the key.
@@ -109,5 +114,9 @@ abstract class AbstractCacheClient<T> {
     }
 
     return allData;
+  }
+
+  public Collection<String> filterIdentifiers(String glob) {
+    return cacheView.filterIdentifiers(keyNamespace, glob);
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/AbstractCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/AbstractCacheClient.java
@@ -67,6 +67,9 @@ abstract class AbstractCacheClient<T> {
 
   public Collection<T> getAll(Collection<String> identifiers) {
     Collection<CacheData> allData = cacheView.getAll(keyNamespace, identifiers);
+    if (allData == null) {
+      return Collections.emptyList();
+    }
     return convertAll(allData);
   }
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsCloudWatchAlarmCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsCloudWatchAlarmCacheClient.java
@@ -73,6 +73,8 @@ public class EcsCloudWatchAlarmCacheClient extends AbstractCacheClient<EcsMetric
   public List<EcsMetricAlarm> getMetricAlarms(
       String serviceName, String accountName, String region) {
     List<EcsMetricAlarm> metricAlarms = new LinkedList<>();
+    // we can filter more here.
+
     Collection<EcsMetricAlarm> allMetricAlarms = getAll(accountName, region);
 
     outLoop:

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsCloudWatchAlarmCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsCloudWatchAlarmCacheClient.java
@@ -20,6 +20,7 @@ import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ALARMS;
 
 import com.netflix.spinnaker.cats.cache.Cache;
 import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsMetricAlarm;
 import java.util.Collection;
 import java.util.Collections;
@@ -71,33 +72,19 @@ public class EcsCloudWatchAlarmCacheClient extends AbstractCacheClient<EcsMetric
   }
 
   public List<EcsMetricAlarm> getMetricAlarms(
-      String serviceName, String accountName, String region) {
+      String serviceName, String accountName, String region, String ecsClusterName) {
     List<EcsMetricAlarm> metricAlarms = new LinkedList<>();
-    // we can filter more here.
 
-    Collection<EcsMetricAlarm> allMetricAlarms = getAll(accountName, region);
+    String glob = Keys.getAlarmKey(accountName, region, "*", ecsClusterName);
+    Collection<String> metricAlarmsIds = filterIdentifiers(glob);
+    Collection<EcsMetricAlarm> allMetricAlarms = getAll(metricAlarmsIds);
 
-    outLoop:
     for (EcsMetricAlarm metricAlarm : allMetricAlarms) {
-      for (String action : metricAlarm.getAlarmActions()) {
-        if (action.contains(serviceName)) {
-          metricAlarms.add(metricAlarm);
-          continue outLoop;
-        }
-      }
-
-      for (String action : metricAlarm.getOKActions()) {
-        if (action.contains(serviceName)) {
-          metricAlarms.add(metricAlarm);
-          continue outLoop;
-        }
-      }
-
-      for (String action : metricAlarm.getInsufficientDataActions()) {
-        if (action.contains(serviceName)) {
-          metricAlarms.add(metricAlarm);
-          continue outLoop;
-        }
+      if (metricAlarm.getAlarmActions().stream().anyMatch(action -> action.contains(serviceName))
+          || metricAlarm.getOKActions().stream().anyMatch(action -> action.contains(serviceName))
+          || metricAlarm.getInsufficientDataActions().stream()
+              .anyMatch(action -> action.contains(serviceName))) {
+        metricAlarms.add(metricAlarm);
       }
     }
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperation.java
@@ -45,7 +45,10 @@ public class DestroyServiceAtomicOperation
 
     updateTaskStatus("Removing MetricAlarms from " + description.getServerGroupName() + ".");
     ecsCloudMetricService.deleteMetrics(
-        description.getServerGroupName(), description.getAccount(), description.getRegion());
+        description.getServerGroupName(),
+        description.getAccount(),
+        description.getRegion(),
+        ecsClusterName);
     updateTaskStatus("Done removing MetricAlarms from " + description.getServerGroupName() + ".");
 
     UpdateServiceRequest updateServiceRequest = new UpdateServiceRequest();

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/EcsApplication.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/EcsApplication.java
@@ -26,11 +26,16 @@ public class EcsApplication implements Application {
   private String name;
   Map<String, String> attributes;
   Map<String, Set<String>> clusterNames;
+  Map<String, Set<String>> clusterNameMetadata;
 
   public EcsApplication(
-      String name, Map<String, String> attributes, Map<String, Set<String>> clusterNames) {
+      String name,
+      Map<String, String> attributes,
+      Map<String, Set<String>> clusterNames,
+      Map<String, Set<String>> getClusterNameMetadata) {
     this.name = name;
     this.attributes = attributes;
     this.clusterNames = clusterNames;
+    this.clusterNameMetadata = getClusterNameMetadata;
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgent.java
@@ -118,7 +118,13 @@ public class EcsCloudMetricAlarmCachingAgent implements CachingAgent, AccountAwa
     Map<String, Collection<CacheData>> newDataMap = new HashMap<>();
 
     for (MetricAlarm metricAlarm : cacheableMetricAlarm) {
-      String key = Keys.getAlarmKey(accountName, region, metricAlarm.getAlarmArn());
+      String cluster =
+          metricAlarm.getDimensions().stream()
+              .filter(t -> t.getName().equalsIgnoreCase("ClusterName"))
+              .map(t -> t.getValue())
+              .collect(Collectors.joining());
+
+      String key = Keys.getAlarmKey(accountName, region, metricAlarm.getAlarmArn(), cluster);
       Map<String, Object> attributes =
           convertMetricAlarmToAttributes(metricAlarm, accountName, region);
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsClusterProvider.java
@@ -23,6 +23,7 @@ import com.amazonaws.services.ecs.model.DescribeClustersResult;
 import com.google.common.collect.Lists;
 import com.netflix.spinnaker.cats.cache.Cache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.EcsClusterCacheClient;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsCluster;
 import com.netflix.spinnaker.clouddriver.ecs.security.NetflixECSCredentials;
@@ -55,9 +56,11 @@ public class EcsClusterProvider {
   // TODO include[] input of Describe Cluster is not a part of this implementation, need to
   // implement in the future if additional properties are needed.
   public Collection<Cluster> getEcsClusterDescriptions(String account, String region) {
+    String glob = Keys.getClusterKey(account, region, "*");
+    Collection<String> ecsClustersIdentifiers = ecsClusterCacheClient.filterIdentifiers(glob);
     Collection<Cluster> clusters = new ArrayList<>();
     List<String> filteredEcsClusters =
-        ecsClusterCacheClient.getAll().stream()
+        ecsClusterCacheClient.getAll(ecsClustersIdentifiers).stream()
             .filter(
                 cluster ->
                     account.equals(cluster.getAccount()) && region.equals(cluster.getRegion()))

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -120,8 +120,13 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
       AmazonCredentials.AWSRegion awsRegion,
       String application) {
 
-    Collection<Service> services =
-        serviceCacheClient.getAll(credentials.getName(), awsRegion.getName());
+    String glob =
+        application != null
+            ? Keys.getServiceKey(credentials.getName(), awsRegion.getName(), application + "*")
+            : Keys.getServiceKey(credentials.getName(), awsRegion.getName(), "*");
+
+    Collection<String> ecsServices = serviceCacheClient.filterIdentifiers(glob);
+    Collection<Service> services = serviceCacheClient.getAll(ecsServices);
     Collection<Task> allTasks = taskCacheClient.getAll(credentials.getName(), awsRegion.getName());
 
     for (Service service : services) {
@@ -456,18 +461,12 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
 
   @Override
   public Map<String, Set<EcsServerCluster>> getClusterSummaries(String application) {
-    return getClusters();
+    return getClusters0(application);
   }
 
   @Override
   public Map<String, Set<EcsServerCluster>> getClusterDetails(String application) {
-    Map<String, Set<EcsServerCluster>> clusterMap = new HashMap<>();
-
-    for (AmazonCredentials credentials : getEcsCredentials()) {
-      clusterMap = findClusters(clusterMap, credentials, application);
-    }
-
-    return clusterMap;
+    return getClusters0(application);
   }
 
   @Override
@@ -476,6 +475,15 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
 
     for (AmazonCredentials credentials : getEcsCredentials()) {
       clusterMap = findClusters(clusterMap, credentials);
+    }
+    return clusterMap;
+  }
+
+  public Map<String, Set<EcsServerCluster>> getClusters0(String application) {
+    Map<String, Set<EcsServerCluster>> clusterMap = new HashMap<>();
+
+    for (AmazonCredentials credentials : getEcsCredentials()) {
+      clusterMap = findClusters(clusterMap, credentials, application);
     }
     return clusterMap;
   }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/EcsCloudMetricService.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/EcsCloudMetricService.java
@@ -43,9 +43,10 @@ public class EcsCloudMetricService {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
-  public void deleteMetrics(String serviceName, String account, String region) {
+  public void deleteMetrics(
+      String serviceName, String account, String region, String ecsClusterName) {
     List<EcsMetricAlarm> metricAlarms =
-        metricAlarmCacheClient.getMetricAlarms(serviceName, account, region);
+        metricAlarmCacheClient.getMetricAlarms(ecsClusterName, serviceName, account, region);
 
     if (metricAlarms.isEmpty()) {
       return;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsApplicationProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsApplicationProvider.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.ecs.view;
 
 import com.google.common.collect.Sets;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
+import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.ServiceCacheClient;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.Service;
 import com.netflix.spinnaker.clouddriver.ecs.model.EcsApplication;
@@ -50,31 +51,32 @@ public class EcsApplicationProvider implements ApplicationProvider {
 
   @Override
   public Application getApplication(String name) {
-
-    for (Application application : getApplications(true)) {
+    name = name.toLowerCase();
+    String glob = Keys.getServiceKey("*", "*", name + "*");
+    Collection<String> ecsServices = serviceCacheClient.filterIdentifiers(glob);
+    for (Application application : populateApplicationSet(ecsServices, true)) {
       if (name.equals(application.getName())) {
         return application;
       }
     }
-
     return null;
   }
 
   @Override
-  public Set<Application> getApplications(boolean expand) {
-    Set<Application> applications = new HashSet<>();
-
+  public Set<EcsApplication> getApplications(boolean expand) {
+    Set<EcsApplication> applications = new HashSet<>();
     for (NetflixECSCredentials credentials : credentialsRepository.getAll()) {
-      Set<Application> retrievedApplications = findApplicationsForAllRegions(credentials, expand);
+      Set<EcsApplication> retrievedApplications =
+          findApplicationsForAllRegions(credentials, expand);
       applications.addAll(retrievedApplications);
     }
 
     return applications;
   }
 
-  private Set<Application> findApplicationsForAllRegions(
+  private Set<EcsApplication> findApplicationsForAllRegions(
       AmazonCredentials credentials, boolean expand) {
-    Set<Application> applications = new HashSet<>();
+    Set<EcsApplication> applications = new HashSet<>();
 
     for (AmazonCredentials.AWSRegion awsRegion : credentials.getRegions()) {
       applications.addAll(
@@ -84,16 +86,16 @@ public class EcsApplicationProvider implements ApplicationProvider {
     return applications;
   }
 
-  private Set<Application> findApplicationsForRegion(
+  private Set<EcsApplication> findApplicationsForRegion(
       String account, String region, boolean expand) {
-    HashMap<String, Application> applicationHashMap =
+    HashMap<String, EcsApplication> applicationHashMap =
         populateApplicationMap(account, region, expand);
     return transposeApplicationMapToSet(applicationHashMap);
   }
 
-  private HashMap<String, Application> populateApplicationMap(
+  private HashMap<String, EcsApplication> populateApplicationMap(
       String account, String region, boolean expand) {
-    HashMap<String, Application> applicationHashMap = new HashMap<>();
+    HashMap<String, EcsApplication> applicationHashMap = new HashMap<>();
     Collection<Service> services = serviceCacheClient.getAll(account, region);
 
     for (Service service : services) {
@@ -102,19 +104,32 @@ public class EcsApplicationProvider implements ApplicationProvider {
     return applicationHashMap;
   }
 
-  private Set<Application> transposeApplicationMapToSet(
-      HashMap<String, Application> applicationHashMap) {
-    Set<Application> applications = new HashSet<>();
+  private Set<EcsApplication> populateApplicationSet(
+      Collection<String> identifiers, boolean expand) {
+    HashMap<String, EcsApplication> applicationHashMap = new HashMap<>();
+    Collection<Service> services = serviceCacheClient.getAll(identifiers);
 
-    for (Map.Entry<String, Application> entry : applicationHashMap.entrySet()) {
+    for (Service service : services) {
+      if (credentialsRepository.has(service.getAccount())) {
+        applicationHashMap = inferApplicationFromServices(applicationHashMap, service, expand);
+      }
+    }
+    return transposeApplicationMapToSet(applicationHashMap);
+  }
+
+  private Set<EcsApplication> transposeApplicationMapToSet(
+      HashMap<String, EcsApplication> applicationHashMap) {
+    Set<EcsApplication> applications = new HashSet<>();
+
+    for (Map.Entry<String, EcsApplication> entry : applicationHashMap.entrySet()) {
       applications.add(entry.getValue());
     }
 
     return applications;
   }
 
-  private HashMap<String, Application> inferApplicationFromServices(
-      HashMap<String, Application> applicationHashMap, Service service, boolean expand) {
+  private HashMap<String, EcsApplication> inferApplicationFromServices(
+      HashMap<String, EcsApplication> applicationHashMap, Service service, boolean expand) {
 
     HashMap<String, String> attributes = new HashMap<>();
     Moniker moniker = service.getMoniker();
@@ -125,18 +140,31 @@ public class EcsApplicationProvider implements ApplicationProvider {
     attributes.put("name", appName);
 
     HashMap<String, Set<String>> clusterNames = new HashMap<>();
+    HashMap<String, Set<String>> clusterNamesMetadata = new HashMap<>();
+
     if (expand) {
       clusterNames.put(accountName, Sets.newHashSet(serviceName));
+      clusterNamesMetadata.put(accountName, Sets.newHashSet(moniker.getCluster()));
     }
 
-    EcsApplication application = new EcsApplication(appName, attributes, clusterNames);
+    EcsApplication application =
+        new EcsApplication(appName, attributes, clusterNames, clusterNamesMetadata);
 
     if (!applicationHashMap.containsKey(appName)) {
       applicationHashMap.put(appName, application);
     } else {
       applicationHashMap.get(appName).getAttributes().putAll(application.getAttributes());
       if (expand) {
-        applicationHashMap.get(appName).getClusterNames().get(accountName).add(serviceName);
+        applicationHashMap
+            .get(appName)
+            .getClusterNames()
+            .computeIfAbsent(accountName, k -> Sets.newHashSet())
+            .add(serviceName);
+        applicationHashMap
+            .get(appName)
+            .getClusterNameMetadata()
+            .computeIfAbsent(accountName, k -> Sets.newHashSet())
+            .add(moniker.getCluster());
       }
     }
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsApplicationProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsApplicationProvider.java
@@ -51,7 +51,6 @@ public class EcsApplicationProvider implements ApplicationProvider {
 
   @Override
   public Application getApplication(String name) {
-    name = name.toLowerCase();
     String glob = Keys.getServiceKey("*", "*", name + "*");
     Collection<String> ecsServices = serviceCacheClient.filterIdentifiers(glob);
     for (Application application : populateApplicationSet(ecsServices, true)) {

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsCloudWatchAlarmCacheClientSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsCloudWatchAlarmCacheClientSpec.groovy
@@ -16,27 +16,58 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.cache
 
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.amazonaws.services.cloudwatch.model.Dimension
+import com.amazonaws.services.cloudwatch.model.MetricAlarm
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.EcsCloudWatchAlarmCacheClient
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsMetricAlarm
+import com.netflix.spinnaker.clouddriver.ecs.provider.agent.CommonCachingAgent
 import com.netflix.spinnaker.clouddriver.ecs.provider.agent.EcsCloudMetricAlarmCachingAgent
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
 
 class EcsCloudWatchAlarmCacheClientSpec extends Specification {
-  def cacheView = Mock(Cache)
   @Subject
-  EcsCloudWatchAlarmCacheClient client = new EcsCloudWatchAlarmCacheClient(cacheView)
+  EcsCloudWatchAlarmCacheClient client
+
+  @Subject
+  EcsCloudMetricAlarmCachingAgent agent
+
+  @Shared
+  String ACCOUNT = 'test-account'
+
+  @Shared
+  String REGION = 'us-west-1'
+
+  Cache cacheView
+  AmazonCloudWatch cloudWatch
+  AmazonClientProvider clientProvider
+  ProviderCache providerCache
+  AWSCredentialsProvider credentialsProvider
+
+  def setup() {
+    cacheView = Mock(Cache)
+    client = new EcsCloudWatchAlarmCacheClient(cacheView)
+    cloudWatch = Mock(AmazonCloudWatch)
+    clientProvider = Mock(AmazonClientProvider)
+    providerCache = Mock(ProviderCache)
+    credentialsProvider = Mock(AWSCredentialsProvider)
+    agent = new EcsCloudMetricAlarmCachingAgent(CommonCachingAgent.netflixAmazonCredentials, REGION, clientProvider)
+  }
 
   def 'should convert cache data into object'() {
     given:
-    def accountName = 'test-account-1'
-    def region = 'us-west-1'
-    def metricAlarm = new EcsMetricAlarm().withAlarmName("alarm-name").withAlarmArn("alarmArn").withRegion(region).withAccountName(accountName)
-    def key = Keys.getAlarmKey(accountName, region, metricAlarm.getAlarmArn())
-    def attributes = EcsCloudMetricAlarmCachingAgent.convertMetricAlarmToAttributes(metricAlarm, accountName, region)
 
+    def ecsClusterName = 'my-cluster'
+    def metricAlarm = new EcsMetricAlarm().withAlarmName("alarm-name").withAlarmArn("alarmArn").withRegion(REGION).withAccountName(ACCOUNT)
+    def key = Keys.getAlarmKey(ACCOUNT, REGION, metricAlarm.getAlarmArn(), ecsClusterName)
+    def attributes = EcsCloudMetricAlarmCachingAgent.convertMetricAlarmToAttributes(metricAlarm, ACCOUNT, REGION)
     when:
     def returnedMetricAlarm = client.get(key)
 
@@ -44,4 +75,175 @@ class EcsCloudWatchAlarmCacheClientSpec extends Specification {
     cacheView.get(Keys.Namespace.ALARMS.ns, key) >> new DefaultCacheData(key, attributes, [:])
     returnedMetricAlarm == metricAlarm
   }
+
+
+  def 'should return metric alarms for a service - single cluster'() {
+    given:
+    def serviceName = 'my-service'
+    def serviceName2 = 'not-matching-service'
+
+    def ecsClusterName = 'my-cluster'
+    def metricAlarms = Set.of(
+      new MetricAlarm().withAlarmName("alarm-name").withAlarmArn("alarmArn")
+      .withAlarmActions("arn:aws:sns:us-west-1:123456789012:${serviceName}")
+      .withDimensions([new Dimension().withName("ClusterName").withValue(ecsClusterName)]),
+      new MetricAlarm().withAlarmName("alarm-name-2").withAlarmArn("alarmArn2")
+        .withAlarmActions("arn:aws:sns:us-west-1:123456789012:${serviceName}")
+        .withDimensions([new Dimension().withName("ClusterName").withValue(ecsClusterName)]),
+      new MetricAlarm().withAlarmName("alarm-name").withAlarmArn("alarmArn3")
+        .withAlarmActions("arn:aws:sns:us-west-1:123456789012:${serviceName2}")
+        .withDimensions([new Dimension().withName("ClusterName").withValue(ecsClusterName)])
+    )
+    def keys = metricAlarms.collect { alarm ->
+      def key = Keys.getAlarmKey(ACCOUNT, REGION, alarm.getAlarmArn(), ecsClusterName)
+      def attributes = agent.convertMetricAlarmToAttributes(alarm, ACCOUNT, REGION)
+      [key, new DefaultCacheData(key, attributes, [:])]
+    }
+
+    cacheView.filterIdentifiers(Keys.Namespace.ALARMS.ns, _) >> keys*.first()
+    cacheView.getAll(Keys.Namespace.ALARMS.ns, _) >>  keys*.last()
+
+    when:
+    def metricAlarmsReturned = client.getMetricAlarms(serviceName, ACCOUNT, REGION, ecsClusterName)
+
+    then:
+    metricAlarmsReturned.size() == 2
+    metricAlarmsReturned*.alarmName.containsAll(["alarm-name", "alarm-name-2"])
+    metricAlarmsReturned*.alarmArn.containsAll(["alarmArn", "alarmArn2"])
+    !metricAlarmsReturned*.alarmArn.contains(["alarmArn3"])
+}
+
+  def 'should return metric alarms for a service - multiple clusters'() {
+    given:
+    def serviceName = 'my-service'
+
+    def ecsClusterName = 'my-cluster'
+    def ecsClusterName2 = 'my-cluster-2'
+    def metricAlarm1 = new MetricAlarm().withAlarmName("alarm-name").withAlarmArn("alarmArn")
+      .withAlarmActions("arn:aws:sns:us-west-1:123456789012:${serviceName}")
+      .withDimensions([new Dimension().withName("ClusterName").withValue(ecsClusterName)])
+    def metricAlarm2 = new MetricAlarm().withAlarmName("alarm-name-2").withAlarmArn("alarmArn2")
+      .withAlarmActions("arn:aws:sns:us-west-1:123456789012:${serviceName}")
+      .withDimensions([new Dimension().withName("ClusterName").withValue(ecsClusterName)])
+    def metricAlarm3 =  new MetricAlarm().withAlarmName("alarm-name3").withAlarmArn("alarmArn3")
+      .withAlarmActions("arn:aws:sns:us-west-1:123456789012:${serviceName}")
+      .withDimensions([new Dimension().withName("ClusterName").withValue(ecsClusterName2)])
+
+    def key1 = Keys.getAlarmKey(ACCOUNT, REGION, metricAlarm1.getAlarmArn(), ecsClusterName)
+    def attributes1 = agent.convertMetricAlarmToAttributes(metricAlarm1, ACCOUNT, REGION)
+    def key2 = Keys.getAlarmKey(ACCOUNT, REGION, metricAlarm2.getAlarmArn(), ecsClusterName)
+    def attributes2 = agent.convertMetricAlarmToAttributes(metricAlarm2, ACCOUNT, REGION)
+    def key3 = Keys.getAlarmKey(ACCOUNT, REGION, metricAlarm3.getAlarmArn(), ecsClusterName2)
+    def attributes3 = agent.convertMetricAlarmToAttributes(metricAlarm3, ACCOUNT, REGION)
+
+
+    cacheView.filterIdentifiers(Keys.Namespace.ALARMS.ns, Keys.getAlarmKey(ACCOUNT, REGION, "*", ecsClusterName)) >> [key1,key2]
+    cacheView.filterIdentifiers(Keys.Namespace.ALARMS.ns, Keys.getAlarmKey(ACCOUNT, REGION, "*", ecsClusterName2)) >> [key3]
+    cacheView.getAll(Keys.Namespace.ALARMS.ns, [key1,key2]) >> [
+      new DefaultCacheData(key1, attributes1, [:]),
+      new DefaultCacheData(key2, attributes2, [:])
+    ]
+    cacheView.getAll(Keys.Namespace.ALARMS.ns, [key3]) >> [
+      new DefaultCacheData(key3, attributes3, [:])
+    ]
+    when:
+    def metricAlarmsReturned = client.getMetricAlarms(serviceName, ACCOUNT, REGION, ecsClusterName)
+    def metricAlarmsReturned2 = client.getMetricAlarms(serviceName, ACCOUNT, REGION, ecsClusterName2)
+
+    then:
+    metricAlarmsReturned.size() == 2
+    metricAlarmsReturned*.alarmName.containsAll(["alarm-name", "alarm-name-2"])
+    metricAlarmsReturned*.alarmArn.containsAll(["alarmArn", "alarmArn2"])
+    !metricAlarmsReturned*.alarmArn.contains(["alarmArn3"])
+    metricAlarmsReturned2.size() == 1
+    metricAlarmsReturned2*.alarmName.containsAll(["alarm-name3"])
+    !metricAlarmsReturned2*.alarmArn.containsAll(["alarmArn", "alarmArn2"])
+    metricAlarmsReturned2*.alarmArn.containsAll(["alarmArn3"])
+  }
+
+def 'should return empty list if no metric alarms match the service'() {
+  given:
+  def serviceName = 'my-service'
+
+  def ecsClusterName = 'my-cluster'
+  def metricAlarms = Set.of(new MetricAlarm().withAlarmName("alarm-name").withAlarmArn("alarmArn")
+    .withAlarmActions("arn:aws:sns:us-west-1:123456789012:${serviceName}")
+    .withDimensions([new Dimension().withName("ClusterName").withValue(ecsClusterName)]))
+  def key = Keys.getAlarmKey(ACCOUNT, REGION, metricAlarms[0].getAlarmArn(), ecsClusterName)
+  def attributes = agent.convertMetricAlarmToAttributes(metricAlarms[0], ACCOUNT, REGION)
+
+  cacheView.filterIdentifiers(Keys.Namespace.ALARMS.ns, _) >> [key]
+  cacheView.getAll(Keys.Namespace.ALARMS.ns, _) >> [
+    new DefaultCacheData(key, attributes, [:])
+  ]
+
+  when:
+  def metricAlarmsReturned = client.getMetricAlarms("some-other-service", ACCOUNT, REGION, ecsClusterName)
+
+  then:
+  metricAlarmsReturned.isEmpty()
+}
+
+def 'should return metric alarms with actions matching the service'() {
+  given:
+  def serviceName = 'my-service'
+
+  def ecsClusterName = 'my-cluster'
+  def metricAlarms = Set.of(
+    new MetricAlarm().withAlarmName("alarm-name").withAlarmArn("alarmArn")
+      .withAlarmActions("arn:aws:sns:us-west-1:123456789012:${serviceName}-AlarmsActions")
+      .withOKActions("arn:aws:sns:us-west-1:123456789012:${serviceName}-OKActions")
+      .withInsufficientDataActions("arn:aws:sns:us-west-1:123456789012:${serviceName}-InsufficientDataActions")
+      .withDimensions([new Dimension().withName("ClusterName").withValue(ecsClusterName)]),
+    new MetricAlarm().withAlarmName("alarm-name-2").withAlarmArn("alarmArn2")
+      .withDimensions([new Dimension().withName("ClusterName").withValue(ecsClusterName)]),
+    new MetricAlarm().withAlarmName("alarm-name-3").withAlarmArn("alarmArn3")
+      .withAlarmActions(
+        "arn:aws:sns:us-west-1:123456789012:${serviceName}-AlarmsActions1",
+        "arn:aws:sns:us-west-1:123456789012:${serviceName}-AlarmsActions2",
+        "arn:aws:sns:us-west-1:123456789012:${serviceName}-AlarmsActions3"
+      )
+      .withOKActions(
+        "arn:aws:sns:us-west-1:123456789012:${serviceName}-OKActions1"
+      )
+      .withInsufficientDataActions(
+        "arn:aws:sns:us-west-1:123456789012:${serviceName}-InsufficientDataActions1"
+      )
+      .withDimensions([new Dimension().withName("ClusterName").withValue(ecsClusterName)])
+  )
+  def keys = metricAlarms.collect { alarm ->
+    def key = Keys.getAlarmKey(ACCOUNT, REGION, alarm.getAlarmArn(), ecsClusterName)
+    def attributes = agent.convertMetricAlarmToAttributes(alarm, ACCOUNT, REGION)
+    [key, new DefaultCacheData(key, attributes, [:])]
+  }
+
+  cacheView.filterIdentifiers(Keys.Namespace.ALARMS.ns, _) >> keys*.first()
+  cacheView.getAll(Keys.Namespace.ALARMS.ns, _) >>  keys*.last()
+
+  when:
+  def metricAlarmsReturned = client.getMetricAlarms(serviceName, ACCOUNT, REGION, ecsClusterName)
+
+  then:
+  metricAlarmsReturned.size() == 2
+  metricAlarmsReturned*.alarmName.containsAll(["alarm-name", "alarm-name-3"])
+  metricAlarmsReturned*.alarmArn.containsAll(["alarmArn", "alarmArn3"])
+  metricAlarmsReturned*.alarmActions.flatten().size() == 4
+  metricAlarmsReturned*.OKActions.flatten().size() == 2
+  metricAlarmsReturned*.insufficientDataActions.flatten().size() == 2
+  metricAlarmsReturned*.OKActions.flatten().sort() == List.of(
+    "arn:aws:sns:us-west-1:123456789012:${serviceName}-OKActions",
+    "arn:aws:sns:us-west-1:123456789012:${serviceName}-OKActions1"
+  )
+  metricAlarmsReturned*.alarmActions.flatten().sort() == List.of(
+    "arn:aws:sns:us-west-1:123456789012:${serviceName}-AlarmsActions",
+    "arn:aws:sns:us-west-1:123456789012:${serviceName}-AlarmsActions1",
+    "arn:aws:sns:us-west-1:123456789012:${serviceName}-AlarmsActions2",
+    "arn:aws:sns:us-west-1:123456789012:${serviceName}-AlarmsActions3"
+  )
+  metricAlarmsReturned*.insufficientDataActions.flatten().sort() == List.of(
+    "arn:aws:sns:us-west-1:123456789012:${serviceName}-InsufficientDataActions",
+    "arn:aws:sns:us-west-1:123456789012:${serviceName}-InsufficientDataActions1"
+  )
+}
+
 }

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsClusterProviderSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsClusterProviderSpec.groovy
@@ -47,6 +47,7 @@ class EcsClusterProviderSpec extends Specification {
     Set<String> clusterNames = new HashSet<>()
     Collection<CacheData> cacheData = new HashSet<>()
     Collection<Cluster> clustersResponse = new ArrayList<>()
+    Collection<String> ecsClustersIdentifiers = new ArrayList<>()
     clusterNames.add("example-app-test-Cluster-NSnYsTXmCfV2")
     clusterNames.add("TestCluster")
     clusterNames.add("spinnaker-deployment-cluster")
@@ -54,6 +55,7 @@ class EcsClusterProviderSpec extends Specification {
     for (int x = 0; x < numberOfClusters; x++) {
       String clusterKey = Keys.getClusterKey(ACCOUNT, REGION, clusterNames[x])
       Map<String, Object> attributes = new HashMap<>()
+      ecsClustersIdentifiers.add(Keys.getClusterKey(ACCOUNT, REGION, clusterNames[x]))
       attributes.put("account", ACCOUNT)
       attributes.put("region", REGION)
       attributes.put("clusterArn", "arn:aws:ecs:::cluster/" + clusterNames[x])
@@ -61,7 +63,8 @@ class EcsClusterProviderSpec extends Specification {
 
       cacheData.add(new DefaultCacheData(clusterKey, attributes, Collections.emptyMap()))
     }
-    cacheView.getAll(_) >> cacheData
+    cacheView.filterIdentifiers(_, _) >> ecsClustersIdentifiers
+    cacheView.getAll(_, ecsClustersIdentifiers) >> cacheData
 
     for (int x = 0; x < numberOfClusters; x++) {
       Cluster cluster = new Cluster()
@@ -102,12 +105,14 @@ class EcsClusterProviderSpec extends Specification {
     Set<String> clusterNames = new HashSet<>()
     Collection<CacheData> cacheData = new HashSet<>()
     Collection<Cluster> clustersResponse = new ArrayList<>()
+    Collection<String> ecsClustersIdentifiers = new ArrayList<>()
     clusterNames.add("example-app-test-Cluster-NSnYsTXmCfV2")
     clusterNames.add("TestCluster")
     clusterNames.add("spinnaker-deployment-cluster")
 
     for (int x = 0; x < 2; x++) {
       String clusterKey = Keys.getClusterKey(ACCOUNT, REGION, clusterNames[x])
+      ecsClustersIdentifiers.add(Keys.getClusterKey(ACCOUNT, REGION, clusterNames[x]))
       Map<String, Object> attributes = new HashMap<>()
       attributes.put("account", ACCOUNT)
       attributes.put("region", REGION)
@@ -126,8 +131,8 @@ class EcsClusterProviderSpec extends Specification {
 
     cacheData.add(new DefaultCacheData(clusterKey, attributes, Collections.emptyMap()))
 
-
-    cacheView.getAll(_) >> cacheData
+    cacheView.filterIdentifiers(_, _) >> ecsClustersIdentifiers
+    cacheView.getAll(_, ecsClustersIdentifiers) >> cacheData
 
     //Adding only two clusters in the response which belongs to the expected region.
     for (int x = 0; x < 2; x++) {

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProviderSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProviderSpec.groovy
@@ -174,7 +174,7 @@ class EcsLoadBalancerProviderSpec extends Specification {
     def loadBalancerList = provider.getApplicationLoadBalancers(applicationName)
 
     then:
-    mockServiceCache.getAll() >> Collections.singletonList(ecsService)
+    mockServiceCache.getAll(_) >> Collections.singletonList(ecsService)
     mockTargetGroupCache.getAllKeys() >> ['fake-tg-key-1', 'fake-tg-key-2']
     mockTargetGroupCache.find(_) >> [ecsTg1, ecsTg2]
     mockLBCache.findWithTargetGroups(_) >> [ecsLoadBalancerCache1, ecsLoadBalancerCache2]
@@ -249,7 +249,7 @@ class EcsLoadBalancerProviderSpec extends Specification {
     def loadBalancerList = provider.getApplicationLoadBalancers(applicationName)
 
     then:
-    mockServiceCache.getAll() >> [ecsService1, ecsService2]
+    mockServiceCache.getAll(_) >> [ecsService1, ecsService2]
     mockTargetGroupCache.getAllKeys() >> ['fake-tg-key-1']
     mockTargetGroupCache.find(_) >> [ecsTg]
     mockLBCache.findWithTargetGroups(_) >> Collections.singletonList(ecsLoadBalancerCache)

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProviderSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProviderSpec.groovy
@@ -191,7 +191,7 @@ class EcsServerClusterProviderSpec extends Specification {
     containerInformationService.getTaskZone(_, _, _) >> 'us-west-1a'
     taskDefinitionCacheClient.get(_) >> cachedTaskDefinition
     scalableTargetCacheClient.get(_) >> scalableTarget
-    ecsCloudWatchAlarmCacheClient.getMetricAlarms(_, _, _) >> []
+    ecsCloudWatchAlarmCacheClient.getMetricAlarms(_, _,_ ,_) >> []
     subnetSelector.getSubnetVpcIds(_, _, _) >> ['vpc-1234']
 
     cacheView.filterIdentifiers(_, _) >> ['key']

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/services/EcsCloudMetricServiceSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/services/EcsCloudMetricServiceSpec.groovy
@@ -413,12 +413,14 @@ class EcsCloudMetricServiceSpec extends Specification {
       )
     }
 
-    metricAlarmCacheClient.getMetricAlarms(_, _, _) >> metricAlarms
+    metricAlarmCacheClient.getMetricAlarms(_, _,_ ,_) >> metricAlarms
 
     when:
-    service.deleteMetrics(targetServiceName, targetAccountName, targetRegion)
+    service.deleteMetrics(targetServiceName, targetAccountName, targetRegion, clusterName)
 
     then:
     1 * targetCloudWatch.deleteAlarms(_)
   }
+
+
 }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterController.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.controllers
 
+import com.netflix.spinnaker.clouddriver.ecs.model.EcsApplication
 import com.netflix.spinnaker.clouddriver.model.*
 import com.netflix.spinnaker.clouddriver.model.view.ClusterViewModelPostProcessor
 import com.netflix.spinnaker.clouddriver.model.view.ServerGroupViewModelPostProcessor
@@ -85,9 +86,12 @@ class ClusterController {
 
   private Map<String, Set<String>> mergeClusters(List<Application> a) {
     Map<String, Set<String>> map = new HashMap<>()
-
     a.stream()
-      .flatMap({ it.getClusterNames().entrySet().stream() })
+      .flatMap({
+        it instanceof EcsApplication
+        ? it.getClusterNameMetadata().entrySet().stream()
+        : it.getClusterNames().entrySet().stream()
+      })
       .forEach({ entry ->
         map.computeIfAbsent(entry.getKey(), { new HashSet<>() }).addAll(entry.getValue())
       })


### PR DESCRIPTION
Attempt to address some of the issues described in https://github.com/spinnaker/spinnaker/issues/6084

Improving the response times on:
- /clusters
- /applications
- /serverGroups
Endpoints when ECS is enabled and a substantial amount of accounts/services exist in cache.

The perf issue with the Alarms still exists and will be addressed in a future PR


Adding some results from a performance test clouddriver response times:
![image](https://github.com/user-attachments/assets/f0f7a4d2-f00a-4ed0-8d59-a937f014bf0c)
![image](https://github.com/user-attachments/assets/d2bd74b1-45e9-43d1-8ebf-fd1b0afe7a4b)
![image](https://github.com/user-attachments/assets/e1c6cf4a-ce58-4124-bb5c-4061c61d0645)

- GET {CLOUDDRIVER_URL}/applications
    - Average: 104ms → 92.1ms (11% improvement)
    - 95th Percentile: 130ms → 126ms
- GET {CLOUDDRIVER_URL}/applications/{application_name}
  - Average: 7.48s → 4.2s (43% improvement)
  - 95th Percentile: 8.55s → 5.86s
- GET {CLOUDDRIVER_URL}/applications/{application_name}/serverGroups
  - Average: 2.72s → 2.16s (20% improvement)
  - 95th Percentile: 3.17s → 3.11s
- GET {CLOUDDRIVER_URL}/applications/{application_name}/clusters
  - Average: 107ms → 43.3ms (59% improvement)
  - 95th Percentile: 135ms → 88.4ms
