### PR TITLE
refactor(retrofit): replace OkClient with Ok3Client

### DIFF
--- a/clouddriver-appengine/clouddriver-appengine.gradle
+++ b/clouddriver-appengine/clouddriver-appengine.gradle
@@ -20,6 +20,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-cloud-config-server"
   implementation "io.spinnaker.kork:kork-moniker"
   implementation "io.spinnaker.kork:kork-retrofit"
+  implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "com.netflix.spectator:spectator-api"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.retrofit:converter-jackson"

--- a/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/config/AppengineConfigurationProperties.java
+++ b/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/config/AppengineConfigurationProperties.java
@@ -18,18 +18,18 @@ package com.netflix.spinnaker.clouddriver.appengine.config;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jakewharton.retrofit.Ok3Client;
 import com.netflix.spinnaker.clouddriver.appengine.AppengineJobExecutor;
 import com.netflix.spinnaker.clouddriver.googlecommon.config.GoogleCommonManagedAccount;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
-import com.squareup.okhttp.OkHttpClient;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import okhttp3.OkHttpClient;
 import org.springframework.util.StringUtils;
 import retrofit.RestAdapter;
-import retrofit.client.OkClient;
 import retrofit.client.Response;
 import retrofit.converter.JacksonConverter;
 import retrofit.http.GET;
@@ -99,13 +99,12 @@ public class AppengineConfigurationProperties {
     }
 
     static MetadataService createMetadataService() {
-      OkHttpClient client = new OkHttpClient();
-      client.setRetryOnConnectionFailure(true);
+      OkHttpClient okHttpClient = new OkHttpClient.Builder().retryOnConnectionFailure(true).build();
       RestAdapter restAdapter =
           new RestAdapter.Builder()
               .setEndpoint(metadataUrl)
               .setConverter(new JacksonConverter())
-              .setClient(new OkClient(client))
+              .setClient(new Ok3Client(okHttpClient))
               .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
               .build();
       return restAdapter.create(MetadataService.class);

--- a/clouddriver-consul/clouddriver-consul.gradle
+++ b/clouddriver-consul/clouddriver-consul.gradle
@@ -1,6 +1,7 @@
 dependencies {
   implementation project(":clouddriver-core")
 
+  implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.retrofit:converter-jackson"
   implementation "com.squareup.retrofit:retrofit"

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/Consul.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/Consul.groovy
@@ -16,13 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.consul.api.v1
 
-
+import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spinnaker.clouddriver.consul.config.ConsulConfig
 import com.netflix.spinnaker.clouddriver.consul.config.ConsulProperties
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler
-import com.squareup.okhttp.OkHttpClient
+import okhttp3.OkHttpClient
 import retrofit.RestAdapter
-import retrofit.client.OkClient
 import retrofit.converter.JacksonConverter
 
 class Consul<T> {
@@ -39,7 +38,7 @@ class Consul<T> {
     this.timeout = timeout
     this.api = new RestAdapter.Builder()
       .setEndpoint(this.endpoint)
-      .setClient(new OkClient(new OkHttpClient()))
+      .setClient(new Ok3Client(new OkHttpClient()))
       .setConverter(new JacksonConverter())
       .setLogLevel(RestAdapter.LogLevel.NONE)
       .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/ConsulAgent.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/ConsulAgent.groovy
@@ -19,11 +19,6 @@ package com.netflix.spinnaker.clouddriver.consul.api.v1
 import com.netflix.spinnaker.clouddriver.consul.api.v1.services.AgentApi
 import com.netflix.spinnaker.clouddriver.consul.config.ConsulConfig
 import com.netflix.spinnaker.clouddriver.consul.config.ConsulProperties
-import com.squareup.okhttp.OkHttpClient
-import retrofit.RestAdapter
-import retrofit.client.OkClient
-
-import java.util.concurrent.TimeUnit
 
 class ConsulAgent extends Consul<AgentApi> {
   ConsulAgent(ConsulConfig config, String agentBaseUrl) {

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/ConsulCatalog.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/ConsulCatalog.groovy
@@ -18,12 +18,6 @@ package com.netflix.spinnaker.clouddriver.consul.api.v1
 
 import com.netflix.spinnaker.clouddriver.consul.api.v1.services.CatalogApi
 import com.netflix.spinnaker.clouddriver.consul.config.ConsulConfig
-import com.netflix.spinnaker.clouddriver.consul.config.ConsulProperties
-import com.squareup.okhttp.OkHttpClient
-import retrofit.RestAdapter
-import retrofit.client.OkClient
-
-import java.util.concurrent.TimeUnit
 
 class ConsulCatalog extends Consul<CatalogApi> {
   ConsulCatalog(ConsulConfig config) {

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/ConsulKeyValueStore.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/ConsulKeyValueStore.groovy
@@ -18,12 +18,6 @@ package com.netflix.spinnaker.clouddriver.consul.api.v1
 
 import com.netflix.spinnaker.clouddriver.consul.api.v1.services.KeyValueApi
 import com.netflix.spinnaker.clouddriver.consul.config.ConsulConfig
-import com.netflix.spinnaker.clouddriver.consul.config.ConsulProperties
-import com.squareup.okhttp.OkHttpClient
-import retrofit.RestAdapter
-import retrofit.client.OkClient
-
-import java.util.concurrent.TimeUnit
 
 class ConsulKeyValueStore extends Consul<KeyValueApi> {
   ConsulKeyValueStore(ConsulConfig config) {

--- a/clouddriver-docker/clouddriver-docker.gradle
+++ b/clouddriver-docker/clouddriver-docker.gradle
@@ -9,6 +9,7 @@ dependencies {
   implementation "org.springframework.cloud:spring-cloud-context"
   implementation "org.apache.groovy:groovy"
   implementation "com.google.guava:guava"
+  implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "com.netflix.spectator:spectator-api"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.retrofit:converter-jackson"
@@ -27,6 +28,7 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.mockito:mockito-core"
+  testImplementation 'org.mockito:mockito-inline'
   testImplementation "org.mockito:mockito-junit-jupiter"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"

--- a/clouddriver-docker/src/main/java/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerOkClientProvider.java
+++ b/clouddriver-docker/src/main/java/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerOkClientProvider.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client;
 
-import retrofit.client.OkClient;
+import com.jakewharton.retrofit.Ok3Client;
 
 /** Allows custom configuration of the Docker Registry OkHttpClient. */
 public interface DockerOkClientProvider {
@@ -26,7 +26,7 @@ public interface DockerOkClientProvider {
    * @param timeoutMs The client timeout in milliseconds
    * @param insecure Whether or not the registry should be configured to trust all SSL certificates.
    *     If this is true, you may want to fallback to {@code DefaultDockerOkClientProvider}
-   * @return An OkClient
+   * @return An Ok3Client
    */
-  OkClient provide(String address, long timeoutMs, boolean insecure);
+  Ok3Client provide(String address, long timeoutMs, boolean insecure);
 }

--- a/clouddriver-eureka/clouddriver-eureka.gradle
+++ b/clouddriver-eureka/clouddriver-eureka.gradle
@@ -7,6 +7,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-web"
   implementation "io.spinnaker.kork:kork-retrofit"
   implementation "com.amazonaws:aws-java-sdk"
+  implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "com.squareup.retrofit:converter-jackson"
   implementation "com.squareup.retrofit:retrofit"
   implementation "org.apache.groovy:groovy"

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/EurekaApiFactory.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/EurekaApiFactory.groovy
@@ -16,26 +16,26 @@
 
 package com.netflix.spinnaker.clouddriver.eureka.api
 
-import com.netflix.spinnaker.config.OkHttpClientConfiguration
+import com.jakewharton.retrofit.Ok3Client
+import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler
 import retrofit.RestAdapter
-import retrofit.client.OkClient
 import retrofit.converter.Converter
 
 class EurekaApiFactory {
 
   private Converter eurekaConverter
-  private OkHttpClientConfiguration okHttpClientConfiguration
+  private OkHttp3ClientConfiguration okHttp3ClientConfiguration
 
-  EurekaApiFactory(Converter eurekaConverter, OkHttpClientConfiguration okHttpClientConfiguration) {
+  EurekaApiFactory(Converter eurekaConverter, OkHttp3ClientConfiguration okHttp3ClientConfiguration) {
     this.eurekaConverter = eurekaConverter
-    this.okHttpClientConfiguration = okHttpClientConfiguration
+    this.okHttp3ClientConfiguration = okHttp3ClientConfiguration
   }
 
   public EurekaApi createApi(String endpoint) {
     new RestAdapter.Builder()
       .setConverter(eurekaConverter)
-      .setClient(new OkClient(okHttpClientConfiguration.create()))
+      .setClient(new Ok3Client(okHttp3ClientConfiguration.create().build()))
       .setEndpoint(endpoint)
       .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .build()


### PR DESCRIPTION
Moving away from `com.squareup.okhttp.OkHttpClient` to `okhttp3.OkHttpClient` to avoid any unwanted dependency conflicts.

okhttp3.OkHttpClient for retrofit1 is provided by [Ok3Client](https://github.com/JakeWharton/retrofit1-okhttp3-client)