### PR TITLE
fix(clouddriver-google): Fix logic when Instance Types are available only in selected Zones/Regions - manual backport

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -177,6 +177,7 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
     if (description.instanceType.contains('custom-')) {
       machineTypeName = description.instanceType
     } else {
+      // This is to handle when resources aren't in all zones but only some and this causes failures on deploys.
       def queryZone = description.regional ? (description.selectZones ? description.distributionPolicy.getZones() : [location]) : [location]
       queryZone.each { zoneOrLocation ->
         def msg = description.regional ?

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -45,6 +45,7 @@ import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.BasicGoogleDeployDescription
+import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleResourceNotFoundException
 import com.netflix.spinnaker.clouddriver.google.deploy.ops.GoogleUserDataProvider
 import com.netflix.spinnaker.clouddriver.google.model.GoogleLabeledResource
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
@@ -176,7 +177,19 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
     if (description.instanceType.contains('custom-')) {
       machineTypeName = description.instanceType
     } else {
-      machineTypeName = GCEUtil.queryMachineType(description.instanceType, location, credentials, task, BASE_PHASE)
+      def queryZone = description.regional ? (description.selectZones ? description.distributionPolicy.getZones() : [location]) : [location]
+      queryZone.each { zoneOrLocation ->
+        def msg = description.regional ?
+          (description.selectZones ?
+            "Machine type ${description.instanceType} not found in zone ${zoneOrLocation}. When using selectZones, the machine type must be available in all selected zones." :
+            "Machine type ${description.instanceType} not found in zone ${zoneOrLocation}. When using Regional distribution without explicit selection of Zones, the machine type must be available in all zones of the region."
+          ) : "Machine type ${description.instanceType} not found in region ${zoneOrLocation}."
+        try {
+          machineTypeName = GCEUtil.queryMachineType(description.instanceType, zoneOrLocation, credentials, task, BASE_PHASE)
+        } catch (GoogleResourceNotFoundException e) {
+          throw new GoogleResourceNotFoundException(msg)
+        }
+      }
     }
 
     def network = GCEUtil.queryNetwork(accountName, description.network ?: DEFAULT_NETWORK_NAME, task, BASE_PHASE, googleNetworkProvider)


### PR DESCRIPTION
Implementation pre-refactoring of https://github.com/spinnaker/clouddriver/pull/6351 to release-1.36.x

In GCP there are some instance types (like c4-highcpu-X) that are available only in specific Zones per Region (or all of the zones in some other regions).

- When the user selects a Regional deployment (Distribute instances across multiple zones) and also selects an instance type that is available only in specific zones in that region:
[Before the fix]: Clouddriver was failing with an error message Instance type not found
[After the fix]: If the instance type selected is available in all the region then it succeeds. If the instance type is not available in all the zones within the region it fails with the appropriate message

- When the user selects a Regional deployment (Distribute instances across multiple zones) and Selects the Zones explicitly + also selects an instance type that is available only in specific zones in that region:
[Before the fix]: Clouddriver was failing with an error message Instance type not found
[After the fix]: If the user selects only the Zones that the instance type is available then it succeeds. If the user selects any Zone that the instance type is not available then it fails with the appropriate message. 