### PR TITLE
fix(install): Removed install_awscli2 function from Debian post install script

### DIFF
--- a/clouddriver-web/pkg_scripts/postInstall.sh
+++ b/clouddriver-web/pkg_scripts/postInstall.sh
@@ -28,30 +28,6 @@ install_kubectl() {
   fi
 }
 
-install_awscli2() {
-  if [ -d "/usr/local/aws-cli/v2/${AWS_CLI_VERSION}" ]; then
-    echo "awscli2 ${AWS_CLI_VERSION} is already installed"
-  else
-    echo "Installing awscli2 ${AWS_CLI_VERSION}"
-    curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip"
-
-    # This shouldn't usually exist unless the installation failed previously
-    if [ -d "./aws" ]; then
-      rm -rf ./aws
-    fi
-
-    unzip awscliv2.zip
-    ./aws/install --update
-    rm -rf ./awscliv2.zip ./aws
-  fi
-
-  echo "Installing aws-iam-authenticator ${AWS_AIM_AUTHENTICATOR_VERSION}"
-  curl -s "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AWS_AIM_AUTHENTICATOR_VERSION}/aws-iam-authenticator_${AWS_AIM_AUTHENTICATOR_VERSION}_linux_amd64" -o aws-iam-authenticator
-  chmod +x ./aws-iam-authenticator
-  mv ./aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
-}
-
 install_kubectl
-install_awscli2
 
 install --mode=755 --owner=spinnaker --group=spinnaker --directory /var/log/spinnaker/clouddriver


### PR DESCRIPTION
Installing awscliv2 from the Debian packages causes more issues than anything else.
@dbyron-sf, @jasonmcintosh and I agree that its better off being removed and installed manually if required.

See https://spinnakerteam.slack.com/archives/CHD4ATAMV/p1724124605600089?thread_ts=1723850633.262419&cid=CHD4ATAMV for background.