### PR TITLE
feat(gce): add partnerMetadata in instanceProperties for GCE deployment

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.description
 
+import com.google.api.services.compute.model.StructuredEntries
 import com.netflix.spinnaker.clouddriver.google.model.GoogleDisk
 import com.netflix.spinnaker.clouddriver.google.model.GoogleLabeledResource
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
@@ -69,6 +70,7 @@ class BaseGoogleInstanceDescription extends AbstractGoogleCredentialsDescription
   String accountName
 
   Map<String, String> resourceManagerTags
+  Map<String, StructuredEntries> partnerMetadata
 
   // The source of the image to deploy
   // ARTIFACT: An artifact of type gce/image stored in imageArtifact

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -426,7 +426,9 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
                                                     labels: labels,
                                                     scheduling: scheduling,
                                                     serviceAccounts: serviceAccount,
-                                                    resourceManagerTags: description.resourceManagerTags,)
+                                                    resourceManagerTags: description.resourceManagerTags,
+      partnerMetadata: description.partnerMetadata,
+    )
 
     if (GCEUtil.isShieldedVmCompatible(bootImage)) {
       def shieldedVmConfig = GCEUtil.buildShieldedVmConfig(description)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -416,17 +416,18 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
         "Accelerators are only supported with regional server groups if the zones are specified by the user.");
     }
 
-    def instanceProperties = new InstanceProperties(machineType: machineTypeName,
-                                                    disks: attachedDisks,
-                                                    guestAccelerators: description.acceleratorConfigs ?: [],
-                                                    networkInterfaces: [networkInterface],
-                                                    canIpForward: canIpForward,
-                                                    metadata: metadata,
-                                                    tags: tags,
-                                                    labels: labels,
-                                                    scheduling: scheduling,
-                                                    serviceAccounts: serviceAccount,
-                                                    resourceManagerTags: description.resourceManagerTags,
+    def instanceProperties = new InstanceProperties(
+      machineType: machineTypeName,
+      disks: attachedDisks,
+      guestAccelerators: description.acceleratorConfigs ?: [],
+      networkInterfaces: [networkInterface],
+      canIpForward: canIpForward,
+      metadata: metadata,
+      tags: tags,
+      labels: labels,
+      scheduling: scheduling,
+      serviceAccounts: serviceAccount,
+      resourceManagerTags: description.resourceManagerTags,
       partnerMetadata: description.partnerMetadata,
     )
 


### PR DESCRIPTION
Support partnerMetadata in GCE deployment. See https://cloud.google.com/compute/docs/metadata/overview#partner_attributes

Basically clouddriver will receive partnerMetadata from the execution context and it will add it in the instanceProperties if partnerMetadata is defined.

PartnerMetadata is a feature under Preview but clouddriver currently uses beta google compute client and it recognizes it.

If there is an error in the structure of the parterMetadata the deployment will fail and it will describe the error like the following:
<img width="1113" alt="Captura de pantalla 2024-10-17 a la(s) 2 04 04 p m" src="https://github.com/user-attachments/assets/1e8a7a60-ff9f-4543-b50a-2fa7e06b3f31">

We can validate that the instance template & instance itself has the partnerMetadata by using the following beta command in gcloud.
`gcloud beta compute instance-templates describe armorytests-v005-92753465 --view=FULL`
`gcloud beta compute instances describe armorytests-v005-5mxg --view=FULL`

Issue related: https://github.com/spinnaker/spinnaker/issues/6931

PartnerMetadata is available in clouddriver because the newer client version: https://github.com/spinnaker/kork/pull/1208