### PR TITLE
fix(mergify): Mergify config needs adjusting for latest mergify releases

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,8 +3,10 @@ queue_rules:
     merge_method: squash 
     queue_conditions:
       - check-success=build
+      - check-sucess=it-test
     merge_conditions:
       - check-success=build
+      - check-sucess=it-test
 
 pull_request_rules:
   - name: Make sure PR are up to date before merging

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,61 +1,73 @@
 queue_rules:
   - name: default
-    conditions:
-      - status-success=build
+    merge_method: squash 
+    queue_conditions:
+      - check-success=build
+    merge_conditions:
+      - check-success=build
 
 pull_request_rules:
+  - name: Make sure PR are up to date before merging
+    description: This automatically updates PRs when they are out-of-date with the
+      base branch to avoid semantic conflicts (next step is using a merge queue).
+    conditions: []
+    actions:
+      update:
+  - name: Automatically merge backports to releases on succesful build
+    conditions:
+      - base~=^(release-)
+      - head~=^mergify\/bp\/
+      - "author=mergify[bot]"
+    actions:
+      queue:
+        name: default
+      label:
+        add: ["auto merged"]
   - name: Automatically merge on CI success and review
     conditions:
       - base=master
-      - status-success=build
       - "label=ready to merge"
       - "approved-reviews-by=@oss-approvers"
+      - "#approved-reviews-by>=1"
     actions:
       queue:
-        method: squash
         name: default
       label:
         add: ["auto merged"]
   - name: Automatically merge release branch changes on CI success and release manager review
     conditions:
       - base~=^release-
-      - status-success=build
       - "label=ready to merge"
       - "approved-reviews-by=@release-managers"
     actions:
       queue:
-        method: squash
         name: default
       label:
         add: ["auto merged"]
   - name: Automatically merge PRs from maintainers on CI success and review
     conditions:
       - base=master
-      - status-success=build
       - "label=ready to merge"
       - "author=@oss-approvers"
+      - "#approved-reviews-by>=1"
     actions:
       queue:
-        method: squash
         name: default
       label:
         add: ["auto merged"]
   - name: Automatically merge autobump PRs on CI success
     conditions:
       - base~=^(master|release-)
-      - status-success=build
       - "label~=autobump-*"
       - "author:spinnakerbot"
     actions:
       queue:
-        method: squash
         name: default
       label:
         add: ["auto merged"]
   - name: Request reviews for autobump PRs on CI failure
     conditions:
       - base~=^(master|release-)
-      - status-failure=build
       - "label~=autobump-*"
       - base=master
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,8 +3,10 @@ queue_rules:
     merge_method: squash 
     queue_conditions:
       - check-success=build
+      - check-success=it-test
     merge_conditions:
       - check-success=build
+      - check-success=it-test
 
 pull_request_rules:
   - name: Make sure PR are up to date before merging

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,9 +4,6 @@ queue_rules:
     queue_conditions:
       - check-success=build
       - check-success=it-test
-    merge_conditions:
-      - check-success=build
-      - check-success=it-test
 
 pull_request_rules:
   - name: Make sure PR are up to date before merging

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,10 +3,8 @@ queue_rules:
     merge_method: squash 
     queue_conditions:
       - check-success=build
-      - check-sucess=it-test
     merge_conditions:
       - check-success=build
-      - check-sucess=it-test
 
 pull_request_rules:
   - name: Make sure PR are up to date before merging


### PR DESCRIPTION
Couple of changes & new features:
* Moved the check-success conditions up.  NOTE:  We're NOT checking the integration tests - and probably should be on these.  I didn't change that open to doing so
* Added an auto update a PR with latest changes from head rule.  This would help keep PRs up-to-date
* An auto merge back ports rule.  This way back ports from mergify will auto merge post passing build checks.
* Added a reviewer count check as well