### PR TITLE
fix(ecs): evaluate targetgroup healthcheck in instance healthcheck

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationService.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationService.java
@@ -18,16 +18,19 @@ package com.netflix.spinnaker.clouddriver.ecs.services;
 
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ecs.model.ContainerDefinition;
+import com.amazonaws.services.ecs.model.LoadBalancer;
 import com.amazonaws.services.ecs.model.NetworkBinding;
 import com.amazonaws.services.ecs.model.TaskDefinition;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.ContainerInstanceCacheClient;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.EcsInstanceCacheClient;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.ServiceCacheClient;
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.TargetHealthCacheClient;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskCacheClient;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskDefinitionCacheClient;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskHealthCacheClient;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.ContainerInstance;
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsTargetHealth;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.Service;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.Task;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.TaskHealth;
@@ -37,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -50,6 +54,7 @@ public class ContainerInformationService {
   private final TaskDefinitionCacheClient taskDefinitionCacheClient;
   private final EcsInstanceCacheClient ecsInstanceCacheClient;
   private final ContainerInstanceCacheClient containerInstanceCacheClient;
+  private final TargetHealthCacheClient targetHealthCacheClient;
 
   @Autowired
   public ContainerInformationService(
@@ -59,7 +64,8 @@ public class ContainerInformationService {
       TaskHealthCacheClient taskHealthCacheClient,
       TaskDefinitionCacheClient taskDefinitionCacheClient,
       EcsInstanceCacheClient ecsInstanceCacheClient,
-      ContainerInstanceCacheClient containerInstanceCacheClient) {
+      ContainerInstanceCacheClient containerInstanceCacheClient,
+      TargetHealthCacheClient targetHealthCacheClient) {
     this.ecsCredentialsConfig = ecsCredentialsConfig;
     this.taskCacheClient = taskCacheClient;
     this.serviceCacheClient = serviceCacheClient;
@@ -67,6 +73,7 @@ public class ContainerInformationService {
     this.taskDefinitionCacheClient = taskDefinitionCacheClient;
     this.ecsInstanceCacheClient = ecsInstanceCacheClient;
     this.containerInstanceCacheClient = containerInstanceCacheClient;
+    this.targetHealthCacheClient = targetHealthCacheClient;
   }
 
   public List<Map<String, Object>> getHealthStatus(
@@ -101,17 +108,30 @@ public class ContainerInformationService {
     // Task-based health
     if (task != null) {
       boolean hasHealthCheck = false;
+      EcsTargetHealth targetHealth = null;
       if (service != null) {
         hasHealthCheck = taskHasHealthCheck(service, accountName, region);
+        LoadBalancer loadBalancer = service.getLoadBalancers().stream().findFirst().orElse(null);
+        String targetGroupKey =
+            Keys.getTargetHealthKey(accountName, region, loadBalancer.getTargetGroupArn());
+        targetHealth = targetHealthCacheClient.get(targetGroupKey);
       }
 
       Map<String, Object> taskPlatformHealth = new HashMap<>();
       taskPlatformHealth.put("instanceId", taskId);
       taskPlatformHealth.put("type", "ecs");
       taskPlatformHealth.put("healthClass", "platform");
-      taskPlatformHealth.put(
-          "state",
-          toPlatformHealthState(task.getLastStatus(), task.getHealthStatus(), hasHealthCheck));
+
+      // Check healthcheck in targetHealth
+      if (!hasHealthCheck && targetHealth != null) {
+        taskPlatformHealth.put(
+            "state",
+            toPlatformHealthState(task.getLastStatus(), getTargetHealthStatus(targetHealth), true));
+      } else {
+        taskPlatformHealth.put(
+            "state",
+            toPlatformHealthState(task.getLastStatus(), task.getHealthStatus(), hasHealthCheck));
+      }
       healthMetrics.add(taskPlatformHealth);
     }
 
@@ -135,6 +155,22 @@ public class ContainerInformationService {
     }
 
     return false;
+  }
+
+  private String getTargetHealthStatus(EcsTargetHealth ecsTargetHealth) {
+    List<String> statuses =
+        ecsTargetHealth.getTargetHealthDescriptions().stream()
+            .map(tg -> tg.getTargetHealth().getState())
+            .distinct()
+            .collect(Collectors.toList());
+
+    if (statuses.stream().anyMatch(it -> it.equalsIgnoreCase("unhealthy"))) {
+      return "UNHEALTHY";
+    }
+    if (statuses.stream().anyMatch(it -> it.equalsIgnoreCase("healthy"))) {
+      return "HEALTHY";
+    }
+    return "UNKNOWN";
   }
 
   private String toPlatformHealthState(


### PR DESCRIPTION
Deployments using ECS are marked successful by Spinnaker but the ECS service is unhealthy when target group mappings are defined in the configuration.

Here is pipeline execution with the successful deployment in Spinnaker:
<img width="1183" alt="Captura de pantalla 2024-11-21 a la(s) 1 30 51 p m" src="https://github.com/user-attachments/assets/416f6b40-9a83-4f51-80d1-89e8a53b78b8">
<img width="1253" alt="Captura de pantalla 2024-11-21 a la(s) 1 31 35 p m" src="https://github.com/user-attachments/assets/52f5ad68-a1f5-4061-92a6-9dc142d0390f">

But In the server group events we can see unhealthy issues.
<img width="624" alt="Captura de pantalla 2024-11-21 a la(s) 1 31 58 p m" src="https://github.com/user-attachments/assets/795a7936-ca5d-4809-bad2-deb0d2d03ea1">

Here is the issue in ECS AWS console.
<img width="1320" alt="Captura de pantalla 2024-11-21 a la(s) 1 32 52 p m" src="https://github.com/user-attachments/assets/7b4e7ab4-cb98-43f2-a294-7d5301d86263">


As part of my changes I search for targetGrouphealths and then use them to set unhealthy statuses to the instance.
