### PR TITLE
fix(google): Add retry and status polling logic

### DIFF
--- a/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.java
+++ b/clouddriver-google/src/main/java/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.java
@@ -178,7 +178,12 @@ public class BasicGoogleDeployHandler
       Image bootImage = buildBootImage(description, task);
       List<AttachedDisk> attachedDisks = buildAttachedDisks(description, task, bootImage);
       NetworkInterface networkInterface = buildNetworkInterface(description, network, subnet);
-      GoogleHttpLoadBalancingPolicy lbPolicy = null;
+
+      // Initialize load balancing policy from deployment description or defaults.
+      // This policy contains configuration such as balancing mode, capacity scaler, and max
+      // utilization that will be applied to backend services when the server group is added to load
+      // balancers.
+      GoogleHttpLoadBalancingPolicy lbPolicy = buildLoadBalancerPolicyFromInput(description);
       List<BackendService> backendServicesToUpdate =
           getBackendServiceToUpdate(description, nextServerGroupName, lbToUpdate, lbPolicy, region);
       List<BackendService> regionBackendServicesToUpdate =
@@ -458,9 +463,15 @@ public class BasicGoogleDeployHandler
   protected boolean hasBackedServiceFromInput(
       BasicGoogleDeployDescription description, LoadBalancerInfo loadBalancerInfo) {
     Map<String, String> instanceMetadata = description.getInstanceMetadata();
-    return (!instanceMetadata.isEmpty() && instanceMetadata.containsKey(BACKEND_SERVICE_NAMES))
+    // We must wait for the managed-instance-group (MIG) creation whenever any
+    // backend-service mapping will be updated later in the handler.
+    return (!instanceMetadata.isEmpty()
+            && (instanceMetadata.containsKey(BACKEND_SERVICE_NAMES)
+                || instanceMetadata.containsKey(REGION_BACKEND_SERVICE_NAMES)))
         || !loadBalancerInfo.getSslLoadBalancers().isEmpty()
-        || !loadBalancerInfo.getTcpLoadBalancers().isEmpty();
+        || !loadBalancerInfo.getTcpLoadBalancers().isEmpty()
+        || !loadBalancerInfo.getInternalLoadBalancers().isEmpty()
+        || !loadBalancerInfo.getInternalHttpLoadBalancers().isEmpty();
   }
 
   protected GoogleHttpLoadBalancingPolicy buildLoadBalancerPolicyFromInput(
@@ -534,6 +545,8 @@ public class BasicGoogleDeployHandler
               this));
       instanceMetadata.put(GLOBAL_LOAD_BALANCER_NAMES, String.join(",", globalLbNames));
 
+      // Retrieve and configure each backend service that this server group should be added to.
+      // Backend services define how traffic is distributed to instance groups for load balancers.
       backendServices.forEach(
           backendServiceName -> {
             try {
@@ -618,12 +631,14 @@ public class BasicGoogleDeployHandler
               .map(GoogleBackendService::getName)
               .collect(Collectors.toList());
 
+      // Process each regional backend service for internal load balancers.
+      // Regional backend services handle traffic within a specific GCP region.
       ilbServices.forEach(
           backendServiceName -> {
             try {
               BackendService backendService =
                   getRegionBackendServiceFromProvider(
-                      description.getCredentials(), region, serverGroupName);
+                      description.getCredentials(), region, backendServiceName);
               Backend backendToAdd;
               if (internalHttpLbBackendServices.contains(backendServiceName)) {
                 backendToAdd = GCEUtil.backendFromLoadBalancingPolicy(policy);
@@ -866,23 +881,60 @@ public class BasicGoogleDeployHandler
     }
   }
 
+  /**
+   * Build auto healing policy from the deployment description input.
+   *
+   * <p>This method queries the health check specified in the deployment description and constructs
+   * the appropriate auto healing policy for the instance group manager.
+   *
+   * <p>Note: GCEUtil.queryHealthCheck() may return a LinkedHashMap when data comes from cache, so
+   * we need to handle both typed objects and raw maps properly.
+   *
+   * @param description The deployment description containing auto healing configuration
+   * @param task The task for status updates
+   * @return List of auto healing policies, or null if not configured
+   */
   protected List<InstanceGroupManagerAutoHealingPolicy> buildAutoHealingPolicyFromInput(
       BasicGoogleDeployDescription description, Task task) {
     GoogleHealthCheck autoHealingHealthCheck = null;
     if (description.getAutoHealingPolicy() != null
         && StringUtils.isNotBlank(description.getAutoHealingPolicy().getHealthCheck())) {
-      autoHealingHealthCheck =
-          (GoogleHealthCheck)
-              GCEUtil.queryHealthCheck(
-                  description.getCredentials().getProject(),
-                  description.getAccountName(),
-                  description.getAutoHealingPolicy().getHealthCheck(),
-                  description.getAutoHealingPolicy().getHealthCheckKind(),
-                  description.getCredentials().getCompute(),
-                  cacheView,
-                  task,
-                  BASE_PHASE,
-                  this);
+      Object healthCheckResult =
+          GCEUtil.queryHealthCheck(
+              description.getCredentials().getProject(),
+              description.getAccountName(),
+              description.getAutoHealingPolicy().getHealthCheck(),
+              description.getAutoHealingPolicy().getHealthCheckKind(),
+              description.getCredentials().getCompute(),
+              cacheView,
+              task,
+              BASE_PHASE,
+              this);
+
+      // Handle both typed GoogleHealthCheck objects and LinkedHashMap from cache
+      if (healthCheckResult != null) {
+        if (healthCheckResult instanceof GoogleHealthCheck) {
+          autoHealingHealthCheck = (GoogleHealthCheck) healthCheckResult;
+        } else if (healthCheckResult instanceof Map) {
+          try {
+            // Convert LinkedHashMap to GoogleHealthCheck using ObjectMapper
+            autoHealingHealthCheck =
+                objectMapper.convertValue(healthCheckResult, GoogleHealthCheck.class);
+          } catch (Exception e) {
+            log.warn(
+                "Failed to convert health check data to GoogleHealthCheck: {}", e.getMessage());
+            task.updateStatus(
+                BASE_PHASE, "Warning: Failed to parse health check data - " + e.getMessage());
+          }
+        } else {
+          log.warn(
+              "Unexpected health check result type: {}", healthCheckResult.getClass().getName());
+          task.updateStatus(
+              BASE_PHASE,
+              "Warning: Unexpected health check data type - "
+                  + healthCheckResult.getClass().getName());
+        }
+      }
     }
     List<InstanceGroupManagerAutoHealingPolicy> autoHealingPolicy = null;
     if (autoHealingHealthCheck != null) {
@@ -1038,31 +1090,43 @@ public class BasicGoogleDeployHandler
     if (!description.getDisableTraffic() && hasBackedServiceFromInput(description, lbInfo)) {
       backendServicesToUpdate.forEach(
           backendService -> {
-            safeRetry.doRetry(
-                updateBackendServices(
-                    description.getCredentials().getCompute(),
-                    description.getCredentials().getProject(),
-                    backendService.getName(),
-                    backendService),
-                "Load balancer backend service",
-                task,
-                List.of(400, 412),
-                Collections.emptyList(),
-                Map.of(
-                    "action",
-                    "update",
-                    "phase",
-                    BASE_PHASE,
-                    "operation",
-                    "updateBackendServices",
-                    TAG_SCOPE,
-                    SCOPE_GLOBAL),
-                registry);
+            Operation backendServiceOperation =
+                (Operation)
+                    safeRetry.doRetry(
+                        updateBackendServices(
+                            description.getCredentials().getCompute(),
+                            description.getCredentials().getProject(),
+                            backendService.getName(),
+                            backendService),
+                        "Load balancer backend service",
+                        task,
+                        List.of(400, 412),
+                        Collections.emptyList(),
+                        Map.of(
+                            "action",
+                            "update",
+                            "phase",
+                            BASE_PHASE,
+                            "operation",
+                            "updateBackendServices",
+                            TAG_SCOPE,
+                            SCOPE_GLOBAL),
+                        registry);
             task.updateStatus(
                 BASE_PHASE,
                 String.format(
                     "Done associating server group %s with backend service %s.",
                     serverGroupName, backendService.getName()));
+
+            // Wait for the global backend service update to complete
+            googleOperationPoller.waitForGlobalOperation(
+                description.getCredentials().getCompute(),
+                description.getCredentials().getProject(),
+                backendServiceOperation.getName(),
+                null,
+                task,
+                "backend service " + backendService.getName(),
+                BASE_PHASE);
           });
     }
   }
@@ -1079,34 +1143,47 @@ public class BasicGoogleDeployHandler
             || !lbInfo.internalHttpLoadBalancers.isEmpty())) {
       regionBackendServicesToUpdate.forEach(
           backendService -> {
-            safeRetry.doRetry(
-                updateBackendServices(
-                    description.getCredentials().getCompute(),
-                    description.getCredentials().getProject(),
-                    backendService.getName(),
-                    backendService,
-                    region),
-                "Internal load balancer backend service",
-                task,
-                List.of(400, 412),
-                Collections.emptyList(),
-                Map.of(
-                    "action",
-                    "update",
-                    "phase",
-                    BASE_PHASE,
-                    "operation",
-                    "updateRegionBackendServices",
-                    TAG_SCOPE,
-                    SCOPE_REGIONAL,
-                    TAG_REGION,
-                    region),
-                registry);
+            Operation backendServiceOperation =
+                (Operation)
+                    safeRetry.doRetry(
+                        updateBackendServices(
+                            description.getCredentials().getCompute(),
+                            description.getCredentials().getProject(),
+                            backendService.getName(),
+                            backendService,
+                            region),
+                        "Internal load balancer backend service",
+                        task,
+                        List.of(400, 412),
+                        Collections.emptyList(),
+                        Map.of(
+                            "action",
+                            "update",
+                            "phase",
+                            BASE_PHASE,
+                            "operation",
+                            "updateRegionBackendServices",
+                            TAG_SCOPE,
+                            SCOPE_REGIONAL,
+                            TAG_REGION,
+                            region),
+                        registry);
             task.updateStatus(
                 BASE_PHASE,
                 String.format(
                     "Done associating server group %s with backend service %s.",
                     serverGroupName, backendService.getName()));
+
+            // Wait for the regional backend service update to complete
+            googleOperationPoller.waitForRegionalOperation(
+                description.getCredentials().getCompute(),
+                description.getCredentials().getProject(),
+                region,
+                backendServiceOperation.getName(),
+                null,
+                task,
+                "backend service " + backendService.getName(),
+                BASE_PHASE);
           });
     }
   }
@@ -1214,20 +1291,34 @@ public class BasicGoogleDeployHandler
       task.updateStatus(
           BASE_PHASE, String.format("Creating regional autoscaler for %s...", serverGroupName));
 
+      // Build autoscaler configuration from the deployment description
+      // The autoscaler will manage the instance group created above (targetLink)
       Autoscaler autoscaler =
           GCEUtil.buildAutoscaler(serverGroupName, targetLink, description.getAutoscalingPolicy());
 
-      timeExecute(
-          description
-              .getCredentials()
-              .getCompute()
-              .regionAutoscalers()
-              .insert(description.getCredentials().getProject(), region, autoscaler),
-          "compute.regionAutoscalers.insert",
-          TAG_SCOPE,
-          SCOPE_REGIONAL,
-          TAG_REGION,
-          region);
+      Operation autoscalerOperation =
+          timeExecute(
+              description
+                  .getCredentials()
+                  .getCompute()
+                  .regionAutoscalers()
+                  .insert(description.getCredentials().getProject(), region, autoscaler),
+              "compute.regionAutoscalers.insert",
+              TAG_SCOPE,
+              SCOPE_REGIONAL,
+              TAG_REGION,
+              region);
+
+      // Wait for regional autoscaler creation to complete before proceeding with deployment
+      googleOperationPoller.waitForRegionalOperation(
+          description.getCredentials().getCompute(),
+          description.getCredentials().getProject(),
+          region,
+          autoscalerOperation.getName(),
+          null,
+          task,
+          "regional autoscaler " + serverGroupName,
+          BASE_PHASE);
     }
   }
 
@@ -1284,23 +1375,57 @@ public class BasicGoogleDeployHandler
       task.updateStatus(
           BASE_PHASE, String.format("Creating zonal autoscaler for %s...", serverGroupName));
 
+      // Build autoscaler configuration from the deployment description
+      // The autoscaler will manage the instance group created above (targetLink)
       Autoscaler autoscaler =
           GCEUtil.buildAutoscaler(serverGroupName, targetLink, description.getAutoscalingPolicy());
 
-      timeExecute(
-          description
-              .getCredentials()
-              .getCompute()
-              .autoscalers()
-              .insert(description.getCredentials().getProject(), description.getZone(), autoscaler),
-          "compute.autoscalers.insert",
-          TAG_SCOPE,
-          SCOPE_ZONAL,
-          TAG_ZONE,
-          description.getZone());
+      Operation autoscalerOperation =
+          timeExecute(
+              description
+                  .getCredentials()
+                  .getCompute()
+                  .autoscalers()
+                  .insert(
+                      description.getCredentials().getProject(), description.getZone(), autoscaler),
+              "compute.autoscalers.insert",
+              TAG_SCOPE,
+              SCOPE_ZONAL,
+              TAG_ZONE,
+              description.getZone());
+
+      // Wait for zonal autoscaler creation to complete before proceeding with deployment
+      googleOperationPoller.waitForZonalOperation(
+          description.getCredentials().getCompute(),
+          description.getCredentials().getProject(),
+          description.getZone(),
+          autoscalerOperation.getName(),
+          null,
+          task,
+          "autoscaler " + serverGroupName,
+          BASE_PHASE);
     }
   }
 
+  /**
+   * Creates a closure to update global backend services with new instance groups.
+   *
+   * <p>Per Google Cloud documentation: "Backend service operations are asynchronous and return an
+   * Operation resource. You can use an operation resource to manage asynchronous API requests.
+   * Operations can be global, regional or zonal. For global operations, use the globalOperations
+   * resource."
+   *
+   * <p>The returned Operation object must be polled until completion to ensure the backend service
+   * update has been fully applied before proceeding with subsequent deployment steps. This prevents
+   * race conditions where health checks or traffic routing occurs before the backend service knows
+   * about the new instance group.
+   *
+   * @param compute GCP Compute API client
+   * @param project GCP project ID
+   * @param backendServiceName Name of the backend service to update
+   * @param backendService Backend service configuration with new backends to add
+   * @return Closure that returns an Operation object for the update request
+   */
   private Closure updateBackendServices(
       Compute compute, String project, String backendServiceName, BackendService backendService) {
     return new Closure<>(this, this) {
@@ -1315,31 +1440,56 @@ public class BasicGoogleDeployHandler
                   TAG_SCOPE,
                   SCOPE_GLOBAL);
         } catch (IOException e) {
-          log.error(e.getMessage());
+          log.error(
+              "Failed to retrieve backend service {}: {}", backendServiceName, e.getMessage());
         }
         if (serviceToUpdate.getBackends() == null) {
           serviceToUpdate.setBackends(new ArrayList<>());
         }
+
+        // Add the new backend (instance group) to the existing backend service configuration.
+        // This allows the load balancer to route traffic to instances in the new server group.
         BackendService finalServiceToUpdate = serviceToUpdate;
         backendService.getBackends().forEach(it -> finalServiceToUpdate.getBackends().add(it));
+
+        // Deduplicate backends by group URL to avoid adding the same instance group multiple times.
         Set<String> seenGroup = new HashSet<>();
-        serviceToUpdate.getBackends().stream()
-            .filter(backend -> seenGroup.add(backend.getGroup()))
-            .collect(Collectors.toList());
+        List<Backend> uniqueBackends =
+            serviceToUpdate.getBackends().stream()
+                .filter(backend -> seenGroup.add(backend.getGroup()))
+                .collect(Collectors.toList());
+        serviceToUpdate.setBackends(uniqueBackends);
+
+        // Execute the backend service update and return the Operation for async polling.
+        // The caller can use this Operation to wait until the update is fully applied.
         try {
-          timeExecute(
+          return timeExecute(
               compute.backendServices().update(project, backendServiceName, serviceToUpdate),
               "compute.backendServices.update",
               TAG_SCOPE,
               SCOPE_GLOBAL);
         } catch (IOException e) {
-          log.error(e.getMessage());
+          log.error("Failed to update backend service {}: {}", backendServiceName, e.getMessage());
         }
         return null;
       }
     };
   }
 
+  /**
+   * Creates a closure to update regional backend services with new instance groups.
+   *
+   * <p>Regional backend services are used for Internal Load Balancers and Internal HTTP(S) Load
+   * Balancers. The returned Operation object must be polled until completion to ensure the backend
+   * service update has been fully applied before proceeding with subsequent deployment steps.
+   *
+   * @param compute GCP Compute API client
+   * @param project GCP project ID
+   * @param backendServiceName Name of the regional backend service to update
+   * @param backendService Backend service configuration with new backends to add
+   * @param region GCP region where the backend service is located
+   * @return Closure that returns an Operation object for the update request
+   */
   private Closure updateBackendServices(
       Compute compute,
       String project,
@@ -1353,30 +1503,54 @@ public class BasicGoogleDeployHandler
         try {
           serviceToUpdate =
               timeExecute(
-                  compute.backendServices().get(project, backendServiceName),
+                  compute.regionBackendServices().get(project, region, backendServiceName),
                   "compute.regionBackendServices.get",
                   TAG_SCOPE,
-                  SCOPE_GLOBAL);
+                  SCOPE_REGIONAL,
+                  TAG_REGION,
+                  region);
         } catch (IOException e) {
-          log.error(e.getMessage());
+          log.error(
+              "Failed to retrieve regional backend service {}: {}",
+              backendServiceName,
+              e.getMessage());
         }
         if (serviceToUpdate.getBackends() == null) {
           serviceToUpdate.setBackends(new ArrayList<>());
         }
+
+        // Add the new backend (instance group) to the existing regional backend service
+        // configuration.
+        // Regional backend services handle internal load balancer traffic within the specified
+        // region.
         BackendService finalServiceToUpdate = serviceToUpdate;
         backendService.getBackends().forEach(it -> finalServiceToUpdate.getBackends().add(it));
+
+        // Deduplicate backends by group URL to ensure each instance group is only added once.
         Set<String> seenGroup = new HashSet<>();
-        serviceToUpdate.getBackends().stream()
-            .filter(backend -> seenGroup.add(backend.getGroup()))
-            .collect(Collectors.toList());
+        List<Backend> uniqueBackends =
+            serviceToUpdate.getBackends().stream()
+                .filter(backend -> seenGroup.add(backend.getGroup()))
+                .collect(Collectors.toList());
+        serviceToUpdate.setBackends(uniqueBackends);
+
+        // Execute the regional backend service update and return the Operation for async polling.
+        // The Operation allows the caller to wait for the update to complete before proceeding.
         try {
-          timeExecute(
-              compute.backendServices().update(project, backendServiceName, serviceToUpdate),
+          return timeExecute(
+              compute
+                  .regionBackendServices()
+                  .update(project, region, backendServiceName, serviceToUpdate),
               "compute.regionBackendServices.update",
               TAG_SCOPE,
-              SCOPE_GLOBAL);
+              SCOPE_REGIONAL,
+              TAG_REGION,
+              region);
         } catch (IOException e) {
-          log.error(e.getMessage());
+          log.error(
+              "Failed to update regional backend service {}: {}",
+              backendServiceName,
+              e.getMessage());
         }
         return null;
       }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandlerSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandlerSpec.groovy
@@ -18,6 +18,9 @@ package com.netflix.spinnaker.clouddriver.google.deploy.handlers
 
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.ComputeRequest
+import com.google.api.services.compute.model.Autoscaler
+import com.google.api.services.compute.model.Backend
+import com.google.api.services.compute.model.BackendService
 import com.google.api.services.compute.model.Image
 import com.google.api.services.compute.model.ImageList
 import com.google.api.services.compute.model.Instance
@@ -26,10 +29,28 @@ import com.google.api.services.compute.model.MachineType
 import com.google.api.services.compute.model.MachineTypeList
 import com.google.api.services.compute.model.Network
 import com.google.api.services.compute.model.NetworkList
+import com.google.api.services.compute.model.Operation
+import com.netflix.spectator.api.Clock
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.Timer
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.BasicGoogleDeployDescription
+import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleHttpLoadBalancingPolicy
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancingPolicy
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancerView
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleBackendService
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleInternalLoadBalancer
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleInternalHttpLoadBalancer
 import com.netflix.spinnaker.clouddriver.google.security.GoogleCredentials
+import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.names.NamerRegistry
+import com.netflix.spinnaker.moniker.Namer
+import com.fasterxml.jackson.databind.ObjectMapper
 import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
@@ -86,5 +107,533 @@ class BasicGoogleDeployHandlerSpec extends Specification {
     list.execute() >> listModel
     mock.list(_, _) >> list
     mock
+  }
+
+  def "getBackendServiceToUpdate returns empty list when no backend service metadata"() {
+    given:
+    def handler = new BasicGoogleDeployHandler()
+    def description = new BasicGoogleDeployDescription()
+    def lbInfo = new BasicGoogleDeployHandler.LoadBalancerInfo()
+    def policy = new GoogleHttpLoadBalancingPolicy()
+    
+    // Setup description with no backend service metadata
+    description.instanceMetadata = [:]
+    
+    when:
+    def result = handler.getBackendServiceToUpdate(description, "test-server-group", lbInfo, policy, "us-central1")
+    
+    then:
+    result.isEmpty()
+  }
+  
+  def "hasBackedServiceFromInput returns true when backend service names in metadata"() {
+    given:
+    def handler = new BasicGoogleDeployHandler()
+    def description = new BasicGoogleDeployDescription()
+    def lbInfo = new BasicGoogleDeployHandler.LoadBalancerInfo()
+    
+    // Setup description with backend service metadata
+    description.instanceMetadata = ["backend-service-names": "test-backend-1"]
+    
+    when:
+    def result = handler.hasBackedServiceFromInput(description, lbInfo)
+    
+    then:
+    result == true
+  }
+  
+  def "hasBackedServiceFromInput returns false when no relevant metadata or load balancers"() {
+    given:
+    def handler = new BasicGoogleDeployHandler()
+    def description = new BasicGoogleDeployDescription()
+    def lbInfo = new BasicGoogleDeployHandler.LoadBalancerInfo()
+    
+    // Setup description with no relevant metadata
+    description.instanceMetadata = [:]
+    
+    when:
+    def result = handler.hasBackedServiceFromInput(description, lbInfo)
+    
+    then:
+    result == false
+  }
+    
+  def "autoscaler operations return operations for waiting"() {
+    setup:
+    def mockRegistry = Mock(Registry)
+    def mockClock = Mock(Clock)
+    def mockTimer = Mock(Timer)
+    def mockId = Mock(Id)
+    def mockCompute = Mock(Compute)
+    def mockAutoscalers = Mock(Compute.Autoscalers)
+    def mockAutoscalerInsert = Mock(Compute.Autoscalers.Insert)
+    def mockRegionAutoscalers = Mock(Compute.RegionAutoscalers)
+    def mockRegAutoscalerInsert = Mock(Compute.RegionAutoscalers.Insert)
+    
+    mockRegistry.clock() >> mockClock
+    mockRegistry.createId(_, _) >> mockId
+    mockId.withTags(_) >> mockId
+    mockRegistry.timer(_) >> mockTimer
+    mockClock.monotonicTime() >> 1000L
+    
+    def zonalOperation = new Operation(name: "zonal-op", status: "DONE")
+    def regionalOperation = new Operation(name: "regional-op", status: "DONE")
+    
+    mockCompute.autoscalers() >> mockAutoscalers
+    mockCompute.regionAutoscalers() >> mockRegionAutoscalers
+    mockAutoscalers.insert(_, _, _) >> mockAutoscalerInsert
+    mockAutoscalerInsert.execute() >> zonalOperation
+    mockRegionAutoscalers.insert(_, _, _) >> mockRegAutoscalerInsert
+    mockRegAutoscalerInsert.execute() >> regionalOperation
+    
+    def handler = new BasicGoogleDeployHandler(registry: mockRegistry)
+    
+    when:
+    def zonalResult = handler.timeExecute(mockAutoscalerInsert, "compute.autoscalers.insert", "TAG_SCOPE", "SCOPE_ZONAL")
+    def regionalResult = handler.timeExecute(mockRegAutoscalerInsert, "compute.regionAutoscalers.insert", "TAG_SCOPE", "SCOPE_REGIONAL")
+    
+    then:
+    1 * mockAutoscalerInsert.execute() >> zonalOperation
+    1 * mockRegAutoscalerInsert.execute() >> regionalOperation
+    
+    zonalResult.getName() == "zonal-op"
+    regionalResult.getName() == "regional-op"
+  }
+
+  def "buildLoadBalancerPolicyFromInput initializes policy from description"() {
+    given:
+    def handler = new BasicGoogleDeployHandler()
+    handler.objectMapper = new ObjectMapper()
+    
+    def description = new BasicGoogleDeployDescription()
+    description.instanceMetadata = [:] // Initialize empty metadata map
+    def inputPolicy = new GoogleHttpLoadBalancingPolicy(
+        balancingMode: GoogleLoadBalancingPolicy.BalancingMode.UTILIZATION,
+        maxUtilization: 0.8f,
+        capacityScaler: 1.0f
+    )
+    description.loadBalancingPolicy = inputPolicy
+    
+    when:
+    def result = handler.buildLoadBalancerPolicyFromInput(description)
+    
+    then:
+    result != null
+    result.balancingMode == GoogleLoadBalancingPolicy.BalancingMode.UTILIZATION
+    result.maxUtilization == 0.8f
+    result.capacityScaler == 1.0f
+  }
+
+  def "buildLoadBalancerPolicyFromInput creates default policy when no input provided"() {
+    given:
+    def handler = new BasicGoogleDeployHandler()
+    handler.objectMapper = new ObjectMapper()
+    
+    def description = new BasicGoogleDeployDescription()
+    description.instanceMetadata = [:] // Initialize empty metadata map
+    // No load balancing policy set in description
+    
+    when:
+    def result = handler.buildLoadBalancerPolicyFromInput(description)
+    
+    then:
+    result != null
+    result.balancingMode == GoogleLoadBalancingPolicy.BalancingMode.UTILIZATION
+    // Should have sensible defaults for HTTP load balancing
+    result.maxRatePerInstance == null
+    result.maxConnectionsPerInstance == null
+    result.maxUtilization != null  // Default for UTILIZATION mode
+    result.capacityScaler != null
+  }
+  
+  def "buildLoadBalancerPolicyFromInput uses policy from JSON metadata when available"() {
+    given:
+    def handler = new BasicGoogleDeployHandler()
+    handler.objectMapper = new ObjectMapper()
+    
+    def description = new BasicGoogleDeployDescription()
+    def policyJson = '''{
+      "balancingMode": "UTILIZATION",
+      "maxUtilization": 0.9,
+      "capacityScaler": 0.8
+    }'''
+    description.instanceMetadata = ["load-balancing-policy": policyJson]
+    // No loadBalancingPolicy set in description to test JSON fallback
+    
+    when:
+    def result = handler.buildLoadBalancerPolicyFromInput(description)
+    
+    then:
+    result != null
+    result.balancingMode == GoogleLoadBalancingPolicy.BalancingMode.UTILIZATION
+    result.maxUtilization == 0.9f
+    result.capacityScaler == 0.8f
+  }
+  
+  def "buildLoadBalancerPolicyFromInput handles invalid JSON gracefully"() {
+    given:
+    def handler = new BasicGoogleDeployHandler()
+    handler.objectMapper = new ObjectMapper()
+    
+    def description = new BasicGoogleDeployDescription()
+    description.instanceMetadata = ["load-balancing-policy": "invalid-json{"]
+    // No loadBalancingPolicy set in description
+    
+    when:
+    def result = handler.buildLoadBalancerPolicyFromInput(description)
+    
+    then:
+    // Should throw JsonProcessingException for invalid JSON
+    thrown(com.fasterxml.jackson.core.JsonProcessingException)
+  }
+  
+  def "buildLoadBalancerPolicyFromInput prioritizes description policy over metadata"() {
+    given:
+    def handler = new BasicGoogleDeployHandler()
+    handler.objectMapper = new ObjectMapper()
+    
+    def description = new BasicGoogleDeployDescription()
+    def inputPolicy = new GoogleHttpLoadBalancingPolicy(
+        balancingMode: GoogleLoadBalancingPolicy.BalancingMode.RATE,
+        maxRatePerInstance: 1000
+    )
+    description.loadBalancingPolicy = inputPolicy
+    
+    // Add JSON metadata that should be ignored since description policy is set
+    def policyJson = '''{
+      "balancingMode": "UTILIZATION",
+      "maxUtilization": 0.9
+    }'''
+    description.instanceMetadata = ["load-balancing-policy": policyJson]
+    
+    when:
+    def result = handler.buildLoadBalancerPolicyFromInput(description)
+    
+    then:
+    result != null
+    result.balancingMode == GoogleLoadBalancingPolicy.BalancingMode.RATE
+    result.maxRatePerInstance == 1000
+    // Should use description policy, not JSON metadata
+    result.maxUtilization == null
+  }
+
+  def "getBackendServiceFromProvider retrieves backend service successfully"() {
+    given:
+    def mockCompute = Mock(Compute)
+    def mockBackendServices = Mock(Compute.BackendServices)
+    def mockGet = Mock(Compute.BackendServices.Get)
+    def expectedBackendService = new BackendService(name: "test-backend-service")
+    
+    // Setup registry mocks for timeExecute
+    def mockRegistry = Mock(Registry)
+    def mockClock = Mock(Clock)
+    def mockTimer = Mock(Timer)
+    def mockId = Mock(Id)
+    mockRegistry.clock() >> mockClock
+    mockRegistry.createId(_, _) >> mockId
+    mockId.withTags(_) >> mockId
+    mockRegistry.timer(_) >> mockTimer
+    mockClock.monotonicTime() >> 1000L
+    
+    def handler = new BasicGoogleDeployHandler(registry: mockRegistry)
+    
+    // Create real credentials with mocked compute
+    def credentials = new GoogleNamedAccountCredentials.Builder()
+        .name("test-account")
+        .project("test-project")
+        .compute(mockCompute)
+        .build()
+    
+    mockCompute.backendServices() >> mockBackendServices
+    mockBackendServices.get("test-project", "test-backend-service") >> mockGet
+    mockGet.execute() >> expectedBackendService
+    
+    when:
+    def result = handler.getBackendServiceFromProvider(credentials, "test-backend-service")
+    
+    then:
+    result == expectedBackendService
+    result.name == "test-backend-service"
+  }
+  
+  def "getBackendServiceFromProvider propagates IOException"() {
+    given:
+    def mockCompute = Mock(Compute)
+    def mockBackendServices = Mock(Compute.BackendServices)
+    def mockGet = Mock(Compute.BackendServices.Get)
+    
+    // Setup registry mocks for timeExecute
+    def mockRegistry = Mock(Registry)
+    def mockClock = Mock(Clock)
+    def mockTimer = Mock(Timer)
+    def mockId = Mock(Id)
+    mockRegistry.clock() >> mockClock
+    mockRegistry.createId(_, _) >> mockId
+    mockId.withTags(_) >> mockId
+    mockRegistry.timer(_) >> mockTimer
+    mockClock.monotonicTime() >> 1000L
+    
+    def handler = new BasicGoogleDeployHandler(registry: mockRegistry)
+    
+    // Create real credentials with mocked compute
+    def credentials = new GoogleNamedAccountCredentials.Builder()
+        .name("test-account")
+        .project("test-project")
+        .compute(mockCompute)
+        .build()
+    
+    mockCompute.backendServices() >> mockBackendServices
+    mockBackendServices.get("test-project", "test-backend-service") >> mockGet
+    mockGet.execute() >> { throw new IOException("Network error") }
+    
+    when:
+    handler.getBackendServiceFromProvider(credentials, "test-backend-service")
+    
+    then:
+    thrown(IOException)
+  }
+
+  def "getRegionBackendServiceFromProvider retrieves regional backend service successfully"() {
+    given:
+    def mockCompute = Mock(Compute)
+    def mockRegionBackendServices = Mock(Compute.RegionBackendServices)
+    def mockGet = Mock(Compute.RegionBackendServices.Get)
+    def expectedBackendService = new BackendService(name: "test-regional-backend-service")
+    
+    // Setup registry mocks for timeExecute
+    def mockRegistry = Mock(Registry)
+    def mockClock = Mock(Clock)
+    def mockTimer = Mock(Timer)
+    def mockId = Mock(Id)
+    mockRegistry.clock() >> mockClock
+    mockRegistry.createId(_, _) >> mockId
+    mockId.withTags(_) >> mockId
+    mockRegistry.timer(_) >> mockTimer
+    mockClock.monotonicTime() >> 1000L
+    
+    def handler = new BasicGoogleDeployHandler(registry: mockRegistry)
+    
+    // Create real credentials with mocked compute
+    def credentials = new GoogleNamedAccountCredentials.Builder()
+        .name("test-account")
+        .project("test-project")
+        .compute(mockCompute)
+        .build()
+    
+    mockCompute.regionBackendServices() >> mockRegionBackendServices
+    mockRegionBackendServices.get("test-project", "us-central1", "test-regional-backend-service") >> mockGet
+    mockGet.execute() >> expectedBackendService
+    
+    when:
+    def result = handler.getRegionBackendServiceFromProvider(credentials, "us-central1", "test-regional-backend-service")
+    
+    then:
+    result == expectedBackendService
+    result.name == "test-regional-backend-service"
+  }
+  
+  def "getRegionBackendServiceFromProvider propagates IOException"() {
+    given:
+    def mockCompute = Mock(Compute)
+    def mockRegionBackendServices = Mock(Compute.RegionBackendServices)
+    def mockGet = Mock(Compute.RegionBackendServices.Get)
+    
+    // Setup registry mocks for timeExecute
+    def mockRegistry = Mock(Registry)
+    def mockClock = Mock(Clock)
+    def mockTimer = Mock(Timer)
+    def mockId = Mock(Id)
+    mockRegistry.clock() >> mockClock
+    mockRegistry.createId(_, _) >> mockId
+    mockId.withTags(_) >> mockId
+    mockRegistry.timer(_) >> mockTimer
+    mockClock.monotonicTime() >> 1000L
+    
+    def handler = new BasicGoogleDeployHandler(registry: mockRegistry)
+    
+    // Create real credentials with mocked compute
+    def credentials = new GoogleNamedAccountCredentials.Builder()
+        .name("test-account")
+        .project("test-project")
+        .compute(mockCompute)
+        .build()
+    
+    mockCompute.regionBackendServices() >> mockRegionBackendServices
+    mockRegionBackendServices.get("test-project", "us-central1", "test-regional-backend-service") >> mockGet
+    mockGet.execute() >> { throw new IOException("Network error") }
+    
+    when:
+    handler.getRegionBackendServiceFromProvider(credentials, "us-central1", "test-regional-backend-service")
+    
+    then:
+    thrown(IOException)
+  }
+
+  def "getRegionBackendServicesToUpdate returns empty list when no internal load balancers"() {
+    given:
+    def handler = new BasicGoogleDeployHandler()
+    def description = new BasicGoogleDeployDescription()
+    def lbInfo = new BasicGoogleDeployHandler.LoadBalancerInfo()
+    def policy = new GoogleHttpLoadBalancingPolicy()
+    
+    // Setup description with no internal load balancers
+    description.instanceMetadata = [:]
+    lbInfo.internalLoadBalancers = []
+    lbInfo.internalHttpLoadBalancers = []
+    
+    when:
+    def result = handler.getRegionBackendServicesToUpdate(description, "test-server-group", lbInfo, policy, "us-central1")
+    
+    then:
+    result.isEmpty()
+  }
+
+  def "getBackendServiceToUpdate handles IOException by logging error and returning empty list"() {
+    given:
+    def mockDescription = Mock(BasicGoogleDeployDescription)
+    def mockCompute = Mock(Compute)
+    def mockBackendServices = Mock(Compute.BackendServices)
+    def mockGet = Mock(Compute.BackendServices.Get)
+    def mockUrlMaps = Mock(Compute.UrlMaps)
+    def lbInfo = Mock(BasicGoogleDeployHandler.LoadBalancerInfo)
+    def lbPolicy = new GoogleHttpLoadBalancingPolicy()
+    
+    // Setup registry mocks for timeExecute
+    def mockRegistry = Mock(Registry)
+    def mockClock = Mock(Clock)
+    def mockTimer = Mock(Timer)
+    def mockId = Mock(Id)
+    mockRegistry.clock() >> mockClock
+    mockRegistry.createId(_, _) >> mockId
+    mockId.withTags(_) >> mockId
+    mockRegistry.timer(_) >> mockTimer
+    mockClock.monotonicTime() >> 1000L
+    
+    def handler = new BasicGoogleDeployHandler(registry: mockRegistry)
+    
+    // Create real credentials with mocked compute
+    def credentials = new GoogleNamedAccountCredentials.Builder()
+        .name("test-account")
+        .project("test-project")
+        .compute(mockCompute)
+        .build()
+    
+    // Mock description
+    mockDescription.getCredentials() >> credentials
+    mockDescription.getInstanceMetadata() >> ["backend-service-names": "test-backend-service"]
+    
+    // Mock all required methods on LoadBalancerInfo
+    lbInfo.getSslLoadBalancers() >> []
+    lbInfo.getTcpLoadBalancers() >> []
+    lbInfo.getHttpLoadBalancers() >> []
+    lbInfo.getInternalLoadBalancers() >> []
+    lbInfo.getInternalHttpLoadBalancers() >> []
+    lbInfo.hasBackedServiceFromInput(mockDescription, lbPolicy) >> true
+    
+    // Mock compute API calls needed by GCEUtil.resolveHttpLoadBalancerNamesMetadata
+    def mockUrlMapsList = Mock(Compute.UrlMaps.List)
+    def mockGlobalForwardingRules = Mock(Compute.GlobalForwardingRules)
+    def mockGlobalForwardingRulesList = Mock(Compute.GlobalForwardingRules.List)
+    
+    mockCompute.urlMaps() >> mockUrlMaps
+    mockUrlMaps.list("test-project") >> mockUrlMapsList
+    mockUrlMapsList.execute() >> [items: []]
+    
+    mockCompute.globalForwardingRules() >> mockGlobalForwardingRules
+    mockGlobalForwardingRules.list("test-project") >> mockGlobalForwardingRulesList
+    mockGlobalForwardingRulesList.execute() >> [items: []]
+    
+    // Mock backend service API to throw IOException
+    mockCompute.backendServices() >> mockBackendServices
+    mockBackendServices.get("test-project", "test-backend-service") >> mockGet
+    mockGet.execute() >> { throw new IOException("GCP API error") }
+    
+    when:
+    def result = handler.getBackendServiceToUpdate(mockDescription, "server-group", lbInfo, lbPolicy, "us-central1")
+    
+    then:
+    // Should not throw exception, should return empty list instead
+    result.isEmpty()
+  }
+  
+  def "getBackendServiceToUpdate returns empty list when no backend services in metadata"() {
+    given:
+    def mockDescription = Mock(BasicGoogleDeployDescription)
+    def lbInfo = Mock(BasicGoogleDeployHandler.LoadBalancerInfo)
+    def lbPolicy = new GoogleHttpLoadBalancingPolicy()
+    
+    def handler = new BasicGoogleDeployHandler()
+    
+    // Mock description with no backend service metadata
+    mockDescription.getInstanceMetadata() >> [:]
+    
+    // Mock all required methods on LoadBalancerInfo
+    lbInfo.getSslLoadBalancers() >> []
+    lbInfo.getTcpLoadBalancers() >> []
+    lbInfo.getHttpLoadBalancers() >> []
+    lbInfo.getInternalLoadBalancers() >> []
+    lbInfo.getInternalHttpLoadBalancers() >> []
+    lbInfo.hasBackedServiceFromInput(mockDescription, lbPolicy) >> false
+    
+    when:
+    def result = handler.getBackendServiceToUpdate(mockDescription, "server-group", lbInfo, lbPolicy, "us-central1")
+    
+    then:
+    result.isEmpty()
+  }
+  
+  def "getRegionBackendServicesToUpdate handles IOException by logging error and returning empty list"() {
+    given:
+    def mockDescription = Mock(BasicGoogleDeployDescription)
+    def mockCompute = Mock(Compute)
+    def mockRegionBackendServices = Mock(Compute.RegionBackendServices)
+    def mockGet = Mock(Compute.RegionBackendServices.Get)
+    def lbInfo = Mock(BasicGoogleDeployHandler.LoadBalancerInfo)
+    def lbPolicy = new GoogleHttpLoadBalancingPolicy()
+    
+    // Setup registry mocks for timeExecute
+    def mockRegistry = Mock(Registry)
+    def mockClock = Mock(Clock)
+    def mockTimer = Mock(Timer)
+    def mockId = Mock(Id)
+    mockRegistry.clock() >> mockClock
+    mockRegistry.createId(_, _) >> mockId
+    mockId.withTags(_) >> mockId
+    mockRegistry.timer(_) >> mockTimer
+    mockClock.monotonicTime() >> 1000L
+    
+    def handler = new BasicGoogleDeployHandler(registry: mockRegistry)
+    
+    // Create real credentials with mocked compute
+    def credentials = new GoogleNamedAccountCredentials.Builder()
+        .name("test-account")
+        .project("test-project")
+        .compute(mockCompute)
+        .build()
+    
+    // Mock description with proper instanceMetadata
+    def instanceMetadata = [:]
+    mockDescription.getCredentials() >> credentials
+    mockDescription.getInstanceMetadata() >> instanceMetadata
+    
+    // Mock loadbalancer info to return internal load balancers  
+    def mockInternalLB = Mock(GoogleInternalLoadBalancer.View)
+    def mockBackendService = Mock(GoogleBackendService)
+    mockBackendService.getName() >> "test-regional-backend-service"
+    mockInternalLB.getBackendService() >> mockBackendService
+    lbInfo.getInternalLoadBalancers() >> [mockInternalLB]
+    lbInfo.getInternalHttpLoadBalancers() >> []
+    
+    // Mock regional backend service API to throw IOException
+    mockCompute.regionBackendServices() >> mockRegionBackendServices
+    mockRegionBackendServices.get("test-project", "us-central1", "test-regional-backend-service") >> mockGet
+    mockGet.execute() >> { throw new IOException("GCP API error") }
+    
+    when:
+    def result = handler.getRegionBackendServicesToUpdate(mockDescription, "server-group", lbInfo, lbPolicy, "us-central1")
+    
+    then:
+    // Should not throw exception, should return empty list instead
+    result.isEmpty()
   }
 }


### PR DESCRIPTION
Addresses https://github.com/spinnaker/spinnaker/issues/7170 similarly to https://github.com/spinnaker/clouddriver/pull/6379 but for the master branch code, which was refactored to Java.

The `enableAsyncOperationWait` flag was omitted for this PR, because part of the operations were already using `googleOperationPoller` correctly, and we're just making the behaviour consistent.

Also covers a couple of regression bugs discovered during implementation and testing.