### PR TITLE
fix(google): Add partner metadata on instanceTemplate properties

### DIFF
--- a/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplates.java
+++ b/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplates.java
@@ -29,6 +29,8 @@ public class InstanceTemplates {
   private final Compute.InstanceTemplates computeApi;
   private final GoogleNamedAccountCredentials credentials;
   private final GlobalGoogleComputeRequestFactory requestFactory;
+  private static final String defaultView =
+      "FULL"; // https://cloud.google.com/sdk/gcloud/reference/beta/compute/instance-templates/list
 
   InstanceTemplates(
       GoogleNamedAccountCredentials credentials,
@@ -61,12 +63,14 @@ public class InstanceTemplates {
     return requestFactory.wrapOperationRequest(request, "insert");
   }
 
-  public PaginatedComputeRequest<Compute.InstanceTemplates.List, InstanceTemplate> list(
-      String view) {
+  public PaginatedComputeRequest<Compute.InstanceTemplates.List, InstanceTemplate> list() {
     return new PaginatedComputeRequestImpl<>(
         pageToken ->
             requestFactory.wrapRequest(
-                computeApi.list(credentials.getProject()).setPageToken(pageToken).setView(view),
+                computeApi
+                    .list(credentials.getProject())
+                    .setPageToken(pageToken)
+                    .setView(defaultView),
                 "list"),
         InstanceTemplateList::getNextPageToken,
         InstanceTemplateList::getItems);

--- a/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplates.java
+++ b/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplates.java
@@ -61,11 +61,17 @@ public class InstanceTemplates {
     return requestFactory.wrapOperationRequest(request, "insert");
   }
 
-  public PaginatedComputeRequest<Compute.InstanceTemplates.List, InstanceTemplate> list() {
+  public PaginatedComputeRequest<Compute.InstanceTemplates.List, InstanceTemplate> list(
+      String viewInput) {
+    if (viewInput.isBlank()) {
+      viewInput = "BASIC";
+    }
+    String view = viewInput;
     return new PaginatedComputeRequestImpl<>(
         pageToken ->
             requestFactory.wrapRequest(
-                computeApi.list(credentials.getProject()).setPageToken(pageToken), "list"),
+                computeApi.list(credentials.getProject()).setPageToken(pageToken).setView(view),
+                "list"),
         InstanceTemplateList::getNextPageToken,
         InstanceTemplateList::getItems);
   }

--- a/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplates.java
+++ b/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplates.java
@@ -62,11 +62,7 @@ public class InstanceTemplates {
   }
 
   public PaginatedComputeRequest<Compute.InstanceTemplates.List, InstanceTemplate> list(
-      String viewInput) {
-    if (viewInput.isBlank()) {
-      viewInput = "BASIC";
-    }
-    String view = viewInput;
+      String view) {
     return new PaginatedComputeRequestImpl<>(
         pageToken ->
             requestFactory.wrapRequest(

--- a/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgent.java
+++ b/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgent.java
@@ -1061,7 +1061,7 @@ public abstract class AbstractGoogleServerGroupCachingAgent
 
   private Collection<InstanceTemplate> retrieveInstanceTemplates() throws IOException {
     InstanceTemplates instanceTemplatesApi = computeApiFactory.createInstanceTemplates(credentials);
-    return instanceTemplatesApi.list().execute();
+    return instanceTemplatesApi.list("FULL").execute();
   }
 
   Collection<String> getZonesForRegion() {

--- a/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgent.java
+++ b/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgent.java
@@ -1061,7 +1061,9 @@ public abstract class AbstractGoogleServerGroupCachingAgent
 
   private Collection<InstanceTemplate> retrieveInstanceTemplates() throws IOException {
     InstanceTemplates instanceTemplatesApi = computeApiFactory.createInstanceTemplates(credentials);
-    return instanceTemplatesApi.list("FULL").execute();
+    return instanceTemplatesApi
+        .list("FULL")
+        .execute(); // https://cloud.google.com/sdk/gcloud/reference/beta/compute/instance-templates/list
   }
 
   Collection<String> getZonesForRegion() {

--- a/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgent.java
+++ b/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgent.java
@@ -1061,10 +1061,7 @@ public abstract class AbstractGoogleServerGroupCachingAgent
 
   private Collection<InstanceTemplate> retrieveInstanceTemplates() throws IOException {
     InstanceTemplates instanceTemplatesApi = computeApiFactory.createInstanceTemplates(credentials);
-    return instanceTemplatesApi
-        .list("FULL") // See view options:
-        // https://cloud.google.com/sdk/gcloud/reference/beta/compute/instance-templates/list
-        .execute();
+    return instanceTemplatesApi.list().execute();
   }
 
   Collection<String> getZonesForRegion() {

--- a/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgent.java
+++ b/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgent.java
@@ -1062,8 +1062,9 @@ public abstract class AbstractGoogleServerGroupCachingAgent
   private Collection<InstanceTemplate> retrieveInstanceTemplates() throws IOException {
     InstanceTemplates instanceTemplatesApi = computeApiFactory.createInstanceTemplates(credentials);
     return instanceTemplatesApi
-        .list("FULL")
-        .execute(); // https://cloud.google.com/sdk/gcloud/reference/beta/compute/instance-templates/list
+        .list("FULL") // See view options:
+        // https://cloud.google.com/sdk/gcloud/reference/beta/compute/instance-templates/list
+        .execute();
   }
 
   Collection<String> getZonesForRegion() {

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplatesTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplatesTest.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.google.compute;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIOException;
+import static org.mockito.Mockito.*;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
@@ -25,6 +26,7 @@ import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.InstanceTemplate;
+import com.google.common.collect.ImmutableList;
 import com.netflix.spectator.api.BasicTag;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.NoopRegistry;
@@ -188,6 +190,96 @@ public class InstanceTemplatesTest {
             tag("status", "4xx"),
             tag("success", "false"));
     assertThat(timer.totalTime()).isEqualTo(CLOCK_STEP_TIME_NS);
+  }
+
+  @Test
+  public void list_success() throws IOException {
+
+    MockHttpTransport transport =
+        new MockHttpTransport.Builder()
+            .setLowLevelHttpResponse(
+                new MockLowLevelHttpResponse()
+                    .setStatusCode(200)
+                    .addHeader("Content-Type", "application/json")
+                    .setContent(
+                        "{\"items\": [{\"name\": \"template1\"}, {\"name\": \"template2\"}], \"nextPageToken\": \"\"}"))
+            .build();
+
+    InstanceTemplates instanceTemplates = createInstanceTemplates(transport);
+
+    PaginatedComputeRequest<Compute.InstanceTemplates.List, InstanceTemplate> request =
+        instanceTemplates.list("BASIC");
+
+    ImmutableList<InstanceTemplate> response = request.execute();
+    assertThat(response).hasSize(2);
+    assertThat(response.get(0).getName()).isEqualTo("template1");
+    assertThat(response.get(1).getName()).isEqualTo("template2");
+  }
+
+  @Test
+  public void list_noResults() throws IOException {
+
+    MockHttpTransport transport =
+        new MockHttpTransport.Builder()
+            .setLowLevelHttpResponse(
+                new MockLowLevelHttpResponse()
+                    .setStatusCode(200)
+                    .setContent("{\"items\": [], \"nextPageToken\": \"\"}"))
+            .build();
+
+    InstanceTemplates instanceTemplates = createInstanceTemplates(transport);
+
+    PaginatedComputeRequest<Compute.InstanceTemplates.List, InstanceTemplate> request =
+        instanceTemplates.list("BASIC");
+
+    ImmutableList<InstanceTemplate> response = request.execute();
+    assertThat(response).isEmpty();
+  }
+
+  @Test
+  public void list_errorResponse() {
+
+    MockHttpTransport transport =
+        new MockHttpTransport.Builder()
+            .setLowLevelHttpResponse(
+                new MockLowLevelHttpResponse()
+                    .setStatusCode(500)
+                    .setContent("{\"error\": \"Internal Server Error\"}"))
+            .build();
+
+    InstanceTemplates instanceTemplates = createInstanceTemplates(transport);
+
+    PaginatedComputeRequest<Compute.InstanceTemplates.List, InstanceTemplate> request =
+        instanceTemplates.list("BASIC");
+
+    assertThatIOException().isThrownBy(() -> request.execute());
+  }
+
+  @Test
+  public void list_withFullView_success() throws IOException {
+
+    MockHttpTransport transport =
+        new MockHttpTransport.Builder()
+            .setLowLevelHttpResponse(
+                new MockLowLevelHttpResponse()
+                    .setStatusCode(200)
+                    .addHeader("Content-Type", "application/json")
+                    .setContent(
+                        "{\"items\": [{\"name\": \"template1\", \"description\": \"Detailed description for template1\"}, {\"name\": \"template2\", \"description\": \"Detailed description for template2\"}], \"nextPageToken\": \"\"}"))
+            .build();
+
+    InstanceTemplates instanceTemplates = createInstanceTemplates(transport);
+
+    PaginatedComputeRequest<Compute.InstanceTemplates.List, InstanceTemplate> request =
+        instanceTemplates.list("FULL");
+
+    ImmutableList<InstanceTemplate> response = request.execute();
+
+    assertThat(response).hasSize(2);
+    assertThat(response.get(0).getName()).isEqualTo("template1");
+    assertThat(response.get(0).getDescription()).isEqualTo("Detailed description for template1");
+    assertThat(response.get(1).getName()).isEqualTo("template2");
+    assertThat(response.get(1).getDescription()).isEqualTo("Detailed description for template2");
   }
 
   private static InstanceTemplates createInstanceTemplates(HttpTransport transport) {

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplatesTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplatesTest.java
@@ -207,7 +207,7 @@ public class InstanceTemplatesTest {
     InstanceTemplates instanceTemplates = createInstanceTemplates(transport);
 
     PaginatedComputeRequest<Compute.InstanceTemplates.List, InstanceTemplate> request =
-        instanceTemplates.list("BASIC");
+        instanceTemplates.list();
 
     ImmutableList<InstanceTemplate> response = request.execute();
     assertThat(response).hasSize(2);
@@ -229,7 +229,7 @@ public class InstanceTemplatesTest {
     InstanceTemplates instanceTemplates = createInstanceTemplates(transport);
 
     PaginatedComputeRequest<Compute.InstanceTemplates.List, InstanceTemplate> request =
-        instanceTemplates.list("BASIC");
+        instanceTemplates.list();
 
     ImmutableList<InstanceTemplate> response = request.execute();
     assertThat(response).isEmpty();
@@ -249,36 +249,9 @@ public class InstanceTemplatesTest {
     InstanceTemplates instanceTemplates = createInstanceTemplates(transport);
 
     PaginatedComputeRequest<Compute.InstanceTemplates.List, InstanceTemplate> request =
-        instanceTemplates.list("BASIC");
+        instanceTemplates.list();
 
     assertThatIOException().isThrownBy(() -> request.execute());
-  }
-
-  @Test
-  public void list_withFullView_success() throws IOException {
-
-    MockHttpTransport transport =
-        new MockHttpTransport.Builder()
-            .setLowLevelHttpResponse(
-                new MockLowLevelHttpResponse()
-                    .setStatusCode(200)
-                    .addHeader("Content-Type", "application/json")
-                    .setContent(
-                        "{\"items\": [{\"name\": \"template1\", \"description\": \"Detailed description for template1\"}, {\"name\": \"template2\", \"description\": \"Detailed description for template2\"}], \"nextPageToken\": \"\"}"))
-            .build();
-
-    InstanceTemplates instanceTemplates = createInstanceTemplates(transport);
-
-    PaginatedComputeRequest<Compute.InstanceTemplates.List, InstanceTemplate> request =
-        instanceTemplates.list("FULL");
-
-    ImmutableList<InstanceTemplate> response = request.execute();
-
-    assertThat(response).hasSize(2);
-    assertThat(response.get(0).getName()).isEqualTo("template1");
-    assertThat(response.get(0).getDescription()).isEqualTo("Detailed description for template1");
-    assertThat(response.get(1).getName()).isEqualTo("template2");
-    assertThat(response.get(1).getDescription()).isEqualTo("Detailed description for template2");
   }
 
   private static InstanceTemplates createInstanceTemplates(HttpTransport transport) {

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplatesTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/InstanceTemplatesTest.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.clouddriver.google.compute;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIOException;
-import static org.mockito.Mockito.*;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.gson.GsonFactory;


### PR DESCRIPTION
When cloning a server group using the UI. The resourceManagerTags and partnerMetadata are not populated even if the deployment is configured with resourceManagerTags and partnerMetadata.

In clouddriver we include the resourceManagerTags under the instanceTemplate properties but by default the partnerMetadata is not included. See https://cloud.google.com/sdk/gcloud/reference/beta/compute/instance-templates/list

The fix only set the view option to "FULL". This ensure the partnerMetadata is included in the instanceTemplate properties.

Deck PR: https://github.com/spinnaker/deck/pull/10161