### PR TITLE
fix(core): fix InMemoryTaskRepository.listByThisInstance

### DIFF
--- a/clouddriver-core-tck/src/main/java/com/netflix/spinnaker/clouddriver/core/test/TaskRepositoryTck.java
+++ b/clouddriver-core-tck/src/main/java/com/netflix/spinnaker/clouddriver/core/test/TaskRepositoryTck.java
@@ -117,6 +117,29 @@ public abstract class TaskRepositoryTck<T extends TaskRepository> {
   }
 
   @Test
+  public void testListByThisInstance() {
+    Task t1 = subject.create("Test", "STARTED");
+    Task t2 = subject.create("Test", "STARTED");
+    Task t3 = subject.create("Test", "STARTED");
+    Task t4 = subject.create("Test", "STARTED");
+    Task t5 = subject.create("Test", "STARTED");
+    String ownerId = ClouddriverHostname.ID;
+
+    t3.updateOwnerId("foo@not_this_clouddriver", "Test");
+    t5.complete();
+
+    List<Task> runningTasks = subject.listByThisInstance();
+
+    assertThat(runningTasks.stream().allMatch(t -> t.getOwnerId().equals(ownerId))).isTrue();
+    assertThat(runningTasks.stream().map(Task::getId).collect(Collectors.toList()))
+        .contains(t1.getId(), t2.getId(), t4.getId());
+    // Task 3 doesn't belong to this pod and task 5 is not running, so should not be included in the
+    // result
+    assertThat(runningTasks.stream().map(Task::getId).collect(Collectors.toList()))
+        .doesNotContain(t3.getId(), t5.getId());
+  }
+
+  @Test
   public void testResultObjectsPersistence() {
     Task t1 = subject.create("Test", "Test Status");
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/InMemoryTaskRepository.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/InMemoryTaskRepository.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.data.task
 
+import com.netflix.spinnaker.clouddriver.core.ClouddriverHostname
+
 import java.util.concurrent.ConcurrentHashMap
 
 class InMemoryTaskRepository implements TaskRepository {
@@ -60,7 +62,7 @@ class InMemoryTaskRepository implements TaskRepository {
 
   @Override
   List<Task> listByThisInstance() {
-    return list()
+    return list().findAll { it.ownerId == ClouddriverHostname.ID }
   }
 
   private String getNextId() {

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
@@ -213,6 +213,7 @@ class OperationsController {
    */
   @PreDestroy
   void destroy() {
+    log.info("Destroy has been triggered. Initiating graceful shutdown of tasks.")
     long start = System.currentTimeMillis()
     def tasks = taskRepository.listByThisInstance()
     while (tasks && !tasks.isEmpty() &&
@@ -225,6 +226,8 @@ class OperationsController {
     if (tasks && !tasks.isEmpty()) {
       log.error("Shutting down while tasks '{}' are still in progress!", tasks)
     }
+
+    log.info("Destruction procedure completed.")
   }
 
   private StartOperationResult start(@Nullable String cloudProvider,


### PR DESCRIPTION
to return only tasks owned by this clouddriver instance

and some other small cleanups, including adding a test which https://github.com/spinnaker/clouddriver/pull/5680 already fixed.