### PR TITLE
feat(aws): CleanupAlarmsAgent with an optional user-defined name pattern

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfigurationProperties.groovy
@@ -39,6 +39,7 @@ class AwsConfigurationProperties {
     static class AlarmsConfig {
       boolean enabled = false
       int daysToKeep = 90
+      String alarmsNamePattern = ".+-v[0-9]{3}-alarm-.+"
     }
 
     @NestedConfigurationProperty

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgent.groovy
@@ -40,31 +40,35 @@ class CleanupAlarmsAgent implements RunnableAgent, CustomScheduledAgent {
   public static final long POLL_INTERVAL_MILLIS = TimeUnit.HOURS.toMillis(24)
   public static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(20)
 
-  public static final Pattern ALARM_NAME_PATTERN = Pattern.compile(".+-v[0-9]{3}-alarm-.+")
+  public final Pattern ALARM_NAME_PATTERN = Pattern.compile(alarmsNamePattern)
 
   final AmazonClientProvider amazonClientProvider
   final CredentialsRepository<NetflixAmazonCredentials> credentialsRepository
   final long pollIntervalMillis
   final long timeoutMillis
   final int daysToLeave
+  final String alarmsNamePattern;
 
 
   CleanupAlarmsAgent(AmazonClientProvider amazonClientProvider,
                      CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
-                     int daysToLeave) {
-    this(amazonClientProvider, credentialsRepository, POLL_INTERVAL_MILLIS, DEFAULT_TIMEOUT_MILLIS, daysToLeave)
+                     int daysToLeave,
+                     String alarmsNamePattern) {
+    this(amazonClientProvider, credentialsRepository, POLL_INTERVAL_MILLIS, DEFAULT_TIMEOUT_MILLIS, daysToLeave, alarmsNamePattern)
   }
 
   CleanupAlarmsAgent(AmazonClientProvider amazonClientProvider,
                      CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
                      long pollIntervalMillis,
                      long timeoutMills,
-                     int daysToLeave) {
+                     int daysToLeave,
+                     String alarmsNamePattern) {
     this.amazonClientProvider = amazonClientProvider
     this.credentialsRepository = credentialsRepository
     this.pollIntervalMillis = pollIntervalMillis
     this.timeoutMillis = timeoutMills
     this.daysToLeave = daysToLeave
+    this.alarmsNamePattern = alarmsNamePattern
   }
 
   @Override

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/provider/config/ProviderHelpers.java
@@ -250,7 +250,8 @@ public class ProviderHelpers {
             new CleanupAlarmsAgent(
                 amazonClientProvider,
                 credentialsRepository,
-                awsConfigurationProperties.getCleanup().getAlarms().getDaysToKeep()));
+                awsConfigurationProperties.getCleanup().getAlarms().getDaysToKeep(),
+                awsConfigurationProperties.getCleanup().getAlarms().getAlarmsNamePattern()));
       }
       newlyAddedAgents.add(
           new CleanupDetachedInstancesAgent(amazonClientProvider, credentialsRepository));


### PR DESCRIPTION
Users might defined a custom name for the scaling policies and alarms names that dont match the strict namePattern of the AlarmsCleanUp agent. 
Especially for custom alarms when a scaling policy is deleted the alarms are not cascade deleted leading to stale cache in the cats_v1_alarms table.

This PR allows the user to define their own AlarmsNamePattern for the AlarmsCleanupAgent