### PR TITLE
fix(docker): resolve the issue of double encoding while making the next call to ECR's tags list

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
@@ -243,7 +243,7 @@ class DockerRegistryClient {
     @Headers([
       "Docker-Distribution-API-Version: registry/2.0"
     ])
-    Call<ResponseBody> getTags(@Path(value="repository", encoded=true) String repository, @Header("Authorization") String token, @Header("User-Agent") String agent, @QueryMap Map<String, String> queryParams)
+    Call<ResponseBody> getTags(@Path(value="repository", encoded=true) String repository, @Header("Authorization") String token, @Header("User-Agent") String agent, @QueryMap(encoded=true) Map<String, String> queryParams)
 
 
     @GET("/v2/{name}/manifests/{reference}")
@@ -263,14 +263,14 @@ class DockerRegistryClient {
     @Headers([
         "Docker-Distribution-API-Version: registry/2.0"
     ])
-    Call<ResponseBody> getCatalog(@Header("Authorization") String token, @Header("User-Agent") String agent, @QueryMap Map<String, String> queryParams)
+    Call<ResponseBody> getCatalog(@Header("Authorization") String token, @Header("User-Agent") String agent, @QueryMap(encoded=true) Map<String, String> queryParams)
 
 
     @GET("/{path}")
     @Headers([
         "Docker-Distribution-API-Version: registry/2.0"
     ])
-    Call<ResponseBody> get(@Path(value="path", encoded=true) String path, @Header("Authorization") String token, @Header("User-Agent") String agent, @QueryMap Map<String, String> queryParams)
+    Call<ResponseBody> get(@Path(value="path", encoded=true) String path, @Header("Authorization") String token, @Header("User-Agent") String agent, @QueryMap(encoded=true) Map<String, String> queryParams)
 
 
     @GET("/v2/")
@@ -394,7 +394,6 @@ class DockerRegistryClient {
     }
 
     def headerValues = caseInsensitiveHeaders["link"]
-    headers.values("link")
 
     // We are at the end of the pagination.
     if (!headerValues || headerValues.size() == 0) {
@@ -453,6 +452,7 @@ class DockerRegistryClient {
   }
 
   public DockerRegistryTags getTags(String repository, String path = null, Map<String, String> queryParams = [:]) {
+    queryParams.computeIfAbsent("n", { paginateSize.toString() })
     def response = request({
       path ? Retrofit2SyncCall.executeCall(registryService.get(path, tokenService.basicAuthHeader, userAgent, queryParams)) :
         Retrofit2SyncCall.executeCall(registryService.getTags(repository, tokenService.basicAuthHeader, userAgent, queryParams))

--- a/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentialsTest.java
+++ b/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentialsTest.java
@@ -110,7 +110,7 @@ final class DockerRegistryNamedAccountCredentialsTest {
             .build();
     when(mockTagListCall.execute()).thenReturn(tagListResponse);
     when(okHttpClient.newCall(
-            argThat(r -> r.url().toString().equals("https://gcr.io/v2/myrepo/tags/list"))))
+            argThat(r -> r.url().toString().equals("https://gcr.io/v2/myrepo/tags/list?n=100"))))
         .thenReturn(mockTagListCall);
 
     doAnswer(


### PR DESCRIPTION
Addresses the issue - https://github.com/spinnaker/spinnaker/issues/7015#issuecomment-2707933716

AWS ECR's response header `link` contains encrypted and encoded url which often has special characters like `%2F`(`/ ` before encoding), `%3D`(`=` before encoding) etc. But retrofit2 doesn't allow `%` in the url without encoding it. As a result `%2F`   becomes `%252F` and `%3D` becomes `%253D` as `%25` is the encoded representation of `%` and causing server side error - 
```
com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException: 
Status: 405, Method: GET, 
URL: https://<ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/v2/<REPOSITORY_NAME>/tags/list?last=...%252F...%252B...%252F...%252F...%252F...%252B...%252B...%252B...%253D, 
Message: Method Not Allowed
``` 

This PR addresses the issue by preventing double encoding by retrofit2 client. 

Since the QueryMap was introduced earlier, the very first call to tags list api needs to be passed the original paginate size in the query param. This is addressed in this PR as well.
