### PR TITLE
feat(gce): support resource-manager-tags in GCE deployment

### DIFF
--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -48,7 +48,3 @@ dependencies {
   testImplementation "org.springframework.boot:spring-boot-test"
   testImplementation "org.apache.groovy:groovy-test"
 }
-
-configurations.all {
-   resolutionStrategy.force 'com.google.apis:google-api-services-compute:beta-rev20201102-1.30.10'
-}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
@@ -68,6 +68,8 @@ class BaseGoogleInstanceDescription extends AbstractGoogleCredentialsDescription
 
   String accountName
 
+  Map<String, String> resourceManagerTags
+
   // The source of the image to deploy
   // ARTIFACT: An artifact of type gce/image stored in imageArtifact
   // STRING:   A string representing a GCE image name in the current

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -425,7 +425,8 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
                                                     tags: tags,
                                                     labels: labels,
                                                     scheduling: scheduling,
-                                                    serviceAccounts: serviceAccount)
+                                                    serviceAccounts: serviceAccount,
+                                                    resourceManagerTags: description.resourceManagerTags,)
 
     if (GCEUtil.isShieldedVmCompatible(bootImage)) {
       def shieldedVmConfig = GCEUtil.buildShieldedVmConfig(description)


### PR DESCRIPTION
Support resourceManagerTags in GCE. See: https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert

Adds resourceManagerTags in the description operation and add it in the instanceTemplateProperties.

Issue related: https://github.com/spinnaker/spinnaker/issues/6931

this PR replaced the [previous PR](https://github.com/spinnaker/clouddriver/pull/6282) in clouddriver because I want to leave only my changes related to `resource-manager-tags`
