### PR TITLE
fix(ubuntu): add commands so apt-get can install libc

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -8,7 +8,7 @@ ENV KUBECTL_RELEASES="${KUBECTL_DEFAULT_RELEASE} 1.26.12 1.27.9 1.28.5 1.29.0"
 ENV AWS_CLI_VERSION=2.15.57
 ENV AWS_AIM_AUTHENTICATOR_VERSION=0.6.14
 
-RUN apt-get update && apt-get install -y curl gnupg && \
+RUN rm /var/lib/dpkg/info/libc-bin.* && apt-get clean && apt-get update && apt-get install -y curl gnupg && \
   curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
   echo "deb https://packages.cloud.google.com/apt cloud-sdk  main" > /etc/apt/sources.list.d/cloud-sdk.list && \
   apt-get update && \


### PR DESCRIPTION
specifically:
```
rm /var/lib/dpkg/info/libc-bin.* && apt-get clean
```
to fix errors like
```
#9 97.09 Segmentation fault (core dumped)
#9 97.16 qemu: uncaught target signal 11 (Segmentation fault) - core dumped #9 98.28 Segmentation fault (core dumped)
#9 98.29 dpkg: error processing package libc-bin (--configure): #9 98.29  installed libc-bin package post-installation script subprocess returned error exit status 139
```
from https://github.com/spinnaker/clouddriver/actions/runs/13294114050/job/37121755898?pr=6345

Similar to https://github.com/spinnaker/orca/pull/4834.
