### PR TITLE
chore(dependency): add explicit byte-buddy dependency while upgrading spockframework to 2.2-groovy-3.0

### DIFF
--- a/clouddriver-elasticsearch/clouddriver-elasticsearch.gradle
+++ b/clouddriver-elasticsearch/clouddriver-elasticsearch.gradle
@@ -20,5 +20,6 @@ dependencies {
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
+  testRuntimeOnly "net.bytebuddy:byte-buddy"
 
 }

--- a/clouddriver-google-common/clouddriver-google-common.gradle
+++ b/clouddriver-google-common/clouddriver-google-common.gradle
@@ -16,4 +16,5 @@ dependencies {
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"
   testImplementation "org.spockframework:spock-core"
+  testRuntimeOnly "net.bytebuddy:byte-buddy"
 }

--- a/clouddriver-oracle/clouddriver-oracle.gradle
+++ b/clouddriver-oracle/clouddriver-oracle.gradle
@@ -24,6 +24,7 @@ dependencies {
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
+  testRuntimeOnly "net.bytebuddy:byte-buddy"
 }
 
 def allSourceSets = sourceSets

--- a/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver-titus/clouddriver-titus.gradle
@@ -49,6 +49,7 @@ dependencies {
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
   testImplementation "io.spinnaker.kork:kork-test"
+  testRuntimeOnly "net.bytebuddy:byte-buddy"
 }
 
 sourceSets {


### PR DESCRIPTION
While upgrading spockframework from 2.0-groovy-3.0 to 2.2-groovy-3.0, encountered similar errors as mentioned below during test execution of clouddriver-elasticsearch, clouddriver-google-common, clouddriver-oracle and clouddriver-titus  module:

```
Caused by: net.sf.cglib.core.CodeGenerationException: java.lang.reflect.InaccessibleObjectException-->Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @3e07d849
        at app//net.sf.cglib.core.ReflectUtils.defineClass(ReflectUtils.java:464)
        at app//net.sf.cglib.core.AbstractClassGenerator.generate(AbstractClassGenerator.java:339)
        at app//net.sf.cglib.core.AbstractClassGenerator$ClassLoaderData$3.apply(AbstractClassGenerator.java:96)
        at app//net.sf.cglib.core.AbstractClassGenerator$ClassLoaderData$3.apply(AbstractClassGenerator.java:94)
        at app//net.sf.cglib.core.internal.LoadingCache$2.call(LoadingCache.java:54)
        at java.base@17.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at app//net.sf.cglib.core.internal.LoadingCache.createEntry(LoadingCache.java:61)
        at app//net.sf.cglib.core.internal.LoadingCache.get(LoadingCache.java:34)
        at app//net.sf.cglib.core.AbstractClassGenerator$ClassLoaderData.get(AbstractClassGenerator.java:119)
        at app//net.sf.cglib.core.AbstractClassGenerator.create(AbstractClassGenerator.java:294)
        at app//net.sf.cglib.core.KeyFactory$Generator.create(KeyFactory.java:221)
        at app//net.sf.cglib.core.KeyFactory.create(KeyFactory.java:174)
        at app//net.sf.cglib.core.KeyFactory.create(KeyFactory.java:153)
        at app//net.sf.cglib.proxy.Enhancer.<clinit>(Enhancer.java:73)
        ... 10 more
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @3e07d849
        at net.sf.cglib.core.ReflectUtils$1.run(ReflectUtils.java:61)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:569)
        at net.sf.cglib.core.ReflectUtils.<clinit>(ReflectUtils.java:52)
        at net.sf.cglib.core.KeyFactory$Generator.generateClass(KeyFactory.java:243)
        at net.sf.cglib.core.DefaultGeneratorStrategy.generate(DefaultGeneratorStrategy.java:25)
        at net.sf.cglib.core.AbstractClassGenerator.generate(AbstractClassGenerator.java:332)
        ... 22 more
```
This issue caused due to dropping of `net.bytebuddy:byte-buddy` transitive dependency from [spock 2.2](https://repo1.maven.org/maven2/org/spockframework/spock-core/2.2-groovy-3.0/spock-core-2.2-groovy-3.0.pom), while it is part of [spock 2.0](https://repo1.maven.org/maven2/org/spockframework/spock-core/2.0-groovy-3.0/spock-core-2.0-groovy-3.0.pom). So, introducing the `testRuntimeOnly` byte-buddy explicit dependency to fix this issue. Since spring boot 2.7.18 bring byte-buddy as transitive dependency with [1.12.23](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.18/spring-boot-dependencies-2.7.18.pom) version, so tying the byte-buddy version with spring boot by unpinning it.
