### PR TITLE
test(cats-sql): actually execute groovy tests

### DIFF
--- a/cats/cats-sql/cats-sql.gradle
+++ b/cats/cats-sql/cats-sql.gradle
@@ -62,3 +62,7 @@ dependencies {
   testImplementation "com.mysql:mysql-connector-j"
   testImplementation "org.postgresql:postgresql"
 }
+
+test {
+  useJUnitPlatform()
+}

--- a/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/MySqlCacheSpec.groovy
+++ b/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/MySqlCacheSpec.groovy
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.WriteableCache
 import com.netflix.spinnaker.cats.sql.cache.SqlCache
 import com.netflix.spinnaker.cats.sql.cache.SqlCacheMetrics
-import com.netflix.spinnaker.cats.sql.cache.SqlNamedCacheFactory
 import com.netflix.spinnaker.config.SqlConstraintsInitializer
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
@@ -42,7 +41,7 @@ class MySqlCacheSpec extends SqlCacheSpec {
   @Override
   Cache getSubject() {
     def mapper = new ObjectMapper()
-    def clock = new Clock.FixedClock(Instant.EPOCH, ZoneId.of("UTC"))
+    def clock = Clock.fixed(Instant.EPOCH, ZoneId.of("UTC"))
     def sqlRetryProperties = new SqlRetryProperties(new RetryProperties(1, 10), new RetryProperties(1, 10))
 
     def dynamicConfigService = Mock(DynamicConfigService) {

--- a/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/PostgreSqlCacheSpec.groovy
+++ b/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/PostgreSqlCacheSpec.groovy
@@ -39,7 +39,7 @@ class PostgreSqlCacheSpec extends SqlCacheSpec {
   @Override
   Cache getSubject() {
     def mapper = new ObjectMapper()
-    def clock = new Clock.FixedClock(Instant.EPOCH, ZoneId.of("UTC"))
+    def clock = Clock.fixed(Instant.EPOCH, ZoneId.of("UTC"))
     def sqlRetryProperties = new SqlRetryProperties(new RetryProperties(1, 10), new RetryProperties(1, 10))
 
     def dynamicConfigService = Mock(DynamicConfigService) {

--- a/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/SqlProviderCacheSpec.groovy
+++ b/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/SqlProviderCacheSpec.groovy
@@ -53,7 +53,7 @@ class SqlProviderCacheSpec extends ProviderCacheSpec {
   @Override
   Cache getSubject() {
     def mapper = new ObjectMapper()
-    def clock = new Clock.FixedClock(Instant.EPOCH, ZoneId.of("UTC"))
+    def clock = Clock.fixed(Instant.EPOCH, ZoneId.of("UTC"))
     def sqlRetryProperties = new SqlRetryProperties(new RetryProperties(1, 10), new RetryProperties(1, 10))
     def sqlMetrics = new SpectatorSqlCacheMetrics(new NoopRegistry())
     def dynamicConfigService = Mock(DynamicConfigService) {


### PR DESCRIPTION
Before this they weren't executing.  For example:
```
$ ./gradlew cats:cats-sql:test --tests MySqlCacheSpec
> Task :cats:cats-sql:test FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':cats:cats-sql:test'.
> No tests found for given includes: [MySqlCacheSpec](--tests filter)
```
Once they executed, there were some small tweaks to get them to pass.