### PR TITLE
fix(cloudfoundry): Update ProcessStats model due to capi-1.84.0 changes

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/ProcessStats.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/ProcessStats.java
@@ -26,6 +26,7 @@ public class ProcessStats {
     RUNNING,
     CRASHED,
     STARTING,
+    STOPPING,
     DOWN
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/CloudFoundryOperationUtils.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/CloudFoundryOperationUtils.java
@@ -25,6 +25,8 @@ class CloudFoundryOperationUtils {
         return "is still starting";
       case CRASHED:
         return "crashed";
+      case STOPPING:
+        return "is in graceful shutdown - stopping";
       case RUNNING:
       case DOWN:
       default:

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/StopCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/StopCloudFoundryServerGroupAtomicOperation.java
@@ -51,7 +51,8 @@ public class StopCloudFoundryServerGroupAtomicOperation implements AtomicOperati
             () -> client.getApplications().getAppState(description.getServerGroupId()),
             inProgressState ->
                 inProgressState != ProcessStats.State.STARTING
-                    && inProgressState != ProcessStats.State.RUNNING,
+                    && inProgressState != ProcessStats.State.RUNNING
+                    && inProgressState != ProcessStats.State.STOPPING,
             null,
             getTask(),
             description.getServerGroupName(),


### PR DESCRIPTION
Cloudfoundry API 1.84.0 is shipped with a fix for https://github.com/cloudfoundry/cloud_controller_ng/pull/3834. Summary of the change is: 

- Before the change when an app was stopped the state was immediately returned as DOWN although a graceful shutdown period may existed before actually was stopped.

- After the change when an app is stopped if within a  graceful shutdown period the state will be returned as STOPPING -> DOWN

Clouddriver ProcessStats model is updated with this PR to include the STOPPING state. Additionally updated the StopCloudFoundryServerGroupAtomicOperation to wait until the Graceful shutdown period expires. 