### PR TITLE
fix(aws): Launch template version of ASG default to  '$Latest' when not defined

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
@@ -579,7 +579,7 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster>, ServerGro
     // get launch template for version specified
     def ltSpec = serverGroup.getLaunchTemplateSpecification()
     log.debug("Attempting to populate server group $serverGroup.name with launch template $ltSpec.")
-    Map ec2Lt = getLaunchTemplateForVersion(launchData, ltSpec["version"] as String)
+    Map ec2Lt = getLaunchTemplateForVersion(launchData,  (ltSpec["version"] ?: "\$Latest") as String)
 
     if (!ec2Lt) {
       return


### PR DESCRIPTION
An edge case involves an ASG created via CloudFormation or via a Crossplane custom resource which the launchTemplate.version not defined. According to the AWS docs this defaults to $Latest as it is not a mandatory field.

When Clouddriver caches it and if it matches an Application name it will be present in the Cluster view tab. This causes an NPE on the ServerGroupController as:

```
2025-05-15 09:55:00.341 ERROR 1 — [0.0-7002-exec-8] c.n.s.k.w.e.GenericExceptionHandlers     : Internal Server Error
java.lang.NullPointerException: Cannot invoke method toInteger() on null object
at org.codehaus.groovy.runtime.NullObject.invokeMethod(NullObject.java:98) ~[groovy-4.0.15.jar:4.0.15]
at org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.invokeGroovyObjectInvoker(IndyGuardsFiltersAndSignatures.java:151) ~[groovy-4.0.15.jar:4.0.15]
at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321) ~[groovy-4.0.15.jar:4.0.15]
at com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonClusterProvider$_getLaunchTemplateForVersion_closure27.doCall(AmazonClusterProvider.groovy:549) ~[clouddriver-aws-2025.04.10.18.48.11.release-1.36.x.jar:2025.04.10.18.48.11.release-1.36.x]
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
at java.base/java.lang.reflect.Method.invoke(Method.java:569) ~[na:na]
at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343) ~[groovy-4.0.15.jar:4.0.15]
at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328) ~[groovy-4.0.15.jar:4.0.15]
at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:279) ~[groovy-4.0.15.jar:4.0.15]
at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1008) ~[groovy-4.0.15.jar:4.0.15]
at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:39) ~[groovy-4.0.15.jar:4.0.15]
at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45) ~[groovy-4.0.15.jar:4.0.15]
at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125) ~[groovy-4.0.15.jar:4.0.15]
at org.codehaus.groovy.runtime.callsite.BooleanReturningMethodInvoker.invoke(BooleanReturningMethodInvoker.java:49) ~[groovy-4.0.15.jar:4.0.15]
at org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper.call(BooleanClosureWrapper.java:52) ~[groovy-4.0.15.jar:4.0.15]
at org.codehaus.groovy.runtime.DefaultGroovyMethods.find(DefaultGroovyMethods.java:4357) ~[groovy-4.0.15.jar:4.0.15]
at org.codehaus.groovy.runtime.dgm$242.doMethodInvoke(Unknown Source) ~[groovy-4.0.15.jar:4.0.15]
at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321) ~[groovy-4.0.15.jar:4.0.15]
at com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonClusterProvider.getLaunchTemplateForVersion(AmazonClusterProvider.groovy:548) ~[clouddriver-aws-2025.04.10.18.48.11.release-1.36.x.jar:2025.04.10.18.48.11.release-1.36.x]
at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321) ~[groovy-4.0.15.jar:4.0.15]
at com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonClusterProvider.populateServerGroupWithLtOrMip(AmazonClusterProvider.groovy:582) ~[clouddriver-aws-2025.04.10.18.48.11.release-1.36.x.jar:2025.04.10.18.48.11.release-1.36.x]
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
at java.base/java.lang.reflect.Method.invoke(Method.java:569) ~[na:na]
at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343) ~[groovy-4.0.15.jar:4.0.15]
at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328) ~[groovy-4.0.15.jar:4.0.15]
at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:342) ~[groovy-4.0.15.jar:4.0.15]
at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1008) ~[groovy-4.0.15.jar:4.0.15]
at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321) ~[groovy-4.0.15.jar:4.0.15]
at com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonClusterProvider$_updateServerGroupLaunchSettings_closure28.doCall(AmazonClusterProvider.groovy:564) ~[clouddriver-aws-2025.04.10.18.48.11.release-1.36.x.jar:2025.04.10.18.48.11.release-1.36.x]
...
```

