### PR TITLE
fix(tests): refactor a test to consume retrofit2 interfaced FiatService

### DIFF
--- a/clouddriver-docker/clouddriver-docker.gradle
+++ b/clouddriver-docker/clouddriver-docker.gradle
@@ -21,6 +21,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-retrofit"
   implementation "io.spinnaker.kork:kork-exceptions"
 
+  testImplementation "com.squareup.retrofit2:retrofit-mock"
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"
   testImplementation "org.assertj:assertj-core"

--- a/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupControllerTest.java
+++ b/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupControllerTest.java
@@ -61,6 +61,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import retrofit2.mock.Calls;
 
 @SpringBootTest(classes = TestConfig.class, properties = "services.fiat.cache.max-entries=0")
 @AutoConfigureMockMvc
@@ -112,7 +113,7 @@ class DockerRegistryImageLookupControllerTest {
   @Test
   void authorizedToReadTags() throws Exception {
     var permissions = createAuthorizedUserPermission();
-    given(fiatService.getUserPermission(eq("user"))).willReturn(permissions);
+    given(fiatService.getUserPermission(eq("user"))).willReturn(Calls.response(permissions));
 
     mockMvc
         .perform(
@@ -125,7 +126,7 @@ class DockerRegistryImageLookupControllerTest {
   @Test
   void notAuthorizedToReadTags() throws Exception {
     var permissions = createUnauthorizedUserPermission();
-    given(fiatService.getUserPermission("user")).willReturn(permissions);
+    given(fiatService.getUserPermission("user")).willReturn(Calls.response(permissions));
 
     mockMvc
         .perform(
@@ -138,7 +139,7 @@ class DockerRegistryImageLookupControllerTest {
   @Test
   void canSearchForAuthorizedItems() throws Exception {
     var permissions = createAuthorizedUserPermission();
-    given(fiatService.getUserPermission("user")).willReturn(permissions);
+    given(fiatService.getUserPermission("user")).willReturn(Calls.response(permissions));
     cache.merge(Keys.Namespace.TAGGED_IMAGE.getNs(), createTestAccountTaggedImageCacheData());
     var credentials = createTestAccountCredentials();
     accountCredentialsRepository.save(credentials.getName(), credentials);
@@ -151,7 +152,7 @@ class DockerRegistryImageLookupControllerTest {
   @Test
   void filtersOutUnauthorizedItems() throws Exception {
     var permissions = createUnauthorizedUserPermission();
-    given(fiatService.getUserPermission("user")).willReturn(permissions);
+    given(fiatService.getUserPermission("user")).willReturn(Calls.response(permissions));
     cache.merge(Keys.Namespace.TAGGED_IMAGE.getNs(), createTestAccountTaggedImageCacheData());
     var credentials = createTestAccountCredentials();
     accountCredentialsRepository.save(credentials.getName(), credentials);


### PR DESCRIPTION
Fiat's retrofit client is upgraded to retrofit2 - https://github.com/spinnaker/fiat/pull/1195

This PR makes changes to a test to use retrofit2 interfaced FiatService.  